### PR TITLE
scroll locks on scroll up and notifies for new messages

### DIFF
--- a/src/components/output.css
+++ b/src/components/output.css
@@ -13,6 +13,8 @@
     overflow: auto;
     white-space: pre-wrap;
     word-wrap: normal;
+    position:relative;
+    z-index: 1;
 }
 
 .output.sidebar-visible {
@@ -35,20 +37,20 @@ a.exit {
 }
 
 .new-lines-notification {
-    position: absolute;
-    top: 40px;
-    right: 20px;
-    background-color: #ffa500;
+    position: sticky;
+    bottom: 0;
+    background-color: orange;
+    border: .5px solid white;
+    font-size: .75em;
+    width: 13%;
+    text-align:center;
     color: #000000;
-    text-align: center;
-    padding: 5px 10px;
-    font-family: Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
-    font-size: 0.75em;
-    border-top: 1px solid #ee7600;
-    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.2);
+    padding: 10px;
+    border-radius: 5px;
     cursor: pointer;
-    z-index: 10;
-    transition: transform 0.3s ease-in-out;
-    transform: translateY(100%); /* Start off-screen */
-    will-change: transform; /* Optimize for animations */
+    z-index: 3; /* Higher than .output to ensure it's on top */
+}
+
+.new-lines-notification:hover {
+background-color: pink;
 }

--- a/src/components/output.css
+++ b/src/components/output.css
@@ -33,3 +33,22 @@ a.exit {
         padding: 10px;
     }
 }
+
+.new-lines-notification {
+    position: absolute;
+    top: 40px;
+    right: 20px;
+    background-color: #ffa500;
+    color: #000000;
+    text-align: center;
+    padding: 5px 10px;
+    font-family: Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
+    font-size: 0.75em;
+    border-top: 1px solid #ee7600;
+    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    z-index: 10;
+    transition: transform 0.3s ease-in-out;
+    transform: translateY(100%); /* Start off-screen */
+    will-change: transform; /* Optimize for animations */
+}

--- a/src/components/output.tsx
+++ b/src/components/output.tsx
@@ -2,6 +2,7 @@ import "./output.css";
 import React from 'react';
 import { parseToElements } from "../ansiParser";
 import MudClient from "../client";
