### PR TITLE
feat: Add player name tab completion to command input

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,17 @@ import Statusbar from "./components/statusbar";
 import Toolbar from "./components/toolbar";
 import {
   GMCPAutoLogin,
-  GMCPCharItems,
-  GMCPCharStatus,
+  GMCPChar, // Added
+  GMCPCharAfflictions, // Added
+  GMCPCharDefences,
+  GMCPCharItems, // Added
+  GMCPCharOffer, // Added
+  GMCPCharPrompt, // Added
+  GMCPCharSkills,
+  GMCPCharStatus, // Added
+  GMCPCharStatusAffectedBy, // Added
+  GMCPCharStatusConditions, // Added
+  GMCPCharStatusTimers,
   GMCPClientFileTransfer,
   GMCPClientHtml,
   GMCPClientKeystrokes,
@@ -23,16 +32,7 @@ import {
   GMCPCommChannel,
   GMCPCommLiveKit,
   GMCPCore,
-  GMCPCoreSupports,
-  GMCPChar, // Added
-  GMCPCharOffer, // Added
-  GMCPCharPrompt, // Added
-  GMCPCharStatusAffectedBy, // Added
-  GMCPCharStatusConditions, // Added
-  GMCPCharStatusTimers, // Added
-  GMCPCharAfflictions, // Added
-  GMCPCharDefences, // Added
-  GMCPCharSkills, // Added
+  GMCPCoreSupports, // Added
   GMCPGroup, // Added
   GMCPLogging, // Added
   GMCPRedirect, // Added
@@ -166,7 +166,9 @@ function App() {
         event.preventDefault();
 
         // Call the function exposed by Sidebar via ref
-        console.log(`App: Detected CTRL+${digit}, calling switchToTab(${targetIndex})`);
+        console.log(
+          `App: Detected CTRL+${digit}, calling switchToTab(${targetIndex})`
+        );
         sidebarRef.current?.switchToTab(targetIndex);
       }
     };
@@ -227,17 +229,17 @@ function App() {
 
   return (
     // Add conditional 'sidebar-shown' class based on showSidebar state
-    <div className={`App ${showSidebar ? 'sidebar-shown' : ''}`}>
+    <div className={`App ${showSidebar ? "sidebar-shown" : ""}`}>
       <header role="banner" style={{ gridArea: "header" }}>
         <Toolbar
           client={client}
-         onSaveLog={saveLog}
-         onClearLog={clearLog}
-         onCopyLog={copyLog} // <-- Pass copyLog function
-         onToggleSidebar={() => setShowSidebar(!showSidebar)}
-         onOpenPrefs={() => prefsDialogRef.current?.open()}
-         showSidebar={showSidebar}
-       />
+          onSaveLog={saveLog}
+          onClearLog={clearLog}
+          onCopyLog={copyLog} // <-- Pass copyLog function
+          onToggleSidebar={() => setShowSidebar(!showSidebar)}
+          onOpenPrefs={() => prefsDialogRef.current?.open()}
+          showSidebar={showSidebar}
+        />
       </header>
       <main role="main" style={{ gridArea: "main" }}>
         {/* Pass the focusInput function down to OutputWindow */}
@@ -248,7 +250,8 @@ function App() {
         aria-label="Command input"
         style={{ gridArea: "input" }}
       >
-        <CommandInput onSend={handleCommand} inputRef={inRef} />
+        {/* Pass the client prop to CommandInput */}
+        <CommandInput onSend={handleCommand} inputRef={inRef} client={client} />
       </div>
       {/* Conditionally render the aside element */}
       {showSidebar && (
@@ -259,10 +262,7 @@ function App() {
           // className is no longer needed here for visibility
         >
           {/* Pass the ref and client prop */}
-          <Sidebar
-            ref={sidebarRef}
-            client={client}
-          />
+          <Sidebar ref={sidebarRef} client={client} />
         </aside>
       )}
       <footer role="contentinfo" style={{ gridArea: "status" }}>

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,13 +31,14 @@ import { Cacophony } from "cacophony";
 import { AutoreadMode, preferencesStore } from "./PreferencesStore";
 import { WebRTCService } from "./WebRTCService";
 import FileTransferManager from "./FileTransferManager.js";
-import { GMCPMessageRoomInfo } from "./gmcp/Room"; // Import RoomInfo type
+import { GMCPMessageRoomInfo, RoomPlayer } from "./gmcp/Room"; // Import RoomPlayer
 
 export interface WorldData {
   liveKitTokens: string[];
   playerId: string;
   playerName: string;
   roomId: string;
+  roomPlayers: RoomPlayer[]; // Changed from string[]
 }
 
 class MudClient extends EventEmitter {
@@ -68,6 +69,7 @@ class MudClient extends EventEmitter {
     playerName: "",
     roomId: "",
     liveKitTokens: [],
+    roomPlayers: [], // Initialized as RoomPlayer[]
   };
   public cacophony: Cacophony;
   public editors: EditorManager;

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -3,20 +3,57 @@ import { CommandHistory } from "../CommandHistory";
 import "./input.css";
 import { useInputStore } from "../hooks/useInputStore";
 import { InputActionType, setInputText, clearInputText } from "../InputStore";
+import MudClient from "../client"; // Import MudClient
+import { RoomPlayer } from "../gmcp/Room"; // Import RoomPlayer type
 
 type SendFunction = (text: string) => void;
 
 type Props = {
   onSend: SendFunction;
   inputRef: React.RefObject<HTMLTextAreaElement>;
+  client: MudClient; // Added client prop
 };
 
 const STORAGE_KEY = 'command_history';
 const MAX_HISTORY = 1000;
 
-const CommandInput = ({ onSend, inputRef }: Props) => {
+// Helper function to quote name if needed
+const quoteNameIfNeeded = (name: string): string => {
+  return name.includes(" ") ? `"${name}"` : name;
+};
+
+// Helper function to parse a word for tab completion parts
+const parseWordForCompletion = (word: string): { leadingPunctuation: string, namePart: string } => {
+  if (word.startsWith('"')) {
+    // For user input like "Dav, namePart should be Dav.
+    // If the input is fully quoted like "David Miller", namePart is "David Miller".
+    // The quoteNameIfNeeded will handle re-quoting the completed name.
+    // Leading punctuation is considered empty as quotes handle the structure.
+    let namePart = word.substring(1);
+    // Don't strip trailing quote from user's partial input like "David M
+    // if (namePart.endsWith('"')) { 
+    //   namePart = namePart.substring(0, namePart.length - 1);
+    // }
+    return { leadingPunctuation: "", namePart };
+  } else {
+    // Matches leading non-alphanumeric, non-whitespace, non-quote characters
+    const punctuationMatch = word.match(/^([^\w\s"]+)(.*)$/); 
+    if (punctuationMatch) {
+      return { leadingPunctuation: punctuationMatch[1], namePart: punctuationMatch[2] };
+    }
+    return { leadingPunctuation: "", namePart: word };
+  }
+};
+
+const CommandInput = ({ onSend, inputRef, client }: Props) => {
   const commandHistoryRef = useRef(new CommandHistory());
   const [inputState, dispatch] = useInputStore();
+
+  // Refs for tab completion state
+  const completionCandidatesRef = useRef<RoomPlayer[]>([]); // Store RoomPlayer objects
+  const completionIndexRef = useRef<number>(0);
+  // Stores the full word (e.g., "-Da", "David") that initiated the current completion sequence
+  const completionActiveOriginalWordRef = useRef<string | null>(null); 
 
   // Load saved history on component mount
   useEffect(() => {
@@ -43,23 +80,11 @@ const CommandInput = ({ onSend, inputRef }: Props) => {
     }
   };
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const commandHistory = commandHistoryRef.current;
-    const currentInput = inputState.text;
-
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      const prevCommand = commandHistory.navigateUp(currentInput);
-      setInputText(prevCommand);
-    } else if (e.key === "ArrowDown") {
-      e.preventDefault();
-      const nextCommand = commandHistory.navigateDown(currentInput);
-      setInputText(nextCommand);
-    }
-  }, [inputState.text]);
+  const resetCompletionState = useCallback(() => {
+    completionCandidatesRef.current = [];
+    completionIndexRef.current = 0;
+    completionActiveOriginalWordRef.current = null; // Reset active original word
+  }, []);
 
   const handleSend = useCallback(() => {
     const currentInput = inputState.text;
@@ -69,14 +94,139 @@ const CommandInput = ({ onSend, inputRef }: Props) => {
       saveHistory();
       clearInputText();
       inputRef.current?.focus();
+      resetCompletionState(); // Explicitly reset on send
     }
-  }, [inputState.text, onSend, inputRef]);
+  }, [inputState.text, onSend, inputRef, resetCompletionState]); // Added resetCompletionState
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const commandHistory = commandHistoryRef.current;
+    const currentInputText = inputState.text;
+    const textArea = inputRef.current;
+
+    if (e.key === "Tab") {
+      // e.preventDefault(); // Remove from here
+
+      if (!textArea) return;
+
+      // If the entire input field is empty, reset completion state and do nothing further.
+      // This handles the case where Tab is pressed in a completely empty input.
+      if (currentInputText === "") {
+        resetCompletionState();
+        return; // Allow default tab behavior if input is empty
+      }
+      
+      // Add e.preventDefault() here, as we are now proceeding with custom tab handling
+      e.preventDefault(); 
+
+      const cursorPos = textArea.selectionStart;
+      const textBeforeCursor = currentInputText.substring(0, cursorPos);
+      const wordMatch = textBeforeCursor.match(/(?:[^"\s]\S*|"[^"]*"?)$/);
+      const currentWord = wordMatch ? wordMatch[0] : "";
+      const wordStartIndex = wordMatch ? textBeforeCursor.lastIndexOf(currentWord) : -1;
+
+      // If tabbing on empty space with no active completion, reset and do nothing further.
+      if (currentWord === "" && completionActiveOriginalWordRef.current === null) {
+        resetCompletionState();
+        return;
+      }
+
+      let isCycling = false;
+      if (completionActiveOriginalWordRef.current !== null && completionCandidatesRef.current.length > 0) {
+        const activeCyclePlayer = completionCandidatesRef.current[completionIndexRef.current];
+        // Parse the original word that started this completion sequence to get its leading punctuation
+        const { leadingPunctuation: activeOriginalLeadingPunctuation } = parseWordForCompletion(completionActiveOriginalWordRef.current);
+        const expectedCompletedWord = activeOriginalLeadingPunctuation + quoteNameIfNeeded(activeCyclePlayer.name);
+        isCycling = currentWord === expectedCompletedWord;
+      }
+
+      if (isCycling) { // We are cycling
+        completionIndexRef.current = (completionIndexRef.current + 1) % completionCandidatesRef.current.length;
+        const nextCandidatePlayer = completionCandidatesRef.current[completionIndexRef.current];
+        
+        // Re-parse the original word to get its leading punctuation for consistency
+        const { leadingPunctuation: activeOriginalLeadingPunctuation } = parseWordForCompletion(completionActiveOriginalWordRef.current!);
+        const baseCompletedName = quoteNameIfNeeded(nextCandidatePlayer.name);
+        const completedName = activeOriginalLeadingPunctuation + baseCompletedName;
+
+        const newText = currentInputText.substring(0, wordStartIndex) + completedName + currentInputText.substring(cursorPos);
+        setInputText(newText);
+        const newCursorPos = wordStartIndex + completedName.length;
+        requestAnimationFrame(() => textArea.setSelectionRange(newCursorPos, newCursorPos));
+      } else { // This is for initial completion or if currentWord changed (breaking the cycle)
+        resetCompletionState(); // Reset before starting a new completion sequence
+
+        const { leadingPunctuation: initialLeadingPunctuation, namePart: initialNamePart } = parseWordForCompletion(currentWord);
+        
+        // If, after parsing, the namePart is empty (e.g., currentWord was just "-" or ""), do not attempt to complete.
+        if (initialNamePart === "") {
+          // No resetCompletionState() here as it was called above, and we don't want to clear a just-started valid prefix
+          return;
+        }
+        
+        const roomPlayersData: RoomPlayer[] = client.worldData.roomPlayers || [];
+        const candidatePlayers = roomPlayersData
+          .filter(p => {
+            const nameMatch = typeof p.name === 'string' && p.name.toLowerCase().startsWith(initialNamePart.toLowerCase());
+            const fullnameWords = typeof p.fullname === 'string' ? p.fullname.toLowerCase().split(' ') : [];
+            const fullnameMatch = fullnameWords.some(word => word.startsWith(initialNamePart.toLowerCase()));
+            return nameMatch || fullnameMatch;
+          })
+          .sort((a, b) => { // Sort by name first, then fullname for tie-breaking
+            const nameCompare = a.name.localeCompare(b.name);
+            if (nameCompare !== 0) return nameCompare;
+            return a.fullname.localeCompare(b.fullname);
+          });
+
+        if (candidatePlayers.length > 0) {
+          completionActiveOriginalWordRef.current = currentWord; // Store the word that initiated this sequence
+          completionCandidatesRef.current = candidatePlayers;
+          completionIndexRef.current = 0;
+          
+          const firstCandidatePlayer = candidatePlayers[0];
+          const baseCompletedName = quoteNameIfNeeded(firstCandidatePlayer.name);
+          const completedName = initialLeadingPunctuation + baseCompletedName;
+          
+          const newText = currentInputText.substring(0, wordStartIndex) + completedName + currentInputText.substring(cursorPos);
+          setInputText(newText);
+          const newCursorPos = wordStartIndex + completedName.length;
+          requestAnimationFrame(() => textArea.setSelectionRange(newCursorPos, newCursorPos));
+        } else {
+          // No candidates found, ensure state is reset (already done at the start of this block)
+        }
+      }
+    } else if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prevCommand = commandHistory.navigateUp(currentInputText);
+      setInputText(prevCommand);
+      resetCompletionState();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const nextCommand = commandHistory.navigateDown(currentInputText);
+      setInputText(nextCommand);
+      resetCompletionState();
+    } else {
+      // For other keys that might change the text (like Backspace, Delete, or character input)
+      // we reset the completion state. The onChange handler will also catch this.
+      // Non-text-altering keys (Shift, Ctrl, Alt) won't reset here.
+      if (e.key.length === 1 || e.key === "Backspace" || e.key === "Delete") {
+        resetCompletionState();
+      }
+    }
+  }, [inputState.text, client, inputRef, onSend, resetCompletionState, handleSend]); // Added handleSend and resetCompletionState
 
   return (
     <div className="command-input-container">
       <textarea
         value={inputState.text}
-        onChange={(e) => setInputText(e.target.value)}
+        onChange={(e) => {
+          setInputText(e.target.value);
+          // If user types, reset tab completion state.
+          // This ensures that typing new characters clears any ongoing completion.
+          resetCompletionState();
+        }}
         onKeyDown={handleKeyDown}
         id="command-input"
         ref={inputRef}

--- a/src/gmcp/Room.ts
+++ b/src/gmcp/Room.ts
@@ -2,62 +2,75 @@ import { GMCPMessage, GMCPPackage } from "./package";
 
 // More detailed Room.Info structure based on IRE docs
 export class GMCPMessageRoomInfo extends GMCPMessage {
-    num: number = 0; // Docs say number
-    name: string = "";
-    area: string = "";
-    environment?: string;
-    coords?: string; // "area,X,Y,Z,building"
-    map?: string; // "url X Y"
-    details?: string[]; // ["shop", "bank"]
-    exits?: { [key: string]: number }; // {"n": 12344, "se": 12336}
+  num: number = 0; // Docs say number
+  name: string = "";
+  area: string = "";
+  environment?: string;
+  coords?: string; // "area,X,Y,Z,building"
+  map?: string; // "url X Y"
+  details?: string[]; // ["shop", "bank"]
+  exits?: { [key: string]: number }; // {"n": 12344, "se": 12336}
 }
 
 export interface RoomPlayer {
-    name: string;
-    fullname: string;
+  name: string;
+  fullname: string;
 }
 
 export class GMCPRoom extends GMCPPackage {
-    public packageName: string = "Room"; // Corrected: packageName should be instance property
-    public name: string = "";
-    public id: string = "";
-    public exits: string[] = [];
-    public people: string[] = [];
+  public packageName: string = "Room"; // Corrected: packageName should be instance property
+  public name: string = "";
+  public id: string = "";
+  public exits: string[] = [];
+  public people: string[] = [];
 
-    handleInfo(data: GMCPMessageRoomInfo): void {
-        this.name = data.name;
-        this.name = data.name;
-        this.id = data.num.toString(); // Store as string if needed elsewhere
-        this.client.worldData.roomId = this.id;
-        this.client.currentRoomInfo = data; // Store the data on the client
-        // TODO: Update other room properties (exits, area, etc.) based on data
-        console.log("Received Room.Info:", data);
-        this.client.emit("roomInfo", data); // Emit the full data for live updates
+  handleInfo(data: GMCPMessageRoomInfo): void {
+    this.client.worldData.roomPlayers = []; // Clear player list for the new room
+    this.name = data.name;
+    this.id = data.num.toString(); // Store as string if needed elsewhere
+    this.client.worldData.roomId = this.id;
+    this.client.currentRoomInfo = data; // Store the data on the client
+    // TODO: Update other room properties (exits, area, etc.) based on data
+    console.log("Received Room.Info:", data);
+    this.client.emit("roomInfo", data); // Emit the full data for live updates
+  }
+
+  handleWrongDir(direction: string): void {
+    console.log(`Received Room.WrongDir: ${direction}`);
+    // TODO: Indicate failed movement attempt in UI?
+    this.client.emit("roomWrongDir", direction);
+  }
+
+  handlePlayers(players: RoomPlayer[]): void {
+    console.log("Received Room.Players:", players);
+    // Assign the array of RoomPlayer objects and sort by fullname
+    this.client.worldData.roomPlayers = players.sort((a, b) =>
+      a.fullname.localeCompare(b.fullname)
+    );
+    this.client.emit("roomPlayers", players);
+  }
+
+  handleAddPlayer(player: RoomPlayer): void {
+    console.log("Received Room.AddPlayer:", player);
+    // Check if player (by name/ID) already exists
+    if (
+      !this.client.worldData.roomPlayers.some((p) => p.name === player.name)
+    ) {
+      this.client.worldData.roomPlayers.push(player);
+      // Re-sort by fullname after adding
+      this.client.worldData.roomPlayers.sort((a, b) =>
+        a.fullname.localeCompare(b.fullname)
+      );
     }
+    this.client.emit("roomAddPlayer", player);
+  }
 
-    handleWrongDir(direction: string): void {
-        console.log(`Received Room.WrongDir: ${direction}`);
-        // TODO: Indicate failed movement attempt in UI?
-        this.client.emit("roomWrongDir", direction);
-    }
-
-    handlePlayers(players: RoomPlayer[]): void {
-        console.log("Received Room.Players:", players);
-        // TODO: Update the list of players in the room
-        this.client.emit("roomPlayers", players);
-    }
-
-    handleAddPlayer(player: RoomPlayer): void {
-        console.log("Received Room.AddPlayer:", player);
-        // TODO: Add player to the room list
-        this.client.emit("roomAddPlayer", player);
-    }
-
-    handleRemovePlayer(playerName: string): void {
-        // Docs example shows just the name string
-        console.log("Received Room.RemovePlayer:", playerName);
-        // TODO: Remove player from the room list
-        this.client.emit("roomRemovePlayer", playerName);
-    }
-
+  handleRemovePlayer(playerName: string): void {
+    // playerName is the ID (name property of RoomPlayer)
+    // Docs example shows just the name string
+    console.log("Received Room.RemovePlayer:", playerName);
+    this.client.worldData.roomPlayers =
+      this.client.worldData.roomPlayers.filter((p) => p.name !== playerName);
+    this.client.emit("roomRemovePlayer", playerName);
+  }
 }


### PR DESCRIPTION
Player name completion in MUD commands

- Implement tab completion that matches player names and fullnames
- Support cycling through multiple matches with repeated Tab presses  
- Handle quoted names automatically for names containing spaces
- Preserve leading punctuation in completed names
- Upgrade player data structure from string[] to RoomPlayer[] objects

