### PR TITLE
Fix blockquote persistence architecture

### DIFF
--- a/src/components/BlockquoteCopyButton.test.tsx
+++ b/src/components/BlockquoteCopyButton.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BlockquoteCopyButton from './BlockquoteCopyButton';
+
+// Mock clipboard API
+const mockWriteText = vi.fn();
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+  },
+});
+
+// Mock console methods
+const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('BlockquoteCopyButton', () => {
+  let mockBlockquoteElement: HTMLElement;
+
+  beforeEach(() => {
+    // Create a mock blockquote element
+    mockBlockquoteElement = document.createElement('blockquote');
+    mockBlockquoteElement.innerHTML = '<p>Test content</p>';
+    document.body.appendChild(mockBlockquoteElement);
+    
+    // Reset mocks
+    mockWriteText.mockClear();
+    consoleSpy.mockClear();
+  });
+
+  afterEach(() => {
+    // Clean up
+    document.body.removeChild(mockBlockquoteElement);
+    vi.clearAllTimers();
+  });
+
+  it('renders with default "Copy" text', () => {
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    expect(screen.getByRole('button')).toHaveTextContent('Copy');
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Copy blockquote content');
+  });
+
+  it('copies text content when clicked', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+    
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    fireEvent.click(screen.getByRole('button'));
+    
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith('Test content');
+    });
+  });
+
+  it('copies markdown content when contentType is text/markdown', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+    mockBlockquoteElement.innerHTML = '<p><strong>Bold text</strong> and <em>italic text</em></p>';
+    
+    render(
+      <BlockquoteCopyButton 
+        blockquoteElement={mockBlockquoteElement} 
+        contentType="text/markdown" 
+      />
+    );
+    
+    fireEvent.click(screen.getByRole('button'));
+    
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith('**Bold text** and *italic text*');
+    });
+  });
+
+  it('shows "Copied!" feedback after successful copy', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+    
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    
+    // Wait for the state to change to "Copied!"
+    await waitFor(() => {
+      expect(button).toHaveTextContent('Copied!');
+      expect(button).toHaveClass('copied');
+    }, { timeout: 1000 });
+    
+    expect(mockWriteText).toHaveBeenCalledWith('Test content');
+  });
+
+  it('shows "Error" feedback when copy fails', async () => {
+    const error = new Error('Clipboard not available');
+    mockWriteText.mockRejectedValueOnce(error);
+    
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    
+    // Wait for the state to change to "Error"
+    await waitFor(() => {
+      expect(button).toHaveTextContent('Error');
+      expect(button).toHaveClass('error');
+    }, { timeout: 1000 });
+    
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to copy text: ', error);
+    expect(mockWriteText).toHaveBeenCalledWith('Test content');
+  });
+
+  it('removes existing copy buttons from cloned content', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+    
+    // Add a copy button to the mock blockquote
+    const existingButton = document.createElement('button');
+    existingButton.className = 'blockquote-copy-button';
+    existingButton.textContent = 'Copy';
+    mockBlockquoteElement.appendChild(existingButton);
+    
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    // Get all buttons and click the React-rendered one (should be the one with aria-label)
+    const reactButton = screen.getByLabelText('Copy blockquote content');
+    fireEvent.click(reactButton);
+    
+    await waitFor(() => {
+      // Should copy only the text content, not including the button text
+      expect(mockWriteText).toHaveBeenCalledWith('Test content');
+    }, { timeout: 1000 });
+  });
+
+  it('prevents event propagation and default behavior', () => {
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      target: document.createElement('button'),
+    };
+    
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    const button = screen.getByRole('button');
+    fireEvent.click(button, mockEvent);
+    
+    // Note: This test verifies the click handler exists and works
+    // The actual preventDefault/stopPropagation calls are tested indirectly
+    expect(button).toBeInTheDocument();
+  });
+
+  it('handles empty blockquote content', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+    mockBlockquoteElement.innerHTML = '';
+    
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    
+    await vi.waitFor(() => expect(mockWriteText).toHaveBeenCalled());
+    
+    expect(mockWriteText).toHaveBeenCalledWith('');
+  });
+
+  it('trims whitespace from copied content', async () => {
+    mockWriteText.mockResolvedValueOnce(undefined);
+    mockBlockquoteElement.innerHTML = '  <p>  Test content  </p>  ';
+    
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    
+    await vi.waitFor(() => expect(mockWriteText).toHaveBeenCalled());
+    
+    expect(mockWriteText).toHaveBeenCalledWith('Test content');
+  });
+
+  it('has correct accessibility attributes', () => {
+    render(
+      <BlockquoteCopyButton blockquoteElement={mockBlockquoteElement} />
+    );
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('type', 'button');
+    expect(button).toHaveAttribute('aria-label', 'Copy blockquote content');
+  });
+});

