### PR TITLE
Unify file transfer recipients with userlist

### DIFF
--- a/src/components/FileTransfer/Controls.css
+++ b/src/components/FileTransfer/Controls.css
@@ -2,11 +2,72 @@
   display: flex;
   gap: var(--space-3);
   margin-bottom: var(--space-4);
+  align-items: flex-start;
 }
 
 .file-transfer-controls input[type="file"],
 .file-transfer-controls input[type="text"] {
   flex-grow: 1;
+}
+
+.file-transfer-recipient {
+  flex: 1 1 12rem;
+  min-width: 10rem;
+  position: relative;
+}
+
+.file-transfer-recipient input[type="text"] {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.file-transfer-recipient-list {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  left: 0;
+  list-style: none;
+  margin: var(--space-1) 0 0;
+  max-height: 12rem;
+  min-width: 100%;
+  overflow-y: auto;
+  padding: var(--space-1);
+  position: absolute;
+  right: 0;
+  z-index: 20;
+}
+
+.file-transfer-recipient-option,
+.file-transfer-recipient-empty {
+  align-items: center;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  display: flex;
+  font-size: var(--font-size-sm);
+  gap: var(--space-2);
+  justify-content: space-between;
+  min-height: 2rem;
+  padding: var(--space-2) var(--space-3);
+  white-space: nowrap;
+}
+
+.file-transfer-recipient-option {
+  cursor: pointer;
+}
+
+.file-transfer-recipient-option.active,
+.file-transfer-recipient-option:hover {
+  background: var(--color-bg-hover);
+}
+
+.file-transfer-recipient-status,
+.file-transfer-recipient-empty {
+  color: var(--color-text-muted);
+}
+
+.file-transfer-recipient-status {
+  font-size: var(--font-size-xs);
 }
 
 .file-transfer-controls button {

--- a/src/components/FileTransfer/Controls.test.tsx
+++ b/src/components/FileTransfer/Controls.test.tsx
@@ -54,7 +54,10 @@ describe("FileTransfer Controls", () => {
       target: { value: "Not Connected" },
     });
 
-    expect(screen.getByRole("button", { name: "Send File" })).toBeDisabled();
+    expect(
+      (screen.getByRole("button", { name: "Send File" }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
   });
 
   it("enables Send after selecting a connected player", () => {
@@ -63,6 +66,9 @@ describe("FileTransfer Controls", () => {
     fireEvent.focus(screen.getByLabelText("Recipient"));
     fireEvent.mouseDown(screen.getByRole("option", { name: "Quinn" }));
 
-    expect(screen.getByRole("button", { name: "Send File" })).toBeEnabled();
+    expect(
+      (screen.getByRole("button", { name: "Send File" }) as HTMLButtonElement)
+        .disabled
+    ).toBe(false);
   });
 });

--- a/src/components/FileTransfer/Controls.test.tsx
+++ b/src/components/FileTransfer/Controls.test.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TransferPeer } from "../../fileTransferPeers";
+import Controls from "./Controls";
+
+const recipients: TransferPeer[] = [
+  {
+    id: "#100",
+    label: "Quinn",
+    transferAddress: "Quinn",
+    away: false,
+    idle: false,
+  },
+  {
+    id: "#200",
+    label: "Riley",
+    transferAddress: "Riley",
+    away: true,
+    idle: false,
+  },
+];
+
+const selectedFile = new File(["hello"], "hello.txt", {
+  type: "text/plain",
+});
+
+function renderControls(onSendFile = vi.fn()) {
+  function Harness() {
+    const [selectedRecipient, setSelectedRecipient] =
+      useState<TransferPeer | null>(null);
+
+    return (
+      <Controls
+        onFileChange={vi.fn()}
+        onRecipientChange={setSelectedRecipient}
+        onSendFile={onSendFile}
+        selectedFile={selectedFile}
+        selectedRecipient={selectedRecipient}
+        recipients={recipients}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return { onSendFile };
+}
+
+describe("FileTransfer Controls", () => {
+  it("keeps Send disabled for arbitrary typed recipients", () => {
+    renderControls();
+
+    fireEvent.change(screen.getByLabelText("Recipient"), {
+      target: { value: "Not Connected" },
+    });
+
+    expect(screen.getByRole("button", { name: "Send File" })).toBeDisabled();
+  });
+
+  it("enables Send after selecting a connected player", () => {
+    renderControls();
+
+    fireEvent.focus(screen.getByLabelText("Recipient"));
+    fireEvent.mouseDown(screen.getByRole("option", { name: "Quinn" }));
+
+    expect(screen.getByRole("button", { name: "Send File" })).toBeEnabled();
+  });
+});

--- a/src/components/FileTransfer/Controls.tsx
+++ b/src/components/FileTransfer/Controls.tsx
@@ -1,12 +1,14 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import type { TransferPeer } from "../../fileTransferPeers";
 import "./Controls.css";
 
 interface FileTransferControlsProps {
   onFileChange: (file: File) => void;
-  onRecipientChange: (recipient: string) => void;
+  onRecipientChange: (recipient: TransferPeer | null) => void;
   onSendFile: () => void;
   selectedFile: File | null;
-  recipient: string;
+  selectedRecipient: TransferPeer | null;
+  recipients: TransferPeer[];
 }
 
 const Controls: React.FC<FileTransferControlsProps> = ({
@@ -14,28 +16,166 @@ const Controls: React.FC<FileTransferControlsProps> = ({
   onRecipientChange,
   onSendFile,
   selectedFile,
-  recipient,
+  selectedRecipient,
+  recipients,
 }) => {
+  const recipientInputId = React.useId();
+  const recipientListId = React.useId();
+  const [recipientQuery, setRecipientQuery] = useState("");
+  const [isRecipientListOpen, setIsRecipientListOpen] = useState(false);
+  const [activeRecipientIndex, setActiveRecipientIndex] = useState(0);
+
+  const matchingRecipients = useMemo(() => {
+    const normalizedQuery = recipientQuery.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return recipients;
+    }
+
+    return recipients.filter((recipient) =>
+      recipient.label.toLowerCase().includes(normalizedQuery)
+    );
+  }, [recipientQuery, recipients]);
+
+  useEffect(() => {
+    setRecipientQuery(selectedRecipient?.label ?? "");
+  }, [selectedRecipient]);
+
+  useEffect(() => {
+    if (activeRecipientIndex >= matchingRecipients.length) {
+      setActiveRecipientIndex(0);
+    }
+  }, [activeRecipientIndex, matchingRecipients.length]);
+
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
       onFileChange(event.target.files[0]);
     }
   };
 
-  const handleRecipientChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onRecipientChange(event.target.value);
+  const selectRecipient = (recipient: TransferPeer) => {
+    onRecipientChange(recipient);
+    setRecipientQuery(recipient.label);
+    setIsRecipientListOpen(false);
+  };
+
+  const handleRecipientChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const nextQuery = event.target.value;
+    const exactMatch =
+      recipients.find(
+        (recipient) =>
+          recipient.label.toLowerCase() === nextQuery.trim().toLowerCase()
+      ) ?? null;
+
+    setRecipientQuery(nextQuery);
+    onRecipientChange(exactMatch);
+    setIsRecipientListOpen(true);
+    setActiveRecipientIndex(0);
+  };
+
+  const handleRecipientKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setIsRecipientListOpen(true);
+      setActiveRecipientIndex((index) =>
+        matchingRecipients.length === 0
+          ? 0
+          : (index + 1) % matchingRecipients.length
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setIsRecipientListOpen(true);
+      setActiveRecipientIndex((index) =>
+        matchingRecipients.length === 0
+          ? 0
+          : (index - 1 + matchingRecipients.length) %
+            matchingRecipients.length
+      );
+    } else if (event.key === "Enter" && isRecipientListOpen) {
+      const activeRecipient = matchingRecipients[activeRecipientIndex];
+      if (activeRecipient) {
+        event.preventDefault();
+        selectRecipient(activeRecipient);
+      }
+    } else if (event.key === "Escape") {
+      setIsRecipientListOpen(false);
+    }
   };
 
   return (
     <div className="file-transfer-controls">
       <input type="file" onChange={handleFileChange} />
-      <input
-        type="text"
-        placeholder="Recipient"
-        value={recipient}
-        onChange={handleRecipientChange}
-      />
-      <button onClick={onSendFile} disabled={!selectedFile || !recipient}>
+      <div className="file-transfer-recipient">
+        <label htmlFor={recipientInputId} className="sr-only">
+          Recipient
+        </label>
+        <input
+          id={recipientInputId}
+          type="text"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={isRecipientListOpen}
+          aria-controls={recipientListId}
+          aria-activedescendant={
+            isRecipientListOpen && matchingRecipients[activeRecipientIndex]
+              ? `${recipientListId}-${matchingRecipients[activeRecipientIndex].id}`
+              : undefined
+          }
+          placeholder="Recipient"
+          value={recipientQuery}
+          onChange={handleRecipientChange}
+          onFocus={() => setIsRecipientListOpen(true)}
+          onBlur={() => setIsRecipientListOpen(false)}
+          onKeyDown={handleRecipientKeyDown}
+        />
+        {isRecipientListOpen && (
+          <ul
+            id={recipientListId}
+            className="file-transfer-recipient-list"
+            role="listbox"
+          >
+            {matchingRecipients.length === 0 ? (
+              <li className="file-transfer-recipient-empty">
+                No connected players
+              </li>
+            ) : (
+              matchingRecipients.map((recipient, index) => (
+                <li
+                  key={recipient.id}
+                  id={`${recipientListId}-${recipient.id}`}
+                  className={
+                    index === activeRecipientIndex
+                      ? "file-transfer-recipient-option active"
+                      : "file-transfer-recipient-option"
+                  }
+                  role="option"
+                  aria-selected={selectedRecipient?.id === recipient.id}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    selectRecipient(recipient);
+                  }}
+                >
+                  <span>{recipient.label}</span>
+                  {(recipient.away || recipient.idle) && (
+                    <span className="file-transfer-recipient-status">
+                      {[recipient.away ? "away" : "", recipient.idle ? "idle" : ""]
+                        .filter(Boolean)
+                        .join(", ")}
+                    </span>
+                  )}
+                </li>
+              ))
+            )}
+          </ul>
+        )}
+      </div>
+      <button
+        onClick={onSendFile}
+        disabled={!selectedFile || !selectedRecipient}
+      >
         Send File
       </button>
     </div>

--- a/src/components/FileTransfer/PendingTransfer.tsx
+++ b/src/components/FileTransfer/PendingTransfer.tsx
@@ -10,19 +10,21 @@ interface PendingOffer {
 
 interface PendingTransferProps {
   offer: PendingOffer;
+  senderLabel: string;
   onAccept: (sender: string, hash: string) => void;
   onReject: (sender: string, hash: string) => void;
 }
 
 const PendingTransfer: React.FC<PendingTransferProps> = ({
   offer,
+  senderLabel,
   onAccept,
   onReject,
 }) => {
   return (
     <div className="incoming-transfer">
       <p>
-        Incoming file: {offer.filename} from {offer.sender}
+        Incoming file: {offer.filename} from {senderLabel}
       </p>
       <button onClick={() => onAccept(offer.sender, offer.hash)}>
         Accept

--- a/src/components/FileTransfer/index.tsx
+++ b/src/components/FileTransfer/index.tsx
@@ -1,5 +1,11 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import MudClient from "../../client";
+import type { UserlistPlayer } from "../../mcp";
+import {
+  findTransferPeerByAddress,
+  userlistPlayersToTransferPeers,
+} from "../../fileTransferPeers";
+import type { TransferPeer } from "../../fileTransferPeers";
 import Controls from "./Controls";
 import ProgressBar from "./ProgressBar";
 import PendingTransfer from "./PendingTransfer";
@@ -9,6 +15,7 @@ import "./styles.css";
 interface FileTransferUIProps {
   client: MudClient;
   expanded: boolean;
+  users: UserlistPlayer[];
 }
 
 interface PendingOffer {
@@ -21,17 +28,38 @@ interface PendingOffer {
 const FileTransferUI: React.FC<FileTransferUIProps> = ({
   client,
   expanded,
+  users,
 }) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [recipient, setRecipient] = useState<string>("");
+  const [selectedRecipient, setSelectedRecipient] =
+    useState<TransferPeer | null>(null);
   const [sendProgress, setSendProgress] = useState<number>(0);
   const [receiveProgress, setReceiveProgress] = useState<number>(0);
   const [pendingOffers, setPendingOffers] = useState<PendingOffer[]>([]);
   const [transferHistory, setTransferHistory] = useState<string[]>([]);
+  const recipients = useMemo(
+    () => userlistPlayersToTransferPeers(users),
+    [users]
+  );
 
   const addToTransferHistory = useCallback((message: string) => {
     setTransferHistory((prevHistory) => [...prevHistory, message].slice(-10));
   }, []);
+
+  const getPeerLabel = useCallback(
+    (address: string) =>
+      findTransferPeerByAddress(recipients, address)?.label ?? address,
+    [recipients]
+  );
+
+  useEffect(() => {
+    if (
+      selectedRecipient &&
+      !recipients.some((recipient) => recipient.id === selectedRecipient.id)
+    ) {
+      setSelectedRecipient(null);
+    }
+  }, [recipients, selectedRecipient]);
 
   const handleFileSendProgress = useCallback(
     (data: { filename: string; sentBytes: number; totalBytes: number }) => {
@@ -101,30 +129,36 @@ const FileTransferUI: React.FC<FileTransferUIProps> = ({
   const handleFileTransferRejected = useCallback(
     (data: { sender: string; filename: string }) => {
       addToTransferHistory(
-        `File transfer rejected: ${data.filename} from ${data.sender}`
+        `File transfer rejected: ${data.filename} from ${getPeerLabel(
+          data.sender
+        )}`
       );
     },
-    [addToTransferHistory]
+    [addToTransferHistory, getPeerLabel]
   );
 
   const handleFileTransferAccepted = useCallback(
     (data: { sender: string; filename: string }) => {
       // Just log acceptance; actual sending is handled internally by FileTransferManager.
       addToTransferHistory(
-        `File transfer accepted: ${data.filename} by ${data.sender}`
+        `File transfer accepted: ${data.filename} by ${getPeerLabel(
+          data.sender
+        )}`
       );
     },
-    [addToTransferHistory]
+    [addToTransferHistory, getPeerLabel]
   );
 
   const handleFileTransferOffer = useCallback(
     (data: PendingOffer) => {
       setPendingOffers((prevOffers) => [...prevOffers, data]);
       addToTransferHistory(
-        `Incoming file offer: ${data.filename} from ${data.sender}`
+        `Incoming file offer: ${data.filename} from ${getPeerLabel(
+          data.sender
+        )}`
       );
     },
-    [addToTransferHistory]
+    [addToTransferHistory, getPeerLabel]
   );
 
   useEffect(() => {
@@ -180,11 +214,13 @@ const FileTransferUI: React.FC<FileTransferUIProps> = ({
   ]);
 
   const handleSendFile = () => {
-    if (selectedFile && recipient) {
+    if (selectedFile && selectedRecipient) {
       client
-        .sendFile(selectedFile, recipient)
+        .sendFile(selectedFile, selectedRecipient.transferAddress)
         .then(() => {
-          addToTransferHistory(`Sending ${selectedFile.name} to ${recipient}`);
+          addToTransferHistory(
+            `Sending ${selectedFile.name} to ${selectedRecipient.label}`
+          );
         })
         .catch((error) => {
           addToTransferHistory(`Error sending file: ${error.message}`);
@@ -198,7 +234,9 @@ const FileTransferUI: React.FC<FileTransferUIProps> = ({
     const offer = pendingOffers.find((o) => o.hash === hash);
     if (offer) {
       addToTransferHistory(
-        `Accepting file transfer: ${offer.filename} from ${sender}`
+        `Accepting file transfer: ${offer.filename} from ${getPeerLabel(
+          sender
+        )}`
       );
     }
     // Remove the offer from pendingOffers
@@ -210,7 +248,9 @@ const FileTransferUI: React.FC<FileTransferUIProps> = ({
     const offer = pendingOffers.find((o) => o.hash === hash);
     if (offer) {
       addToTransferHistory(
-        `Rejected file transfer: ${offer.filename} from ${sender}`
+        `Rejected file transfer: ${offer.filename} from ${getPeerLabel(
+          sender
+        )}`
       );
     }
     setPendingOffers((prevOffers) => prevOffers.filter((o) => o.hash !== hash));
@@ -227,10 +267,11 @@ const FileTransferUI: React.FC<FileTransferUIProps> = ({
 
       <Controls
         onFileChange={setSelectedFile}
-        onRecipientChange={setRecipient}
+        onRecipientChange={setSelectedRecipient}
         onSendFile={handleSendFile}
         selectedFile={selectedFile}
-        recipient={recipient}
+        selectedRecipient={selectedRecipient}
+        recipients={recipients}
       />
 
       {(sendProgress > 0 || receiveProgress > 0) && (

--- a/src/components/FileTransfer/index.tsx
+++ b/src/components/FileTransfer/index.tsx
@@ -284,6 +284,7 @@ const FileTransferUI: React.FC<FileTransferUIProps> = ({
         <PendingTransfer
           key={`${offer.sender}-${offer.filename}`}
           offer={offer}
+          senderLabel={getPeerLabel(offer.sender)}
           onAccept={handleAcceptTransfer}
           onReject={handleRejectTransfer}
         />

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -167,7 +167,11 @@ const Sidebar = React.forwardRef<SidebarRef, SidebarProps>(({ client, collapsed,
       id: "files-tab",
       label: "Files",
       content: (
-        <FileTransferUI client={client} expanded={fileTransferExpanded} />
+        <FileTransferUI
+          client={client}
+          expanded={fileTransferExpanded}
+          users={users}
+        />
       ),
       condition: true, // Always show Files tab
     },
@@ -187,7 +191,7 @@ const Sidebar = React.forwardRef<SidebarRef, SidebarProps>(({ client, collapsed,
   // Note: If tab conditions become more dynamic, add them to the dependency array.
   const visibleTabs = React.useMemo(() => {
     return allTabs.filter((tab) => tab.condition ?? true); // Default condition to true
-  }, [hasRoomData, hasInventoryData, preferences.midi.enabled, preferences.haptics.enabled]); // Add dependencies based on actual conditions used
+  }, [hasRoomData, hasInventoryData, preferences.midi.enabled, preferences.haptics.enabled, users]); // Add dependencies based on actual conditions used
 
   // Expose switchToTab function via useImperativeHandle
   React.useImperativeHandle(ref, () => ({

--- a/src/fileTransferPeers.test.ts
+++ b/src/fileTransferPeers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { UserlistPlayer } from "./mcp";
+import {
+  findTransferPeerByAddress,
+  userlistPlayersToTransferPeers,
+} from "./fileTransferPeers";
+
+const players: UserlistPlayer[] = [
+  {
+    Object: "#100",
+    Name: "Quinn",
+    Icon: 1,
+    away: false,
+    idle: true,
+  },
+  {
+    Object: "#200",
+    Name: "Riley",
+    Icon: 2,
+    away: true,
+    idle: false,
+  },
+];
+
+describe("file transfer peers", () => {
+  it("maps connected userlist players into selectable transfer peers", () => {
+    expect(userlistPlayersToTransferPeers(players)).toEqual([
+      {
+        id: "#100",
+        label: "Quinn",
+        transferAddress: "Quinn",
+        away: false,
+        idle: true,
+      },
+      {
+        id: "#200",
+        label: "Riley",
+        transferAddress: "Riley",
+        away: true,
+        idle: false,
+      },
+    ]);
+  });
+
+  it("resolves incoming transfer addresses by name or object id", () => {
+    const peers = userlistPlayersToTransferPeers(players);
+
+    expect(findTransferPeerByAddress(peers, "quinn")?.label).toBe("Quinn");
+    expect(findTransferPeerByAddress(peers, "#200")?.label).toBe("Riley");
+    expect(findTransferPeerByAddress(peers, "unknown")).toBeNull();
+  });
+});

--- a/src/fileTransferPeers.ts
+++ b/src/fileTransferPeers.ts
@@ -1,0 +1,42 @@
+import type { UserlistPlayer } from "./mcp";
+
+export interface TransferPeer {
+  id: string;
+  label: string;
+  transferAddress: string;
+  away: boolean;
+  idle: boolean;
+}
+
+export function userlistPlayersToTransferPeers(
+  players: UserlistPlayer[]
+): TransferPeer[] {
+  return players
+    .filter((player) => player.Name && player.Object)
+    .map((player) => ({
+      id: String(player.Object),
+      label: player.Name,
+      transferAddress: player.Name,
+      away: player.away,
+      idle: player.idle,
+    }));
+}
+
+export function findTransferPeerByAddress(
+  peers: TransferPeer[],
+  address: string
+): TransferPeer | null {
+  const normalizedAddress = address.trim().toLowerCase();
+  if (!normalizedAddress) {
+    return null;
+  }
+
+  return (
+    peers.find(
+      (peer) =>
+        peer.transferAddress.toLowerCase() === normalizedAddress ||
+        peer.id.toLowerCase() === normalizedAddress ||
+        peer.label.toLowerCase() === normalizedAddress
+    ) ?? null
+  );
+}


### PR DESCRIPTION
## Summary
- replace the raw file-transfer recipient text path with an editable dropdown backed by the MCP userlist
- add a file-transfer peer adapter for selecting known users and resolving incoming sender labels
- keep protocol sends string-based while restricting the UI send action to selected connected players
- add focused tests for peer mapping and dropdown selection behavior

## Verification
- npm test -- src\\fileTransferPeers.test.ts src\\components\\FileTransfer\\Controls.test.tsx
- npm run build