### PR TITLE
feat: Add option for background audio muting when window/tab loses focus

### DIFF
--- a/src/PreferencesStore.tsx
+++ b/src/PreferencesStore.tsx
@@ -17,6 +17,10 @@ export type SpeechPreferences = {
   volume: number;
 };
 
+export type SoundPreferences = {
+  muteInBackground: boolean;
+};
+
 export type ChannelPreferences = {
   autoreadMode: AutoreadMode;
   notify: boolean;
@@ -30,6 +34,7 @@ export type EditorPreferences = {
 export type PrefState = {
   general: GeneralPreferences;
   speech: SpeechPreferences;
+  sound: SoundPreferences;
   channels?: { [channelId: string]: ChannelPreferences };
   editor: EditorPreferences;
 };
@@ -37,6 +42,7 @@ export type PrefState = {
 export enum PrefActionType {
   SetGeneral = "SET_GENERAL",
   SetSpeech = "SET_SPEECH",
+  SetSound = "SET_SOUND",
   SetChannels = "SET_CHANNELS",
   SetEditorAutocompleteEnabled = "SET_EDITOR_AUTOCOMPLETE_ENABLED",
   SetEditorAccessibilityMode = "SET_EDITOR_ACCESSIBILITY_MODE",
@@ -45,6 +51,7 @@ export enum PrefActionType {
 export type PrefAction =
   | { type: PrefActionType.SetGeneral; data: GeneralPreferences }
   | { type: PrefActionType.SetSpeech; data: SpeechPreferences }
+  | { type: PrefActionType.SetSound; data: SoundPreferences }
   | { type: PrefActionType.SetChannels; data: { [channelId: string]: ChannelPreferences } }
   | { type: PrefActionType.SetEditorAutocompleteEnabled; data: boolean }
   | { type: PrefActionType.SetEditorAccessibilityMode; data: boolean };
@@ -73,6 +80,9 @@ class PreferencesStore {
         pitch: 1.0,
         volume: 1.0,
       },
+      sound: {
+        muteInBackground: false,
+      },
       channels: {
         "sayto": {
           autoreadMode: AutoreadMode.Off,
@@ -92,6 +102,7 @@ class PreferencesStore {
       ...initial,
       general: { ...initial.general, ...stored.general },
       speech: { ...initial.speech, ...stored.speech },
+      sound: { ...initial.sound, ...stored.sound },
       channels: stored.channels ? { ...initial.channels, ...stored.channels } : initial.channels,
       editor: { ...initial.editor, ...stored.editor },
     };
@@ -103,6 +114,8 @@ class PreferencesStore {
         return { ...state, general: action.data };
       case PrefActionType.SetSpeech:
         return { ...state, speech: action.data };
+      case PrefActionType.SetSound:
+        return { ...state, sound: action.data };
       case PrefActionType.SetChannels:
         return { ...state, channels: action.data };
       case PrefActionType.SetEditorAutocompleteEnabled:

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,7 +98,7 @@ class MudClient extends EventEmitter {
     this.gmcp_char = this.registerGMCPPackage(GMCPChar);
     this.gmcp_fileTransfer = this.registerGMCPPackage(GMCPClientFileTransfer);
     this.cacophony = new Cacophony();
-    this.cacophony.setGlobalVolume(preferencesStore.getState().general.volume);
+    this.cacophony.setGlobalVolume(preferencesStore.getState().sound.volume);
     this.editors = new EditorManager(this);
     this.webRTCService = new WebRTCService(this);
     this.fileTransferManager = new FileTransferManager(

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -266,6 +266,28 @@ const SpeechTab: React.FC = () => {
 };
 
 
+const SoundsTab: React.FC = () => {
+  const [state, dispatch] = usePreferences();
+
+  return (
+    <div>
+      <label>
+        <input
+          type="checkbox"
+          checked={state.sound.muteInBackground}
+          onChange={(e) =>
+            dispatch({
+              type: PrefActionType.SetSound,
+              data: { ...state.sound, muteInBackground: e.target.checked },
+            })
+          }
+        />
+        Mute sounds when in background
+      </label>
+    </div>
+  );
+};
+
 const EditorTab: React.FC = () => {
   const [state, dispatch] = usePreferences();
   const editor = state.editor;
@@ -304,7 +326,8 @@ const Preferences: React.FC = () => {
   const tabs = [
     { label: "General", content: <GeneralTab /> },
     { label: "Speech", content: <SpeechTab /> },
-    { label: "Editor", content: <EditorTab /> }, // New Editor Tab
+    { label: "Sounds", content: <SoundsTab /> },
+    { label: "Editor", content: <EditorTab /> },
   ];
 
   return <Tabs tabs={tabs} />;

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -36,7 +36,7 @@ const Toolbar = ({
   const connected = useClientEvent(client, 'connectionChange', client.connected);
   const [muted, setMuted] = React.useState(client.cacophony.muted);
   const autosay = useClientEvent(client, 'autosayChanged', client.autosay) || false;
-  const [volume, setVolume] = React.useState(preferencesStore.getState().general.volume);
+  const [volume, setVolume] = React.useState(preferencesStore.getState().sound.volume);
 
   const handleMuteToggle = useCallback(() => {
     const newMutedState = !muted;
@@ -49,9 +49,9 @@ const Toolbar = ({
     setVolume(newVolume);
     client.cacophony.setGlobalVolume(newVolume);
     preferencesStore.dispatch({
-      type: PrefActionType.SetGeneral,
+      type: PrefActionType.SetSound,
       data: {
-        ...preferencesStore.getState().general,
+        ...preferencesStore.getState().sound,
         volume: newVolume
       }
     });

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -39,8 +39,9 @@ const Toolbar = ({
   const [volume, setVolume] = React.useState(preferencesStore.getState().general.volume);
 
   const handleMuteToggle = useCallback(() => {
-    setMuted(!muted);
-    client.cacophony.muted = !muted;
+    const newMutedState = !muted;
+    setMuted(newMutedState);
+    client.setGlobalMute(newMutedState);
   }, [muted, client]);
 
   const handleVolumeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Adds an option for background audio muting when window/tab loses focus (default state: off).

This includes the addition of a new tab in Preferences for sound-related configuration.