### PR TITLE
editor manager

### DIFF
--- a/editor-plan.md
+++ b/editor-plan.md
@@ -1,0 +1,90 @@
+# Editor Manager Implementation Plan
+
+## Objectives
+1. Centralize editor management
+2. Implement focus functionality for duplicate editor references
+3. Simplify MudClient by delegating editor operations
+4. Maintain existing communication structure with editor windows
+
+## Implementation Steps
+
+1. Create EditorManager class:
+   - Manage open editors with a Map (reference -> Window)
+   - Handle BroadcastChannel communication
+
+2. Move editor functionality from MudClient to EditorManager:
+   - Transfer openEditorWindow and saveEditorWindow methods
+   - Move BroadcastChannel handling
+
+3. Update MudClient:
+   - Add EditorManager instance as public 'editors' property
+   - Remove editor-related methods
+
+4. Keep EditorWindow component unchanged
+
+## EditorManager Class Structure
+
+```typescript
+export class EditorManager {
+  private openEditors: Map<string, Window>;
+  private channel: BroadcastChannel;
+
+  constructor(private client: MudClient) {
+    // Initialize openEditors and channel
+    // Setup channel listeners
+  }
+
+  openEditorWindow(editorSession: EditorSession) {
+    // Open new editor or focus existing one
+  }
+
+  private focusEditor(id: string) {
+    // Focus existing editor window
+  }
+
+  saveEditorWindow(editorSession: EditorSession) {
+    // Save editor content using client's sendMCPMultiline
+  }
+
+  private setupChannelListeners() {
+    // Handle 'ready', 'save', and 'close' messages
+  }
+
+  private getEditorSession(id: string): EditorSession {
+    // Retrieve session data (implementation needed)
+  }
+
+  shutdown() {
+    // Close all editor windows and channel
+  }
+}
+```
+
+## MudClient Changes
+
+```typescript
+class MudClient {
+  public editors: EditorManager;
+
+  constructor(host: string, port: number) {
+    // Existing constructor code
+    this.editors = new EditorManager(this);
+  }
+
+  // Remove openEditorWindow and saveEditorWindow methods
+}
+```
+
+## Usage
+
+Instead of `client.openEditorWindow(session)`, use:
+```typescript
+client.editors.openEditorWindow(session);
+```
+
+## Positive Outcomes
+1. Improved code organization and separation of concerns
+2. Enhanced editor management with focus functionality
+3. Simplified MudClient interface
+4. Easier maintenance and potential for future editor-related features
+5. Consistent communication model with editor windows

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -1,0 +1,80 @@
+import MudClient from "./client";
+import { EditorSession } from "./mcp";
+
+export class EditorManager {
+  private openEditors: Map<string, Window>;
+  private channel: BroadcastChannel;
+
+  constructor(private client: MudClient) {
+    this.openEditors = new Map();
+    this.channel = new BroadcastChannel("editor");
+    this.setupChannelListeners();
+  }
+
+  openEditorWindow(editorSession: EditorSession) {
+    const id = editorSession.reference;
+    if (this.openEditors.has(id)) {
+      this.focusEditor(id);
+    } else {
+      const encodedId = encodeURIComponent(id);
+      const editorWindow = window.open(`/editor?reference=${encodedId}`, "_blank");
+      if (editorWindow) {
+        this.openEditors.set(id, editorWindow);
+        editorWindow.focus();
+      }
+    }
+  }
+
+  private focusEditor(id: string) {
+    const editorWindow = this.openEditors.get(id);
+    if (editorWindow && !editorWindow.closed) {
+      editorWindow.focus();
+    } else {
+      this.openEditors.delete(id);
+    }
+  }
+
+  saveEditorWindow(editorSession: EditorSession) {
+    const keyvals = {
+      reference: editorSession.reference,
+      type: editorSession.type,
+      "content*": ""
+    };
+    this.client.sendMCPMultiline("dns-org-mud-moo-simpleedit-set", keyvals, editorSession.contents);
+  }
+
+  private setupChannelListeners() {
+    this.channel.onmessage = (ev) => {
+      console.log("editor window message", ev);
+      if (ev.data.type === "ready") {
+        console.log("sending editor window session", ev.data.id);
+        const session = this.getEditorSession(ev.data.id);
+        this.channel.postMessage({
+          type: "load",
+          session: session,
+        });
+      } else if (ev.data.type === "save") {
+        console.log("saving editor window with session", ev.data.session);
+        this.saveEditorWindow(ev.data.session);
+      } else if (ev.data.type === "close") {
+        console.log("closing editor window");
+        this.openEditors.delete(ev.data.id);
+      }
+    };
+  }
+
+  private getEditorSession(id: string): EditorSession {
+    // This is a placeholder. In a real implementation, you'd fetch the session data from somewhere.
+    return {
+      name: "Placeholder",
+      reference: id,
+      type: "string",
+      contents: []
+    };
+  }
+
+  shutdown() {
+    this.openEditors.forEach((window) => window.close());
+    this.channel.close();
+  }
+}

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -1,48 +1,49 @@
 import MudClient from "./client";
 import { EditorSession } from "./mcp";
 