--- a/src/components/BlockquoteCopyButton.tsx
+++ b/src/components/BlockquoteCopyButton.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import TurndownService from 'turndown';
+
+interface BlockquoteCopyButtonProps {
+  blockquoteElement: HTMLElement;
+  contentType?: string;
+}
+
+const BlockquoteCopyButton: React.FC<BlockquoteCopyButtonProps> = ({
+  blockquoteElement,
+  contentType
+}) => {
+  const [buttonState, setButtonState] = useState<'default' | 'copied' | 'error'>('default');
+  
+  // Create TurndownService instance
+  const turndownService = new TurndownService({ headingStyle: 'atx', emDelimiter: '*' });
+
+  const handleCopyClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    try {
+      // Clone the blockquote to avoid modifying the live DOM
+      const clonedBlockquote = blockquoteElement.cloneNode(true) as HTMLElement;
+      
+      // Remove any existing copy buttons from the clone
+      const buttonsInClone = clonedBlockquote.querySelectorAll('.blockquote-copy-button');
+      buttonsInClone.forEach(button => button.remove());
+
+      let textToCopy: string;
+
+      // Check if the content type is markdown
+      if (contentType === 'text/markdown') {
+        // Get the inner HTML of the clone (without the button)
+        const htmlContent = clonedBlockquote.innerHTML;
+        // Convert HTML to Markdown using Turndown
+        textToCopy = turndownService.turndown(htmlContent);
+      } else {
+        // Default behavior: Get text content from the clone
+        textToCopy = clonedBlockquote.textContent || '';
+      }
+
+      await navigator.clipboard.writeText(textToCopy.trim());
+      
+      // Visual feedback: Change to copied state
+      setButtonState('copied');
+      setTimeout(() => {
+        setButtonState('default');
+      }, 1500);
+
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+      
+      // Error feedback
+      setButtonState('error');
+      setTimeout(() => {
+        setButtonState('default');
+      }, 1500);
+    }
+  };
+
+  const getButtonText = () => {
+    switch (buttonState) {
+      case 'copied': return 'Copied!';
+      case 'error': return 'Error';
+      default: return 'Copy';
+    }
+  };
+
+  return (
+    <button
+      className={`blockquote-copy-button ${buttonState !== 'default' ? buttonState : ''}`}
+      onClick={handleCopyClick}
+      type="button"
+      aria-label="Copy blockquote content"
+    >
+      {getButtonText()}
+    </button>
+  );
+};
+
+export default BlockquoteCopyButton;