+import ReactDOMServer from "react-dom/server";
 
 interface Props {
   client: MudClient;
@@ -36,15 +37,6 @@ class Output extends React.Component<Props, State> {
     this.props.client.on("userlist", this.handleUserList);
   }
 
-  componentDidUpdate() {
-    this.scrollToBottom();
-    this.saveOutput(); // Save output to LocalStorage whenever it updates
-  }
-
-  componentWillUnmount() {
-    this.props.client.removeListener("message", this.handleMessage);
-  }
-
   saveOutput = () => {
     const outputHtml = this.state.output.map(element => ReactDOMServer.renderToStaticMarkup(element));
     localStorage.setItem(Output.LOCAL_STORAGE_KEY, JSON.stringify(outputHtml));
@@ -58,8 +50,6 @@ class Output extends React.Component<Props, State> {
     }
   };
 
-  // ... rest of the existing methods ...
-}
   addCommand = (command: string) => {
     this.addToOutput([
       <span className="command" aria-live="off">
@@ -85,6 +75,7 @@ class Output extends React.Component<Props, State> {
 
   componentDidUpdate() {
     this.scrollToBottom();
+    this.saveOutput(); // Save output to LocalStorage whenever it updates
   }
 
   componentWillUnmount() {

--- a/src/components/output.tsx
+++ b/src/components/output.tsx
@@ -11,6 +11,7 @@ interface Props {
 interface State {
   output: JSX.Element[];
   sidebarVisible: boolean;
+  newLinesCount: number;  // Added to track the count of new lines
 }
 
 class Output extends React.Component<Props, State> {
@@ -21,6 +22,8 @@ class Output extends React.Component<Props, State> {
   state = {
     output: [],
     sidebarVisible: false,
+    newLinesCount: 0,  // Initialize newLinesCount in the state
+
   };
 
   constructor(props: Props) {
@@ -72,10 +75,56 @@ class Output extends React.Component<Props, State> {
   handleUserList = (players: any) =>
     this.setState({ sidebarVisible: !!players })
 
+   getSnapshotBeforeUpdate(prevProps: Props, prevState: State) {
+    // Check if the user is scrolled to the bottom before the update
+    if (this.outputRef.current) {
+      const output = this.outputRef.current;
+      return output.scrollHeight - output.scrollTop <= output.clientHeight;
+    }
+    return null;
+  }
 
-  componentDidUpdate() {
+componentDidUpdate(prevProps: Props, prevState: State, wasScrolledToBottom: boolean | null) {
+    // If the snapshot indicates the user was at the bottom, scroll to the bottom
+    if (wasScrolledToBottom) {
+      this.scrollToBottom();
+    }
+    // Check if the output length has increased
+    if (this.state.output.length > prevState.output.length) {
+      // If the user hasn't scrolled to the bottom, increase the newLinesCount
+      if (!this.isScrolledToBottom()) {
+        this.setState({
+          newLinesCount: this.state.newLinesCount + (this.state.output.length - prevState.output.length),
+        });
+      } else {
+        // Reset newLinesCount if already at the bottom
+        this.setState({ newLinesCount: 0 });
+      }
+    }
+
+    this.saveOutput();  // Save output to LocalStorage whenever it updates
+  }
+
+
+  handleScroll = () => {
+    if (this.isScrolledToBottom()) {
+      this.setState({ newLinesCount: 0 });
+    }
+  };
+
+
+  isScrolledToBottom = () => {
+    const output = this.outputRef.current;
+    if (!output) return false;
+
+    // Check if the scroll is at the bottom
+    return output.scrollHeight - output.scrollTop <= output.clientHeight + 1; // +1 for potential rounding issues
+  }
+
+
+    handleScrollToBottom = () => {
     this.scrollToBottom();
-    this.saveOutput(); // Save output to LocalStorage whenever it updates
+    this.setState({ newLinesCount: 0 }); // Reset the counter after scrolling
   }
 
   componentWillUnmount() {
@@ -102,6 +151,7 @@ class Output extends React.Component<Props, State> {
       output.scrollTop = output.scrollHeight;
     }
   };
+  
 
   handleMessage = (message: string) => {
     if (!message) {
@@ -155,14 +205,23 @@ class Output extends React.Component<Props, State> {
     if (this.state.sidebarVisible) {
       classname += " sidebar-visible";
     }
+    
+  const newLinesText = `${this.state.newLinesCount} new ${this.state.newLinesCount === 1 ? 'message' : 'messages'}`;
+
     return (
       <div
         ref={this.outputRef}
         className={classname}
+                onScroll={this.handleScroll}
         aria-live="polite"
         role="log"
       >
         {this.state.output}
+        {this.state.newLinesCount > 0 && (
+          <div className="new-lines-notification" onClick={this.handleScrollToBottom}>
+            {newLinesText}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/gmcp/Client/Media.ts
+++ b/src/gmcp/Client/Media.ts
@@ -71,14 +71,21 @@ export class GMCPClientMedia extends GMCPPackage {
         let sound = this.sounds[key] as ExtendedSound;
         if (!sound) {
             let sound: ExtendedSound = await this.client.cacophony.createSound(url);
-
             sound.key = key;
             this.sounds[key] = sound;
         }
     }
 
-    async handlePlay(data: GMCPMessageClientMediaPlay) {
+    mediaUrl(data: GMCPMessageClientMediaPlay): string {
         let mediaUrl = (data.url || this.defaultUrl) + data.name;
+        if (data.type?.toLowerCase() === "music") {
+            mediaUrl = CORS_PROXY + encodeURIComponent(mediaUrl);
+        }
+        return mediaUrl;
+    }
+
+    async handlePlay(data: GMCPMessageClientMediaPlay) {
+        let mediaUrl = this.mediaUrl(data);
         data.key = data.key || mediaUrl;
         let sound = this.sounds[data.key] as ExtendedSound;
 
@@ -86,7 +93,6 @@ export class GMCPClientMedia extends GMCPPackage {
         if (!sound || sound.url !== mediaUrl) {
             // Create a new sound object
             if (data.type === "music") {
-                mediaUrl = CORS_PROXY + encodeURIComponent(mediaUrl);
                 sound = await this.client.cacophony.createSound(mediaUrl, SoundType.HTML);
             } else {
                 sound = await this.client.cacophony.createSound(mediaUrl);
@@ -223,3 +229,7 @@ export class GMCPClientMedia extends GMCPPackage {
 
 }
 
+
+function soundKey(data: GMCPMessageClientMediaPlay | GMCPMessageClientMediaLoad): string {
+
+}


### PR DESCRIPTION
Added a scroll lock when user scrolls up from the bottom, so sighted users can read back history uninterrupted by new messages. New messages are shared with a notification bar that can be clicked to bring the user to the end of the output window.