+enum EditorState {
+  Pending,
+  Open,
+  Closed
+}
+
 interface WindowedSession extends EditorSession {
-  window: Window;
+  window: Window | null;
+  state: EditorState;
 }
 
 export class EditorManager {
-  private openEditors: Map<string, WindowedSession>;
+  private editors: Map<string, WindowedSession>;
   private channel: BroadcastChannel;
 
   constructor(private client: MudClient) {
-    this.openEditors = new Map();
+    this.editors = new Map();
     this.channel = new BroadcastChannel("editor");
     this.setupChannelListeners();
   }
 
   openEditorWindow(editorSession: EditorSession) {
-    console.log(editorSession);
+    console.log("Opening editor window for session:", editorSession);
     const id = editorSession.reference;
-    if (this.openEditors.has(id)) {
-      this.focusEditor(id);
+    const existingSession = this.editors.get(id);
+
+    if (existingSession && existingSession.state === EditorState.Open && existingSession.window && !existingSession.window.closed) {
+      existingSession.window.focus();
     } else {
       const encodedId = encodeURIComponent(id);
       const editorWindow = window.open(
         `/editor?reference=${encodedId}`,
         "_blank"
       );
+      const windowedSession: WindowedSession = {
+        ...editorSession,
+        window: editorWindow,
+        state: EditorState.Pending
+      };
+      this.editors.set(id, windowedSession);
       if (editorWindow) {
-        const windowedSession: WindowedSession = {
-          ...editorSession,
-          window: editorWindow
-        };
-        this.openEditors.set(id, windowedSession);
         editorWindow.focus();
       }
-    }
-  }
-
-  private focusEditor(id: string) {
-    const windowedSession = this.openEditors.get(id);
-    if (windowedSession && !windowedSession.window.closed) {
-      windowedSession.window.focus();
-    } else {
-      this.openEditors.delete(id);
     }
   }
 
@@ -61,49 +62,52 @@ export class EditorManager {
 
   private setupChannelListeners() {
     this.channel.onmessage = (ev) => {
-      console.log("editor window message", ev);
+      console.log("Editor window message:", ev);
       const { type, id, session } = ev.data;
 
-      if (type === "ready") {
-        console.log("sending editor window session", id);
-        const editorSession = this.getEditorSession(id);
-        if (editorSession) {
-          this.channel.postMessage({
-            type: "load",
-            session: editorSession,
-          });
-        } else {
-          console.error(`No session found for id: ${id}`);
-        }
-      } else if (type === "save") {
-        console.log("saving editor window with session", session);
-        this.saveEditorWindow(session);
-      } else if (type === "close") {
-        console.log("closing editor window");
-        this.openEditors.delete(id);
+      switch (type) {
+        case "ready":
+          console.log("Editor window ready, id:", id);
+          const editorSession = this.editors.get(id);
+          if (editorSession) {
+            editorSession.state = EditorState.Open;
+            this.channel.postMessage({
+              type: "load",
+              session: editorSession,
+            });
+          } else {
+            console.error(`No session found for id: ${id}`);
+          }
+          break;
+        case "save":
+          console.log("Saving editor window with session:", session);
+          this.saveEditorWindow(session);
+          break;
+        case "close":
+          console.log("Closing editor window, id:", id);
+          const closingSession = this.editors.get(id);
+          if (closingSession) {
+            closingSession.state = EditorState.Closed;
+          }
+          break;
       }
     };
   }
 
-  private getEditorSession(id: string): EditorSession | undefined {
-    const session = this.openEditors.get(id);
-    if (session) {
-      return session;
-    }
-  }
-
   shutdown() {
     console.log("Shutting down EditorManager");
-    this.openEditors.forEach((session, id) => {
+    this.editors.forEach((session, id) => {
       try {
-        console.log(`Closing editor window for ${id}`);
-        session.window.close();
-        this.channel.postMessage({ type: "shutdown", id });
+        if (session.state === EditorState.Open && session.window) {
+          console.log(`Closing editor window for ${id}`);
+          session.window.close();
+          this.channel.postMessage({ type: "shutdown", id });
+        }
       } catch (error) {
         console.error(`Error closing editor window ${id}:`, error);
       }
     });
-    this.openEditors.clear();
+    this.editors.clear();
     console.log("Closing broadcast channel");
     this.channel.close();
     console.log("EditorManager shutdown complete");

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -1,5 +1,6 @@
 import MudClient from "./client";
 import { EditorSession } from "./mcp";
+import { EditorManager } from "./EditorManager";
 
 export class EditorManager {
   private openEditors: Map<string, Window>;

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -90,7 +90,19 @@ export class EditorManager {
   }
 
   shutdown() {
-    this.openEditors.forEach((window) => window.close());
+    console.log("Shutting down EditorManager");
+    this.openEditors.forEach((session, id) => {
+      try {
+        console.log(`Closing editor window for ${id}`);
+        session.window.close();
+        this.channel.postMessage({ type: "shutdown", id });
+      } catch (error) {
+        console.error(`Error closing editor window ${id}:`, error);
+      }
+    });
+    this.openEditors.clear();
+    console.log("Closing broadcast channel");
     this.channel.close();
+    console.log("EditorManager shutdown complete");
   }
 }

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -48,11 +48,15 @@ export class EditorManager {
       console.log("editor window message", ev);
       if (ev.data.type === "ready") {
         console.log("sending editor window session", ev.data.id);
-        const session = this.getEditorSession(ev.data.id);
-        this.channel.postMessage({
-          type: "load",
-          session: session,
-        });
+        const session = this.client.mcp_getset.LocalCache[ev.data.id];
+        if (session) {
+          this.channel.postMessage({
+            type: "load",
+            session: session,
+          });
+        } else {
+          console.error(`No session found for id: ${ev.data.id}`);
+        }
       } else if (ev.data.type === "save") {
         console.log("saving editor window with session", ev.data.session);
         this.saveEditorWindow(ev.data.session);
@@ -60,16 +64,6 @@ export class EditorManager {
         console.log("closing editor window");
         this.openEditors.delete(ev.data.id);
       }
-    };
-  }
-
-  private getEditorSession(id: string): EditorSession {
-    // This is a placeholder. In a real implementation, you'd fetch the session data from somewhere.
-    return {
-      name: "Placeholder",
-      reference: id,
-      type: "string",
-      contents: []
     };
   }
 

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -71,9 +71,10 @@ export class EditorManager {
           const editorSession = this.editors.get(id);
           if (editorSession) {
             editorSession.state = EditorState.Open;
+            const { window, ...sessionWithoutWindow } = editorSession;
             this.channel.postMessage({
               type: "load",
-              session: editorSession,
+              session: sessionWithoutWindow,
             });
           } else {
             console.error(`No session found for id: ${id}`);

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -1,8 +1,12 @@
 import MudClient from "./client";
 import { EditorSession } from "./mcp";
 
+interface WindowedSession extends EditorSession {
+  window: Window;
+}
+
 export class EditorManager {
-  private openEditors: Map<string, Window>;
+  private openEditors: Map<string, WindowedSession>;
   private channel: BroadcastChannel;
 
   constructor(private client: MudClient) {
@@ -22,16 +26,20 @@ export class EditorManager {
         "_blank"
       );
       if (editorWindow) {
-        this.openEditors.set(id, editorWindow);
+        const windowedSession: WindowedSession = {
+          ...editorSession,
+          window: editorWindow
+        };
+        this.openEditors.set(id, windowedSession);
         editorWindow.focus();
       }
     }
   }
 
   private focusEditor(id: string) {
-    const editorWindow = this.openEditors.get(id);
-    if (editorWindow && !editorWindow.closed) {
-      editorWindow.focus();
+    const windowedSession = this.openEditors.get(id);
+    if (windowedSession && !windowedSession.window.closed) {
+      windowedSession.window.focus();
     } else {
       this.openEditors.delete(id);
     }

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -17,7 +17,10 @@ export class EditorManager {
       this.focusEditor(id);
     } else {
       const encodedId = encodeURIComponent(id);
-      const editorWindow = window.open(`/editor?reference=${encodedId}`, "_blank");
+      const editorWindow = window.open(
+        `/editor?reference=${encodedId}`,
+        "_blank"
+      );
       if (editorWindow) {
         this.openEditors.set(id, editorWindow);
         editorWindow.focus();
@@ -38,9 +41,13 @@ export class EditorManager {
     const keyvals = {
       reference: editorSession.reference,
       type: editorSession.type,
-      "content*": ""
+      "content*": "",
     };
-    this.client.sendMCPMultiline("dns-org-mud-moo-simpleedit-set", keyvals, editorSession.contents);
+    this.client.sendMCPMultiline(
+      "dns-org-mud-moo-simpleedit-set",
+      keyvals,
+      editorSession.contents
+    );
   }
 
   private setupChannelListeners() {
@@ -68,7 +75,10 @@ export class EditorManager {
   }
 
   private getEditorSession(id: string): EditorSession | undefined {
-    return this.client.mcp_getset.LocalCache[id];
+    const session = this.openEditors.get(id);
+    if (session) {
+      return session;
+    }
   }
 
   shutdown() {

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -33,12 +33,6 @@ export class EditorManager {
         };
         this.openEditors.set(id, windowedSession);
         editorWindow.focus();
-        
-        // Notify the channel that a new editor window is ready
-        this.channel.postMessage({
-          type: "ready",
-          id: id
-        });
       }
     }
   }

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -48,7 +48,7 @@ export class EditorManager {
       console.log("editor window message", ev);
       if (ev.data.type === "ready") {
         console.log("sending editor window session", ev.data.id);
-        const session = this.client.mcp_getset.LocalCache[ev.data.id];
+        const session = this.getEditorSession(ev.data.id);
         if (session) {
           this.channel.postMessage({
             type: "load",
@@ -65,6 +65,10 @@ export class EditorManager {
         this.openEditors.delete(ev.data.id);
       }
     };
+  }
+
+  private getEditorSession(id: string): EditorSession | undefined {
+    return this.client.mcp_getset.LocalCache[id];
   }
 
   shutdown() {

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -1,6 +1,5 @@
 import MudClient from "./client";
 import { EditorSession } from "./mcp";
-import { EditorManager } from "./EditorManager";
 
 export class EditorManager {
   private openEditors: Map<string, Window>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,8 +6,14 @@ import {
 } from "./telnet";
 
 import { EventEmitter } from "eventemitter3";
-import stripAnsi from 'strip-ansi';
-import { GMCPAutoLogin, GMCPChar, GMCPClientMedia, GMCPCore, GMCPCoreSupports } from "./gmcp";
+import stripAnsi from "strip-ansi";
+import {
+  GMCPAutoLogin,
+  GMCPChar,
+  GMCPClientMedia,
+  GMCPCore,
+  GMCPCoreSupports,
+} from "./gmcp";
 import type { GMCPPackage } from "./gmcp/package";
 import {
   EditorSession,
@@ -54,7 +60,6 @@ class MudClient extends EventEmitter {
     liveKitTokens: [],
   };
   public cacophony: Cacophony;
-  public editors: EditorManager;
   public editors: EditorManager;
 
   constructor(host: string, port: number) {
@@ -155,7 +160,7 @@ class MudClient extends EventEmitter {
     }
     this.send(command + "\r\n");
     console.log("> " + command);
-  }
+  };
 
   /*
 <message> ::= <message-start>
@@ -292,7 +297,6 @@ An MCP message consists of three parts: the name of the message, the authenticat
     this.send(`#$#: ${MLTag}\r\n`);
   }
 
-
   sendMCPMultiline(mcpMessage: string, keyvals: MCPKeyvals, lines: string[]) {
     const MLTag = generateTag();
     keyvals["_data-tag"] = MLTag;
@@ -348,7 +352,7 @@ An MCP message consists of three parts: the name of the message, the authenticat
     utterance.pitch = pitch;
     utterance.volume = volume;
     const voices = speechSynthesis.getVoices();
-    const selectedVoice = voices.find(v => v.name === voice);
+    const selectedVoice = voices.find((v) => v.name === voice);
     if (selectedVoice) {
       utterance.voice = selectedVoice;
     }
@@ -360,7 +364,9 @@ An MCP message consists of three parts: the name of the message, the authenticat
   }
 
   stopAllSounds() {
-    const gmcpClientMedia = this.gmcpHandlers["Client.Media"] as GMCPClientMedia;
+    const gmcpClientMedia = this.gmcpHandlers[
+      "Client.Media"
+    ] as GMCPClientMedia;
     gmcpClientMedia.stopAllSounds();
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -315,6 +315,7 @@ An MCP message consists of three parts: the name of the message, the authenticat
     Object.values(this.gmcpHandlers).forEach((handler) => {
       handler.shutdown();
     });
+    this.editors.shutdown();
   }
 
   requestNotificationPermission() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
 
 import { EventEmitter } from "eventemitter3";
 import stripAnsi from "strip-ansi";
+import { EditorManager } from "./EditorManager";
 import {
   GMCPAutoLogin,
   GMCPChar,
@@ -16,7 +17,6 @@ import {
 } from "./gmcp";
 import type { GMCPPackage } from "./gmcp/package";
 import {
-  EditorSession,
   MCPKeyvals,
   MCPPackage,
   McpAwnsGetSet,
@@ -25,7 +25,6 @@ import {
   parseMcpMessage,
   parseMcpMultiline,
 } from "./mcp";
-import { EditorManager } from "./EditorManager";
 
 import { Cacophony } from "cacophony";
 import { AutoreadMode, preferencesStore } from "./PreferencesStore";
@@ -70,7 +69,6 @@ class MudClient extends EventEmitter {
     this.mcp_getset = this.registerMcpPackage(McpAwnsGetSet);
     this.gmcp_char = this.registerGMCPPackage(GMCPChar);
     this.cacophony = new Cacophony();
-    this.editors = new EditorManager(this);
     this.editors = new EditorManager(this);
   }
 
@@ -169,6 +167,7 @@ class MudClient extends EventEmitter {
 <message-start> ::= <message-name> <space> <auth-key> <keyvals>
 An MCP message consists of three parts: the name of the message, the authentication key, and a set of keywords and their associated values. The message name indicates what action is to be performed; if the given message name is unknown, the message should be ignored. The authentication key is generated at the beginning of the session; if it is incorrect, the message should be ignored. The keyword-value pairs specify the arguments to the message. These arguments may occur in any order, and the ordering of the arguments does not affect the semantics of the message. There is no limit on the number of keyword-value pairs which may appear in a message, or on the lengths of message names, keywords, or values.
 */
+
   private handleData(data: ArrayBuffer) {
     const decoded = this.decoder.decode(data).trimEnd();
     for (const line of decoded.split("\n")) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -55,6 +55,7 @@ class MudClient extends EventEmitter {
   };
   public cacophony: Cacophony;
   public editors: EditorManager;
+  public editors: EditorManager;
 
   constructor(host: string, port: number) {
     super();
@@ -64,6 +65,7 @@ class MudClient extends EventEmitter {
     this.mcp_getset = this.registerMcpPackage(McpAwnsGetSet);
     this.gmcp_char = this.registerGMCPPackage(GMCPChar);
     this.cacophony = new Cacophony();
+    this.editors = new EditorManager(this);
     this.editors = new EditorManager(this);
   }
 

--- a/src/components/editor/editorWindow.tsx
+++ b/src/components/editor/editorWindow.tsx
@@ -77,29 +77,41 @@ function EditorWindow() {
 
     const handleMessage = (event: MessageEvent) => {
       console.log(event.data);
-      if (event.data.type === "load") {
-        if (clientId !== "") {
-          return; // We already have a session
-        }
-        const contents = event.data.session.contents.join("\n");
-        setCode(contents);
-        setOriginalCode(contents);
-        setSession(event.data.session);
-        setDocumentState(DocumentState.Unchanged);
-        setClientId(event.data.clientId);
-        setTimeout(focusEditor, 100);
-      } else if (event.data.type === "shutdown") {
-        if (event.data.clientId !== clientId) {
-          return;
-        }
-        channel.close();
-        window.close();
+      switch (event.data.type) {
+        case "load":
+          if (clientId !== "") {
+            return; // We already have a session
+          }
+          const contents = event.data.session.contents.join("\n");
+          setCode(contents);
+          setOriginalCode(contents);
+          setSession(event.data.session);
+          setDocumentState(DocumentState.Unchanged);
+          setClientId(event.data.clientId);
+          setTimeout(focusEditor, 100);
+          break;
+        case "shutdown":
+          console.log("Received shutdown message");
+          if (documentState === DocumentState.Changed) {
+            const shouldClose = window.confirm("You have unsaved changes. Are you sure you want to close this editor?");
+            if (!shouldClose) {
+              return;
+            }
+          }
+          channel.close();
+          window.close();
+          break;
+        default:
+          console.warn("Unknown message type received", event.data.type);
       }
     };
 
     channel.addEventListener("message", handleMessage);
-    return () => channel.removeEventListener("message", handleMessage);
-  }, [channel, clientId, id]);
+    return () => {
+      channel.removeEventListener("message", handleMessage);
+      channel.postMessage({ type: "close", id });
+    };
+  }, [channel, clientId, id, documentState]);
 
   const revert = () => {
     setCode(originalCode);

--- a/src/components/editor/editorWindow.tsx
+++ b/src/components/editor/editorWindow.tsx
@@ -88,6 +88,7 @@ function EditorWindow() {
           setSession(event.data.session);
           setDocumentState(DocumentState.Unchanged);
           setClientId(event.data.clientId);
+          setIsLoaded(true); // Add this line to set isLoaded to true when content is loaded
           setTimeout(focusEditor, 100);
           break;
         case "shutdown":

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -150,31 +150,28 @@ export interface EditorSession {
 export class McpSimpleEdit extends MCPPackage {
   public packageName = "dns-org-mud-moo-simpleedit";
 
-  public sessions: { [key: string]: EditorSession } = {};
-  clientId: string;
+  private currentSession: EditorSession | null = null;
 
   constructor(client: MudClient) {
     super(client);
-    this.clientId = generateTag();
   }
 
   handle(message: McpMessage): void {
     if (message.name === "dns-org-mud-moo-simpleedit-content") {
-      const session: EditorSession = {
+      this.currentSession = {
         name: message.keyvals["name"],
         reference: message.keyvals["reference"],
         type: message.keyvals["type"],
         contents: [],
       };
-      this.sessions[message.keyvals["_data-tag"]] = session;
     } else {
       console.log(`Unexpected simpleedit message ${message}`);
     }
   }
 
   handleMultiline(message: McpMessage): void {
-    if ("content" in message.keyvals) {
-      this.sessions[message.name].contents.push(message.keyvals["content"]);
+    if (this.currentSession && "content" in message.keyvals) {
+      this.currentSession.contents.push(message.keyvals["content"]);
     } else {
       console.log(`Unexpected simpleedit ML ${message}`);
     }
@@ -182,12 +179,14 @@ export class McpSimpleEdit extends MCPPackage {
 
   closeMultiline(closure: McpMessage): void {
     console.log(`Closing multiline ${closure.name}`);
-    this.client.openEditorWindow(this.sessions[closure.name]);
+    if (this.currentSession) {
+      this.client.editors.openEditorWindow(this.currentSession);
+      this.currentSession = null;
+    }
   }
 
   shutdown() {
-    const channel = new BroadcastChannel("editor");
-    channel.postMessage({ type: "shutdown" });
+    // The EditorManager now handles its own shutdown
   }
 }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -184,10 +184,6 @@ export class McpSimpleEdit extends MCPPackage {
       this.currentSession = null;
     }
   }
-
-  shutdown() {
-    // The EditorManager now handles its own shutdown
-  }
 }
 
 /**


### PR DESCRIPTION
Implement EditorManager to centralize editor handling

This commit introduces an EditorManager class to improve the management
of editor windows and simplify the MudClient implementation. Key changes include:

- Create EditorManager class to handle editor-related operations
- Move editor functionality from MudClient to EditorManager
- Update MudClient to use EditorManager for editor operations
- Implement focus functionality for duplicate editor references
- Improve handling of editor window states (Pending, Open, Closed)
- Enhance shutdown process for editor windows
- Update EditorWindow component to handle new message types

These changes centralize editor management, prevent duplicate editors,
and provide a more robust system for handling editor lifecycles. The
new implementation maintains existing communication structures while
offering improved organization and potential for future editor-related
features.