--- a/src/components/BlockquoteWithCopy.test.tsx
+++ b/src/components/BlockquoteWithCopy.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BlockquoteWithCopy from './BlockquoteWithCopy';
+
+// Mock the BlockquoteCopyButton component
+vi.mock('./BlockquoteCopyButton', () => ({
+  default: ({ blockquoteElement, contentType }: { blockquoteElement: HTMLElement, contentType?: string }) => (
+    <button data-testid="mock-copy-button" data-content-type={contentType}>
+      Mock Copy Button
+    </button>
+  ),
+}));
+
+describe('BlockquoteWithCopy', () => {
+  it('renders blockquote with wrapper div', () => {
+    render(
+      <BlockquoteWithCopy>
+        <p>Test content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    const wrapper = screen.getByText('Test content').closest('.blockquote-with-copy');
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveStyle({ position: 'relative' });
+    
+    const blockquote = screen.getByRole('blockquote');
+    expect(blockquote).toBeInTheDocument();
+    expect(blockquote).toContainElement(screen.getByText('Test content'));
+  });
+
+  it('renders copy button after component mounts', async () => {
+    render(
+      <BlockquoteWithCopy>
+        <p>Test content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-copy-button')).toBeInTheDocument();
+    });
+  });
+
+  it('passes contentType to copy button', async () => {
+    render(
+      <BlockquoteWithCopy contentType="text/markdown">
+        <p>Test markdown content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    await waitFor(() => {
+      const copyButton = screen.getByTestId('mock-copy-button');
+      expect(copyButton).toHaveAttribute('data-content-type', 'text/markdown');
+    });
+  });
+
+  it('sets data-content-type attribute on blockquote', () => {
+    render(
+      <BlockquoteWithCopy contentType="text/markdown">
+        <p>Test content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    const blockquote = screen.getByRole('blockquote');
+    expect(blockquote).toHaveAttribute('data-content-type', 'text/markdown');
+  });
+
+  it('handles string children with dangerouslySetInnerHTML', () => {
+    const htmlContent = '<p><strong>Bold</strong> text</p>';
+    
+    render(
+      <BlockquoteWithCopy>
+        {htmlContent}
+      </BlockquoteWithCopy>
+    );
+    
+    const blockquote = screen.getByRole('blockquote');
+    expect(blockquote).toContainHTML(htmlContent);
+  });
+
+  it('handles React element children normally', () => {
+    render(
+      <BlockquoteWithCopy>
+        <p><strong>Bold</strong> text</p>
+        <p>Another paragraph</p>
+      </BlockquoteWithCopy>
+    );
+    
+    const blockquote = screen.getByRole('blockquote');
+    expect(blockquote).toContainElement(screen.getByText('Bold'));
+    expect(blockquote).toContainElement(screen.getByText('Another paragraph'));
+  });
+
+  it('does not set data-content-type when contentType is undefined', () => {
+    render(
+      <BlockquoteWithCopy>
+        <p>Test content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    const blockquote = screen.getByRole('blockquote');
+    expect(blockquote).not.toHaveAttribute('data-content-type');
+  });
+
+  it('copy button receives blockquote element reference', async () => {
+    render(
+      <BlockquoteWithCopy>
+        <p>Test content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    // Wait for component to mount and copy button to appear
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-copy-button')).toBeInTheDocument();
+    });
+    
+    // The mock component should render, indicating that blockquoteRef.current was not null
+    expect(screen.getByTestId('mock-copy-button')).toBeInTheDocument();
+  });
+
+  it('handles empty children', async () => {
+    render(
+      <BlockquoteWithCopy>
+        {''}
+      </BlockquoteWithCopy>
+    );
+    
+    const blockquote = screen.getByRole('blockquote');
+    expect(blockquote).toBeInTheDocument();
+    
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-copy-button')).toBeInTheDocument();
+    });
+  });
+
+  it('wrapper has correct CSS class', () => {
+    render(
+      <BlockquoteWithCopy>
+        <p>Test content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    const wrapper = screen.getByText('Test content').closest('div');
+    expect(wrapper).toHaveClass('blockquote-with-copy');
+  });
+
+  it('renders copy button after component mounts', async () => {
+    render(
+      <BlockquoteWithCopy>
+        <p>Test content</p>
+      </BlockquoteWithCopy>
+    );
+    
+    // After mount, it should appear
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-copy-button')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/BlockquoteWithCopy.tsx
+++ b/src/components/BlockquoteWithCopy.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect, useRef } from 'react';
+import BlockquoteCopyButton from './BlockquoteCopyButton';
+
+interface BlockquoteWithCopyProps {
+  children: React.ReactNode;
+  contentType?: string;
+}
+
+const BlockquoteWithCopy: React.FC<BlockquoteWithCopyProps> = ({
+  children,
+  contentType
+}) => {
+  const blockquoteRef = useRef<HTMLQuoteElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // Ensure component is mounted before accessing ref
+    setMounted(true);
+  }, []);
+
+  return (
+    <div className="blockquote-with-copy" style={{ position: 'relative' }}>
+      <blockquote
+        ref={blockquoteRef}
+        data-content-type={contentType}
+        dangerouslySetInnerHTML={typeof children === 'string' ? { __html: children } : undefined}
+      >
+        {typeof children !== 'string' ? children : undefined}
+      </blockquote>
+      {mounted && blockquoteRef.current && (
+        <BlockquoteCopyButton
+          blockquoteElement={blockquoteRef.current}
+          contentType={contentType}
+        />
+      )}
+    </div>
+  );
+};
+
+export default BlockquoteWithCopy;

--- a/src/components/output.css
+++ b/src/components/output.css
@@ -85,3 +85,56 @@ a.exit {
   font-weight: bold; /* Keep errors bold */
   display: inline; /* Prevent h2 from taking full width if not desired */
 }
+
+/* BlockquoteWithCopy wrapper styles */
+.blockquote-with-copy {
+  position: relative;
+  margin: 0.5rem 0;
+}
+
+.blockquote-with-copy blockquote {
+  margin: 0;
+  padding: 1rem;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-left: 4px solid #87ceeb;
+  border-radius: 4px;
+  position: relative;
+}
+
+/* BlockquoteCopyButton styles */
+.blockquote-copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #ffffff;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 10;
+}
+
+.blockquote-copy-button:hover {
+  background-color: rgba(0, 0, 0, 0.9);
+  border-color: #87ceeb;
+}
+
+.blockquote-copy-button:active {
+  transform: translateY(1px);
+}
+
+/* Visual feedback styles for copy button */
+.blockquote-copy-button.copied {
+  background-color: #28a745;
+  border-color: #28a745;
+  color: #ffffff;
+}
+
+.blockquote-copy-button.error {
+  background-color: #dc3545;
+  border-color: #dc3545;
+  color: #ffffff;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/vitest.setup.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- Replace imperative DOM manipulation with declarative React components for blockquote copy buttons
- Redesign output persistence to store source data instead of rendered HTML
- Fix copy functionality breaking after page reload from localStorage

## Changes Made
- Created `BlockquoteCopyButton` and `BlockquoteWithCopy` React components
- Updated `OutputLine` interface to track source data (sourceType, sourceContent, metadata)
- Bumped `OUTPUT_LOG_VERSION` to 2 with migration logic that clears old incompatible data
- Rewrote `saveOutput`/`loadOutput` methods to store and recreate from source data
- Added comprehensive test suites for new components (21 tests total)

## Test Plan
- [x] All existing tests pass (141/141)
- [x] New components have comprehensive test coverage
- [x] Copy buttons work for fresh content
- [x] Copy buttons work for content reloaded from localStorage
- [x] Markdown detection and conversion works correctly
- [x] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)