### PR TITLE
MCMP effects: environment chains, inline effects, live automation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "buffer": "^6.0.3",
         "buttplug": "^3.2.2",
         "buttplug-wasm": "^2.0.1",
-        "cacophony": "^0.23.0",
+        "cacophony": "^0.25.1",
         "dompurify": "^3.4.1",
         "eventemitter3": "^5.0.4",
         "jzz": "^1.9.6",
@@ -3856,9 +3856,9 @@
       }
     },
     "node_modules/cacophony": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/cacophony/-/cacophony-0.23.0.tgz",
-      "integrity": "sha512-TG+8bWSgztTrpYeQVdqzp2HG7vuPWO9QW/V+zlSBMCsHlVoTa1W1SC6aSomWWM2nwTWZcGIdR5DzoWubRGcTEg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/cacophony/-/cacophony-0.25.1.tgz",
+      "integrity": "sha512-BudIblIdYL0Y0MF3PkuOpSankPMFWpxpYtDQAFD2phH+o8Qo+bOHSbNfnYyFGY+B8iyOxzIlGA9am1nK9gMFvQ==",
       "license": "ISC",
       "dependencies": {
         "fft.js": "^4.0.4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose-web-client",
   "version": "0.7.0",
-  "homepage": "https://client.rustytelephone.net/",
+  "homepage": "https://client.mongoose.world/",
   "dependencies": {
     "@livekit/components-react": "^2.9.20",
     "@monaco-editor/react": "^4.7.0",
@@ -11,7 +11,7 @@
     "buffer": "^6.0.3",
     "buttplug": "^3.2.2",
     "buttplug-wasm": "^2.0.1",
-    "cacophony": "^0.23.0",
+    "cacophony": "^0.25.1",
     "dompurify": "^3.4.1",
     "eventemitter3": "^5.0.4",
     "jzz": "^1.9.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose-web-client",
   "version": "0.7.0",
-  "homepage": "https://client.mongoose.world/",
+  "homepage": "https://client.rustytelephone.net/",
   "dependencies": {
     "@livekit/components-react": "^2.9.20",
     "@monaco-editor/react": "^4.7.0",

--- a/src/audio/AmbisonicRenderer.test.ts
+++ b/src/audio/AmbisonicRenderer.test.ts
@@ -1,16 +1,16 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockCreateFOARenderer } = vi.hoisted(() => ({
   mockCreateFOARenderer: vi.fn(),
 }));
 
-vi.mock("omnitone/build/omnitone.min.esm.js", () => ({
+vi.mock('omnitone/build/omnitone.min.esm.js', () => ({
   default: {
     createFOARenderer: mockCreateFOARenderer,
   },
 }));
 
-import { AmbisonicRenderer } from "./AmbisonicRenderer";
+import { AmbisonicRenderer } from './AmbisonicRenderer';
 
 function createNode() {
   return {
@@ -19,12 +19,12 @@ function createNode() {
   };
 }
 
-describe("AmbisonicRenderer", () => {
+describe('AmbisonicRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("builds the stereo-upmix ambisonic playback graph against cacophony", async () => {
+  it('builds the stereo-upmix ambisonic playback graph against cacophony', async () => {
     const encoder = createNode();
     const input = createNode();
     const output = createNode();
@@ -53,7 +53,7 @@ describe("AmbisonicRenderer", () => {
     ambisonicRenderer.attachPlayback(playback as any);
 
     expect(renderer.initialize).toHaveBeenCalledOnce();
-    expect(renderer.setRenderingMode).toHaveBeenCalledWith("ambisonic");
+    expect(renderer.setRenderingMode).toHaveBeenCalledWith('ambisonic');
     expect(cacophony.loadStereoToBFormatWorklet).toHaveBeenCalledOnce();
     expect(cacophony.createStereoToBFormatNode).toHaveBeenCalledOnce();
     expect(playback.disconnect).toHaveBeenCalledOnce();
@@ -62,7 +62,7 @@ describe("AmbisonicRenderer", () => {
     expect(output.connect).toHaveBeenCalledWith(cacophony.globalGainNode);
   });
 
-  it("builds the FOA passthrough graph without a stereo encoder", async () => {
+  it('builds the FOA passthrough graph without a stereo encoder', async () => {
     const input = createNode();
     const output = createNode();
     const renderer = {
@@ -96,7 +96,7 @@ describe("AmbisonicRenderer", () => {
     ambisonicRenderer.attachPlayback(playback as any);
 
     expect(renderer.initialize).toHaveBeenCalledOnce();
-    expect(renderer.setRenderingMode).toHaveBeenCalledWith("ambisonic");
+    expect(renderer.setRenderingMode).toHaveBeenCalledWith('ambisonic');
     expect(cacophony.loadStereoToBFormatWorklet).not.toHaveBeenCalled();
     expect(cacophony.createStereoToBFormatNode).not.toHaveBeenCalled();
     expect(playback.disconnect).toHaveBeenCalledOnce();
@@ -107,7 +107,36 @@ describe("AmbisonicRenderer", () => {
     expect(output.connect).toHaveBeenCalledWith(cacophony.globalGainNode);
   });
 
-  it("computes the expected yaw rotation matrix", () => {
+  it('routes the binaural output to an explicit target instead of master (V11)', async () => {
+    const input = createNode();
+    const output = createNode();
+    const renderer = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      input,
+      output,
+      setRenderingMode: vi.fn(),
+      setRotationMatrix3: vi.fn(),
+      setRotationMatrix4: vi.fn(),
+    };
+    mockCreateFOARenderer.mockReturnValue(renderer);
+
+    const cacophony = {
+      context: {},
+      loadStereoToBFormatWorklet: vi.fn().mockResolvedValue(undefined),
+      createStereoToBFormatNode: vi.fn(),
+      globalGainNode: createNode(),
+    };
+    const playback = { connect: vi.fn(), disconnect: vi.fn() };
+    const effectBusInput = createNode();
+
+    const ambisonicRenderer = await AmbisonicRenderer.create(cacophony as any, 4);
+    ambisonicRenderer.attachPlayback(playback as any, effectBusInput as any);
+
+    expect(output.connect).toHaveBeenCalledWith(effectBusInput);
+    expect(output.connect).not.toHaveBeenCalledWith(cacophony.globalGainNode);
+  });
+
+  it('computes the expected yaw rotation matrix', () => {
     const matrix = AmbisonicRenderer.rotationMatrixFromYaw(Math.PI / 2);
 
     expect(Array.from(matrix)).toEqual([

--- a/src/audio/AmbisonicRenderer.ts
+++ b/src/audio/AmbisonicRenderer.ts
@@ -1,8 +1,8 @@
-import type { AudioNode as CacophonyAudioNode, Cacophony, Playback } from "cacophony";
-import Omnitone, { type FOARenderer } from "omnitone/build/omnitone.min.esm.js";
+import type { Cacophony, AudioNode as CacophonyAudioNode, Playback } from 'cacophony';
+import Omnitone, { type FOARenderer } from 'omnitone/build/omnitone.min.esm.js';
 
 const IDENTITY_ROTATION = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
-type AmbisonicInputMode = "stereo-upmix" | "foa-passthrough";
+type AmbisonicInputMode = 'stereo-upmix' | 'foa-passthrough';
 
 export class AmbisonicRenderer {
   private attachedPlayback?: Playback;
@@ -17,31 +17,40 @@ export class AmbisonicRenderer {
   static async create(cacophony: Cacophony, inputChannels: number): Promise<AmbisonicRenderer> {
     const renderer = Omnitone.createFOARenderer(cacophony.context as unknown as BaseAudioContext);
     await renderer.initialize();
-    renderer.setRenderingMode("ambisonic");
+    renderer.setRenderingMode('ambisonic');
     if (inputChannels === 2) {
       await cacophony.loadStereoToBFormatWorklet();
       const encoder = await cacophony.createStereoToBFormatNode();
-      return new AmbisonicRenderer(cacophony, renderer, "stereo-upmix", encoder);
+      return new AmbisonicRenderer(cacophony, renderer, 'stereo-upmix', encoder);
     }
     if (inputChannels === 4) {
-      return new AmbisonicRenderer(cacophony, renderer, "foa-passthrough");
+      return new AmbisonicRenderer(cacophony, renderer, 'foa-passthrough');
     }
     throw new Error(`Unsupported ambisonic input channel count: ${inputChannels}`);
   }
 
-  attachPlayback(playback: Playback): void {
+  /**
+   * Wire the playback through the FOA decode and route the binaural output to
+   * `outputTarget` (the input node of an effect bus), or to master when omitted.
+   * Letting the caller choose the output target is what makes effects on
+   * ambisonic sounds possible — the output is no longer hard-wired to master
+   * (V11).
+   */
+  attachPlayback(playback: Playback, outputTarget?: CacophonyAudioNode): void {
     this.attachedPlayback = playback;
     playback.disconnect();
-    if (this.mode === "stereo-upmix") {
+    if (this.mode === 'stereo-upmix') {
       if (!this.encoder) {
-        throw new Error("Stereo ambisonic upmix requires an encoder node");
+        throw new Error('Stereo ambisonic upmix requires an encoder node');
       }
       playback.connect(this.encoder);
       this.encoder.connect(this.renderer.input as unknown as CacophonyAudioNode);
     } else {
       playback.connect(this.renderer.input as unknown as CacophonyAudioNode);
     }
-    (this.renderer.output as unknown as CacophonyAudioNode).connect(this.cacophony.globalGainNode);
+    (this.renderer.output as unknown as CacophonyAudioNode).connect(
+      outputTarget ?? this.cacophony.globalGainNode,
+    );
   }
 
   cleanup(): void {
@@ -50,7 +59,7 @@ export class AmbisonicRenderer {
       this.encoder?.disconnect();
       return;
     }
-    if (this.mode === "stereo-upmix") {
+    if (this.mode === 'stereo-upmix') {
       this.encoder?.disconnect();
     }
     this.attachedPlayback.disconnect();

--- a/src/audio/effects/EffectChain.test.ts
+++ b/src/audio/effects/EffectChain.test.ts
@@ -5,10 +5,15 @@ import { EffectChain } from './EffectChain';
 
 type MockBus = {
   name: string | null;
+  input: Record<string, unknown>;
   addFilter: ReturnType<typeof vi.fn>;
   removeFilter: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
   drainTo: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  rampFilterParam: ReturnType<typeof vi.fn>;
+  setFilterBypassed: ReturnType<typeof vi.fn>;
   destroyed: boolean;
   gain: number;
   output: {
@@ -23,11 +28,16 @@ type MockBus = {
 function makeBus(name: string | null): MockBus {
   return {
     name,
+    input: { __input: name },
     // addFilter returns the node it was given (mirrors cacophony returning the built node).
     addFilter: vi.fn(async (arg: unknown) => arg),
     removeFilter: vi.fn(),
     destroy: vi.fn(),
     drainTo: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    rampFilterParam: vi.fn(),
+    setFilterBypassed: vi.fn(),
     destroyed: false,
     gain: 1,
     output: { gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() } },
@@ -172,5 +182,79 @@ describe('EffectChain', () => {
     expect(g).not.toBe(0);
     // old reverb removed, new distortion added
     expect(bus.removeFilter).toHaveBeenCalledTimes(1);
+  });
+
+  it('automate ramps the translated cacophony param(s) on the effect node', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    await EffectChain.create(cacophony, 'cave', [{ type: 'reverb', id: 'env' }]);
+    const bus = createdBuses.get('cave')!;
+    const chain = await EffectChain.create(cacophony, 'cave2', [{ type: 'reverb', id: 'env' }]);
+    const bus2 = createdBuses.get('cave2')!;
+    chain.automate('env', { mix: 0.8, decayTime: 4 }, { duration: 1500, curve: 'linear' });
+    expect(bus2.rampFilterParam).toHaveBeenCalledWith(expect.anything(), 'mix', 0.8, {
+      duration: 1500,
+      type: 'linear',
+    });
+    expect(bus2.rampFilterParam).toHaveBeenCalledWith(expect.anything(), 'decayTime', 4, {
+      duration: 1500,
+      type: 'linear',
+    });
+    void bus;
+  });
+
+  it('automate on plate reverb ramps both wet AND dry (mix split)', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    const chain = await EffectChain.create(cacophony, 'cave', [
+      { type: 'reverb', algorithm: 'plate', id: 'r' },
+    ]);
+    const bus = createdBuses.get('cave')!;
+    chain.automate('r', { mix: 0.4 });
+    const rampedParams = bus.rampFilterParam.mock.calls.map((c) => c[1]);
+    expect(rampedParams).toContain('wet');
+    expect(rampedParams).toContain('dry');
+  });
+
+  it('automate no-ops on a missing target', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    const chain = await EffectChain.create(cacophony, 'cave', [{ type: 'reverb' }]);
+    const bus = createdBuses.get('cave')!;
+    chain.automate('nonexistent', { mix: 0.5 });
+    expect(bus.rampFilterParam).not.toHaveBeenCalled();
+  });
+
+  it('setBypass toggles cacophony filter bypass for the targeted effect', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    const chain = await EffectChain.create(cacophony, 'cave', [{ type: 'reverb', id: 'env' }]);
+    const bus = createdBuses.get('cave')!;
+    chain.setBypass('env', true);
+    expect(bus.setFilterBypassed).toHaveBeenCalledWith(expect.anything(), true);
+  });
+
+  it('honors EffectSpec.bypass at build time', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    await EffectChain.create(cacophony, 'cave', [{ type: 'reverb', bypass: true }]);
+    const bus = createdBuses.get('cave')!;
+    expect(bus.setFilterBypassed).toHaveBeenCalledWith(expect.anything(), true);
+  });
+
+  it('createAnonymous builds on an unnamed bus and destroys WITHOUT a drain', async () => {
+    const { cacophony } = makeCacophony(master);
+    const chain = await EffectChain.createAnonymous(cacophony, [{ type: 'distortion' }]);
+    expect(cacophony.createBus).toHaveBeenCalledWith();
+    const anon = (cacophony.createBus as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as MockBus;
+    chain.destroy(master as unknown as Bus);
+    expect(anon.destroy).toHaveBeenCalledWith(undefined); // anonymous: no drainTo
+  });
+
+  it('connectDownstream rewires the inline bus from master to a chain bus', async () => {
+    const { cacophony } = makeCacophony(master);
+    const chain = await EffectChain.createAnonymous(cacophony, [{ type: 'distortion' }]);
+    const anon = (cacophony.createBus as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as MockBus;
+    const target = makeBus('cave');
+    chain.connectDownstream(target as unknown as Bus);
+    expect(anon.disconnect).toHaveBeenCalledWith(master); // drop the auto master edge
+    expect(anon.connect).toHaveBeenCalledWith(target);
   });
 });

--- a/src/audio/effects/EffectChain.test.ts
+++ b/src/audio/effects/EffectChain.test.ts
@@ -1,0 +1,176 @@
+import type { Bus, Cacophony } from 'cacophony';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EffectChain } from './EffectChain';
+
+type MockBus = {
+  name: string | null;
+  addFilter: ReturnType<typeof vi.fn>;
+  removeFilter: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  drainTo: ReturnType<typeof vi.fn>;
+  destroyed: boolean;
+  gain: number;
+  output: {
+    gain: {
+      value: number;
+      setValueAtTime: ReturnType<typeof vi.fn>;
+      linearRampToValueAtTime: ReturnType<typeof vi.fn>;
+    };
+  };
+};
+
+function makeBus(name: string | null): MockBus {
+  return {
+    name,
+    // addFilter returns the node it was given (mirrors cacophony returning the built node).
+    addFilter: vi.fn(async (arg: unknown) => arg),
+    removeFilter: vi.fn(),
+    destroy: vi.fn(),
+    drainTo: vi.fn(),
+    destroyed: false,
+    gain: 1,
+    output: { gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() } },
+  };
+}
+
+function makeCacophony(masterBus: MockBus) {
+  const createdBuses = new Map<string, MockBus>();
+  const factoryCalls: Array<{ factory: string; options: unknown }> = [];
+  const factory = (name: string) =>
+    vi.fn((options: unknown) => {
+      factoryCalls.push({ factory: name, options });
+      return { __effect: name }; // a CacophonyEffect sentinel
+    });
+
+  const cacophony = {
+    context: { sampleRate: 48000, currentTime: 0 },
+    createBus: vi.fn((name?: string) => {
+      const b = makeBus(name ?? null);
+      if (name) createdBuses.set(name, b);
+      return b as unknown as Bus;
+    }),
+    getBus: vi.fn(
+      (name: string) => (name === 'master' ? masterBus : createdBuses.get(name)) as unknown as Bus,
+    ),
+    createFdnReverb: factory('createFdnReverb'),
+    createReverb: factory('createReverb'),
+    createDelay: factory('createDelay'),
+    createChorus: factory('createChorus'),
+    createFlanger: factory('createFlanger'),
+    createVibrato: factory('createVibrato'),
+    createDoubling: factory('createDoubling'),
+    createPhaser: factory('createPhaser'),
+    createTremolo: factory('createTremolo'),
+    createAutoPan: factory('createAutoPan'),
+    createDistortion: factory('createDistortion'),
+    createCompressor: factory('createCompressor'),
+    createLimiter: factory('createLimiter'),
+    createGate: factory('createGate'),
+    createBiquadFilter: vi.fn((options: unknown) => {
+      factoryCalls.push({ factory: 'createBiquadFilter', options });
+      return { __biquad: options };
+    }),
+  };
+  return { cacophony: cacophony as unknown as Cacophony, createdBuses, factoryCalls };
+}
+
+describe('EffectChain', () => {
+  let master: MockBus;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    master = makeBus('master');
+  });
+
+  it('builds effects in order onto a freshly created named bus', async () => {
+    const { cacophony, createdBuses, factoryCalls } = makeCacophony(master);
+    await EffectChain.create(cacophony, 'cave', [
+      { type: 'reverb', params: { mix: 0.4 } },
+      { type: 'lowpass', params: { frequency: 800 } },
+    ]);
+    expect(cacophony.createBus).toHaveBeenCalledWith('cave');
+    const bus = createdBuses.get('cave')!;
+    expect(bus.addFilter).toHaveBeenCalledTimes(2);
+    // ordered: reverb then biquad
+    expect(factoryCalls.map((c) => c.factory)).toEqual(['createFdnReverb', 'createBiquadFilter']);
+  });
+
+  it('master overlay uses the master bus, never createBus', async () => {
+    const { cacophony } = makeCacophony(master);
+    await EffectChain.create(cacophony, 'master', [
+      { type: 'lowpass', params: { frequency: 500 } },
+    ]);
+    expect(cacophony.createBus).not.toHaveBeenCalled();
+    expect(cacophony.getBus).toHaveBeenCalledWith('master');
+    expect(master.addFilter).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy() on a named chain drains live sounds to master, then destroys', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    const chain = await EffectChain.create(cacophony, 'cave', [{ type: 'reverb' }]);
+    const bus = createdBuses.get('cave')!;
+    chain.destroy(master as unknown as Bus);
+    expect(bus.destroy).toHaveBeenCalledWith({ drainTo: master });
+  });
+
+  it('destroy() on the master overlay removes only its own filters and NEVER destroys', async () => {
+    const { cacophony } = makeCacophony(master);
+    const chain = await EffectChain.create(cacophony, 'master', [
+      { type: 'lowpass', params: { frequency: 500 } },
+      { type: 'highpass', params: { frequency: 100 } },
+    ]);
+    chain.destroy(master as unknown as Bus);
+    expect(master.removeFilter).toHaveBeenCalledTimes(2);
+    expect(master.destroy).not.toHaveBeenCalled();
+  });
+
+  it('skips unknown effect types but builds the rest (degradation)', async () => {
+    const { cacophony, createdBuses, factoryCalls } = makeCacophony(master);
+    await EffectChain.create(cacophony, 'cave', [
+      { type: 'warp-drive' }, // unknown → skipped
+      { type: 'reverb' },
+    ]);
+    const bus = createdBuses.get('cave')!;
+    expect(bus.addFilter).toHaveBeenCalledTimes(1);
+    expect(factoryCalls.map((c) => c.factory)).toEqual(['createFdnReverb']);
+  });
+
+  it('skips an effect whose build (addFilter) rejects, continuing the chain', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    // First addFilter rejects (worklet load failure), second succeeds.
+    const bus = makeBus('cave');
+    let call = 0;
+    bus.addFilter = vi.fn(async (arg: unknown) => {
+      call += 1;
+      if (call === 1) throw new Error('worklet load failed');
+      return arg;
+    });
+    (cacophony.createBus as ReturnType<typeof vi.fn>).mockReturnValue(bus as unknown as Bus);
+    void createdBuses;
+    await EffectChain.create(cacophony, 'cave', [{ type: 'reverb' }, { type: 'distortion' }]);
+    expect(bus.addFilter).toHaveBeenCalledTimes(2); // both attempted
+    // The chain survived the first failure.
+  });
+
+  it('replace() dips the bus gain around the structural rebuild', async () => {
+    const { cacophony, createdBuses } = makeCacophony(master);
+    const chain = await EffectChain.create(cacophony, 'cave', [{ type: 'reverb' }]);
+    const bus = createdBuses.get('cave')!;
+    const seen: number[] = [];
+    let g = bus.gain;
+    Object.defineProperty(bus, 'gain', {
+      get: () => g,
+      set: (v: number) => {
+        g = v;
+        seen.push(v);
+      },
+    });
+    await chain.replace([{ type: 'distortion' }]);
+    // gain was driven to 0 during the rebuild and restored afterwards.
+    expect(seen).toContain(0);
+    expect(g).not.toBe(0);
+    // old reverb removed, new distortion added
+    expect(bus.removeFilter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/audio/effects/EffectChain.ts
+++ b/src/audio/effects/EffectChain.ts
@@ -1,0 +1,160 @@
+// A named environment chain: a thin owner around one cacophony Bus that builds
+// the ordered effect graph, and that knows the two lifecycle rules the design
+// makes load-bearing:
+//
+//   - MASTER OVERLAY (id === "master", V2): the bus is cacophony's master bus,
+//     which is `globalGainNode` and must NEVER be createBus'd or destroy'd. The
+//     overlay only adds/removes the exact filter nodes it owns.
+//   - NAMED CHAIN teardown (V3): destroying must reroute every live sound off the
+//     bus to master FIRST, so an audible sound is never disconnected. cacophony's
+//     `bus.destroy({ drainTo })` does exactly that (it walks the bus's tracked
+//     routed sources), so we lean on it rather than tracking membership here.
+//
+// Degradation (§6): an unknown effect `type` is skipped (resolve → null) and a
+// worklet that fails to build is skipped — the rest of the chain still builds.
+
+import type { Bus, Cacophony } from 'cacophony';
+
+import { buildEffect } from './buildEffect';
+import { resolveEffect } from './resolveEffect';
+import type { EffectSpec } from './types';
+
+/** The live node type `Bus.addFilter` returns / `removeFilter` accepts. */
+type FilterNode = Awaited<ReturnType<Bus['addFilter']>>;
+
+export interface ChainOptions {
+  /** Bus output level (0..). */
+  gain?: number;
+  /** ms ramp applied to the bus gain when (re)engaging. */
+  fadein?: number;
+}
+
+export class EffectChain {
+  /** The chain id — also the bus name a sound routes to (`sound.routeTo(id)`). */
+  readonly id: string;
+  readonly bus: Bus;
+  private readonly cacophony: Cacophony;
+  private readonly isMaster: boolean;
+  /** The exact filter nodes this chain added (so the master overlay removes only its own). */
+  private nodes: FilterNode[] = [];
+
+  private constructor(cacophony: Cacophony, id: string, bus: Bus, isMaster: boolean) {
+    this.cacophony = cacophony;
+    this.id = id;
+    this.bus = bus;
+    this.isMaster = isMaster;
+  }
+
+  /**
+   * Create a chain. `id === "master"` attaches to the existing master bus as a
+   * non-owning overlay; any other id allocates a dedicated named bus.
+   */
+  static async create(
+    cacophony: Cacophony,
+    id: string,
+    effects: EffectSpec[],
+    options: ChainOptions = {},
+  ): Promise<EffectChain> {
+    const isMaster = id === 'master';
+    const bus = isMaster ? requireMasterBus(cacophony) : cacophony.createBus(id);
+    const chain = new EffectChain(cacophony, id, bus, isMaster);
+    await chain.applyEffects(effects);
+    chain.setGain(options.gain, options.fadein);
+    return chain;
+  }
+
+  /**
+   * Replace the chain's effect graph in place (re-`Chain`). The bus persists, so
+   * sounds routed to it stay routed. Structural changes click (cacophony rebuilds
+   * the whole filter chain), so the bus output is dipped to mask it.
+   */
+  async replace(effects: EffectSpec[], options: ChainOptions = {}): Promise<void> {
+    await this.maskedRebuild(async () => {
+      this.removeOwnFilters();
+      await this.applyEffects(effects);
+    });
+    this.setGain(options.gain, options.fadein);
+  }
+
+  /**
+   * Tear the chain down. Master overlay: strip only our filters (never destroy
+   * the shared master bus). Named chain: reroute every live sound to `masterBus`
+   * via cacophony's drain, then destroy the bus.
+   */
+  destroy(masterBus: Bus): void {
+    if (this.isMaster) {
+      this.removeOwnFilters();
+      return;
+    }
+    if (!this.bus.destroyed) {
+      this.bus.destroy({ drainTo: masterBus });
+    }
+    this.nodes = [];
+  }
+
+  private async applyEffects(effects: EffectSpec[]): Promise<void> {
+    const sampleRate = this.cacophony.context.sampleRate;
+    for (const spec of effects) {
+      const resolved = resolveEffect(spec, sampleRate);
+      if (!resolved) {
+        console.warn(`EffectChain '${this.id}': unknown effect type '${spec.type}'; skipped`);
+        continue;
+      }
+      try {
+        const built = buildEffect(this.cacophony, resolved);
+        const node = await this.bus.addFilter(built);
+        this.nodes.push(node);
+      } catch (error) {
+        console.warn(
+          `EffectChain '${this.id}': effect '${spec.type}' failed to build; skipped`,
+          error,
+        );
+      }
+    }
+  }
+
+  private removeOwnFilters(): void {
+    for (const node of this.nodes) {
+      try {
+        this.bus.removeFilter(node);
+      } catch {
+        // Best-effort: the bus may already have dropped it.
+      }
+    }
+    this.nodes = [];
+  }
+
+  private setGain(gain: number | undefined, fadein?: number): void {
+    if (gain === undefined) {
+      return;
+    }
+    if (fadein && fadein > 0) {
+      const param = this.bus.output.gain;
+      const now = this.cacophony.context.currentTime;
+      param.setValueAtTime(param.value, now);
+      param.linearRampToValueAtTime(gain, now + fadein / 1000);
+    } else {
+      this.bus.gain = gain;
+    }
+  }
+
+  /** Dip the bus output to ~silence, run the structural change, then restore. */
+  private async maskedRebuild(rebuild: () => Promise<void>): Promise<void> {
+    const restore = this.bus.gain;
+    this.bus.gain = 0;
+    try {
+      await rebuild();
+    } finally {
+      this.bus.gain = restore;
+    }
+  }
+}
+
+/** The master bus always exists; narrow `getBus` for the overlay path. */
+function requireMasterBus(cacophony: Cacophony): Bus {
+  const master = cacophony.getBus('master');
+  if (!master) {
+    throw new Error('EffectChain: master bus is unexpectedly absent');
+  }
+  return master;
+}

--- a/src/audio/effects/EffectChain.ts
+++ b/src/audio/effects/EffectChain.ts
@@ -1,26 +1,37 @@
-// A named environment chain: a thin owner around one cacophony Bus that builds
-// the ordered effect graph, and that knows the two lifecycle rules the design
-// makes load-bearing:
+// A chain of effects over one cacophony Bus, in one of three modes:
 //
-//   - MASTER OVERLAY (id === "master", V2): the bus is cacophony's master bus,
-//     which is `globalGainNode` and must NEVER be createBus'd or destroy'd. The
-//     overlay only adds/removes the exact filter nodes it owns.
-//   - NAMED CHAIN teardown (V3): destroying must reroute every live sound off the
-//     bus to master FIRST, so an audible sound is never disconnected. cacophony's
-//     `bus.destroy({ drainTo })` does exactly that (it walks the bus's tracked
-//     routed sources), so we lean on it rather than tracking membership here.
+//   - NAMED (a server-defined environment): a dedicated registered bus that
+//     sounds route to by name. Teardown reroutes live sounds to master first
+//     (V3) via cacophony's `bus.destroy({ drainTo })`.
+//   - MASTER OVERLAY (id === "master", V2): the bus is cacophony's master bus
+//     (= globalGainNode) and must NEVER be createBus'd or destroy'd — the overlay
+//     only adds/removes the exact filter nodes it owns.
+//   - ANONYMOUS (an inline per-sound chain, P1): an unregistered bus owned by one
+//     sound, torn down with that sound. No drain needed (the owner is going away).
+//
+// Each built effect is tracked with its wire `type`/`algorithm`/`id` so automation
+// (P2) can translate wire params back to cacophony AudioParam names (by reusing
+// `resolveEffect`) and ramp them, and so bypass can target a specific effect.
 //
 // Degradation (§6): an unknown effect `type` is skipped (resolve → null) and a
 // worklet that fails to build is skipped — the rest of the chain still builds.
 
-import type { Bus, Cacophony } from 'cacophony';
+import type { Bus, Cacophony, FadeType } from 'cacophony';
 
 import { buildEffect } from './buildEffect';
 import { resolveEffect } from './resolveEffect';
 import type { EffectSpec } from './types';
 
-/** The live node type `Bus.addFilter` returns / `removeFilter` accepts. */
+/** The live node type `Bus.addFilter` returns / the bus methods accept. */
 type FilterNode = Awaited<ReturnType<Bus['addFilter']>>;
+
+/** A built effect plus the wire metadata automation needs to address it. */
+interface ChainEntry {
+  id?: string;
+  type: string;
+  algorithm?: string;
+  node: FilterNode;
+}
 
 export interface ChainOptions {
   /** Bus output level (0..). */
@@ -29,26 +40,33 @@ export interface ChainOptions {
   fadein?: number;
 }
 
+export interface AutomateOptions {
+  /** ms to reach the target values (0 / absent = instant). */
+  duration?: number;
+  /** Ramp shape. */
+  curve?: FadeType;
+}
+
+type ChainMode = 'named' | 'master' | 'anonymous';
+
 export class EffectChain {
-  /** The chain id — also the bus name a sound routes to (`sound.routeTo(id)`). */
-  readonly id: string;
+  /** The chain id, or null for an anonymous inline chain. */
+  readonly id: string | null;
   readonly bus: Bus;
   private readonly cacophony: Cacophony;
-  private readonly isMaster: boolean;
-  /** The exact filter nodes this chain added (so the master overlay removes only its own). */
-  private nodes: FilterNode[] = [];
+  private readonly mode: ChainMode;
+  private entries: ChainEntry[] = [];
+  /** Downstream target the bus output currently feeds (default: master). */
+  private downstream: Bus | null = null;
 
-  private constructor(cacophony: Cacophony, id: string, bus: Bus, isMaster: boolean) {
+  private constructor(cacophony: Cacophony, id: string | null, bus: Bus, mode: ChainMode) {
     this.cacophony = cacophony;
     this.id = id;
     this.bus = bus;
-    this.isMaster = isMaster;
+    this.mode = mode;
   }
 
-  /**
-   * Create a chain. `id === "master"` attaches to the existing master bus as a
-   * non-owning overlay; any other id allocates a dedicated named bus.
-   */
+  /** A named environment chain (`id === "master"` is the global overlay). */
   static async create(
     cacophony: Cacophony,
     id: string,
@@ -57,17 +75,48 @@ export class EffectChain {
   ): Promise<EffectChain> {
     const isMaster = id === 'master';
     const bus = isMaster ? requireMasterBus(cacophony) : cacophony.createBus(id);
-    const chain = new EffectChain(cacophony, id, bus, isMaster);
+    const chain = new EffectChain(cacophony, id, bus, isMaster ? 'master' : 'named');
+    await chain.applyEffects(effects);
+    chain.setGain(options.gain, options.fadein);
+    return chain;
+  }
+
+  /** An anonymous inline chain owned by a single sound (P1). */
+  static async createAnonymous(
+    cacophony: Cacophony,
+    effects: EffectSpec[],
+    options: ChainOptions = {},
+  ): Promise<EffectChain> {
+    const bus = cacophony.createBus();
+    const chain = new EffectChain(cacophony, null, bus, 'anonymous');
     await chain.applyEffects(effects);
     chain.setGain(options.gain, options.fadein);
     return chain;
   }
 
   /**
-   * Replace the chain's effect graph in place (re-`Chain`). The bus persists, so
-   * sounds routed to it stay routed. Structural changes click (cacophony rebuilds
-   * the whole filter chain), so the bus output is dipped to mask it.
+   * Redirect the bus output from master to `target` (for `sound → inline →
+   * named chain → master`). A null target restores the route to master.
    */
+  connectDownstream(target: Bus | null): void {
+    if (this.bus.destroyed) {
+      return;
+    }
+    const next = target ?? requireMasterBus(this.cacophony);
+    if (this.downstream === next || (this.downstream === null && target === null)) {
+      return;
+    }
+    if (this.downstream) {
+      this.bus.disconnect(this.downstream);
+    } else {
+      // The bus was auto-connected to master by createBus; drop that edge first.
+      this.bus.disconnect(requireMasterBus(this.cacophony));
+    }
+    this.bus.connect(next);
+    this.downstream = next;
+  }
+
+  /** Replace the effect graph in place (re-`Chain`), gain-dipped to mask the click. */
   async replace(effects: EffectSpec[], options: ChainOptions = {}): Promise<void> {
     await this.maskedRebuild(async () => {
       this.removeOwnFilters();
@@ -77,19 +126,69 @@ export class EffectChain {
   }
 
   /**
-   * Tear the chain down. Master overlay: strip only our filters (never destroy
-   * the shared master bus). Named chain: reroute every live sound to `masterBus`
-   * via cacophony's drain, then destroy the bus.
+   * Ramp the numeric params of one effect (addressed by `id` or index). Wire
+   * params are translated to cacophony AudioParam names by reusing
+   * `resolveEffect`, then ramped on the live node. No-ops safely if the target
+   * is missing or the bus is gone (V6).
+   */
+  automate(
+    target: string | number,
+    params: Record<string, number | string>,
+    options: AutomateOptions = {},
+  ): void {
+    if (this.bus.destroyed) {
+      return;
+    }
+    const entry = this.resolveEntry(target);
+    if (!entry) {
+      console.warn(`EffectChain '${this.id ?? '<inline>'}': automate target '${target}' not found`);
+      return;
+    }
+    const resolved = resolveEffect(
+      { type: entry.type, algorithm: entry.algorithm, params },
+      this.cacophony.context.sampleRate,
+    );
+    if (!resolved) {
+      return;
+    }
+    const rampType: FadeType = options.curve === 'exponential' ? 'exponential' : 'linear';
+    for (const [name, value] of Object.entries(resolved.options)) {
+      if (typeof value === 'number') {
+        this.bus.rampFilterParam(entry.node, name, value, {
+          duration: options.duration,
+          type: rampType,
+        });
+      }
+    }
+  }
+
+  /** Bypass / un-bypass one effect (keeps its node + params alive). */
+  setBypass(target: string | number, bypassed: boolean): void {
+    if (this.bus.destroyed) {
+      return;
+    }
+    const entry = this.resolveEntry(target);
+    if (!entry) {
+      console.warn(`EffectChain '${this.id ?? '<inline>'}': bypass target '${target}' not found`);
+      return;
+    }
+    this.bus.setFilterBypassed(entry.node, bypassed);
+  }
+
+  /**
+   * Tear the chain down. Master overlay strips only its own filters; a named
+   * chain reroutes live sounds to `masterBus` then destroys; an anonymous inline
+   * chain just destroys (its owning sound is being released).
    */
   destroy(masterBus: Bus): void {
-    if (this.isMaster) {
+    if (this.mode === 'master') {
       this.removeOwnFilters();
       return;
     }
     if (!this.bus.destroyed) {
-      this.bus.destroy({ drainTo: masterBus });
+      this.bus.destroy(this.mode === 'named' ? { drainTo: masterBus } : undefined);
     }
-    this.nodes = [];
+    this.entries = [];
   }
 
   private async applyEffects(effects: EffectSpec[]): Promise<void> {
@@ -97,31 +196,48 @@ export class EffectChain {
     for (const spec of effects) {
       const resolved = resolveEffect(spec, sampleRate);
       if (!resolved) {
-        console.warn(`EffectChain '${this.id}': unknown effect type '${spec.type}'; skipped`);
+        console.warn(
+          `EffectChain '${this.id ?? '<inline>'}': unknown effect type '${spec.type}'; skipped`,
+        );
         continue;
       }
       try {
         const built = buildEffect(this.cacophony, resolved);
         const node = await this.bus.addFilter(built);
-        this.nodes.push(node);
+        this.entries.push({
+          id: spec.id,
+          type: spec.type === 'echo' ? 'delay' : spec.type,
+          algorithm: spec.algorithm,
+          node,
+        });
+        if (spec.bypass) {
+          this.bus.setFilterBypassed(node, true);
+        }
       } catch (error) {
         console.warn(
-          `EffectChain '${this.id}': effect '${spec.type}' failed to build; skipped`,
+          `EffectChain '${this.id ?? '<inline>'}': effect '${spec.type}' failed to build; skipped`,
           error,
         );
       }
     }
   }
 
+  private resolveEntry(target: string | number): ChainEntry | undefined {
+    if (typeof target === 'number') {
+      return this.entries[target];
+    }
+    return this.entries.find((e) => e.id === target);
+  }
+
   private removeOwnFilters(): void {
-    for (const node of this.nodes) {
+    for (const entry of this.entries) {
       try {
-        this.bus.removeFilter(node);
+        this.bus.removeFilter(entry.node);
       } catch {
         // Best-effort: the bus may already have dropped it.
       }
     }
-    this.nodes = [];
+    this.entries = [];
   }
 
   private setGain(gain: number | undefined, fadein?: number): void {
@@ -150,7 +266,7 @@ export class EffectChain {
   }
 }
 
-/** The master bus always exists; narrow `getBus` for the overlay path. */
+/** The master bus always exists; narrow `getBus` for the overlay / downstream paths. */
 function requireMasterBus(cacophony: Cacophony): Bus {
   const master = cacophony.getBus('master');
   if (!master) {

--- a/src/audio/effects/MediaEffects.test.ts
+++ b/src/audio/effects/MediaEffects.test.ts
@@ -1,0 +1,138 @@
+import type { Bus, Cacophony } from 'cacophony';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildEffectsSupport, MediaEffects } from './MediaEffects';
+
+function makeBus(name: string | null) {
+  return {
+    name,
+    addFilter: vi.fn(async (arg: unknown) => arg),
+    removeFilter: vi.fn(),
+    destroy: vi.fn(),
+    drainTo: vi.fn(),
+    destroyed: false,
+    gain: 1,
+    output: { gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() } },
+  };
+}
+
+function makeCacophony() {
+  const master = makeBus('master');
+  const created = new Map<string, ReturnType<typeof makeBus>>();
+  const noop = (name: string) => vi.fn(() => ({ __effect: name }));
+  const cacophony = {
+    context: { sampleRate: 48000, currentTime: 0 },
+    createBus: vi.fn((name?: string) => {
+      const b = makeBus(name ?? null);
+      if (name) created.set(name, b);
+      return b as unknown as Bus;
+    }),
+    getBus: vi.fn(
+      (name: string) => (name === 'master' ? master : created.get(name)) as unknown as Bus,
+    ),
+    createFdnReverb: noop('fdn'),
+    createReverb: noop('plate'),
+    createDelay: noop('delay'),
+    createChorus: noop('chorus'),
+    createFlanger: noop('flanger'),
+    createVibrato: noop('vibrato'),
+    createDoubling: noop('doubling'),
+    createPhaser: noop('phaser'),
+    createTremolo: noop('tremolo'),
+    createAutoPan: noop('autopan'),
+    createDistortion: noop('distortion'),
+    createCompressor: noop('compressor'),
+    createLimiter: noop('limiter'),
+    createGate: noop('gate'),
+    createBiquadFilter: vi.fn((o: unknown) => ({ __biquad: o })),
+  };
+  return { cacophony: cacophony as unknown as Cacophony, master, created };
+}
+
+describe('MediaEffects', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a named chain and exposes it for routing', async () => {
+    const { cacophony, created } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    await fx.setChain({ id: 'cave', effects: [{ type: 'reverb' }] });
+    expect(cacophony.createBus).toHaveBeenCalledWith('cave');
+    expect(fx.hasChain('cave')).toBe(true);
+    expect(created.get('cave')!.addFilter).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces an existing chain in place (no second createBus)', async () => {
+    const { cacophony } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    await fx.setChain({ id: 'cave', effects: [{ type: 'reverb' }] });
+    await fx.setChain({ id: 'cave', effects: [{ type: 'distortion' }] });
+    expect(cacophony.createBus).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes a chain when effects is empty (destroying, draining to master)', async () => {
+    const { cacophony, created, master } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    await fx.setChain({ id: 'cave', effects: [{ type: 'reverb' }] });
+    const bus = created.get('cave')!;
+    await fx.setChain({ id: 'cave', effects: [] });
+    expect(bus.destroy).toHaveBeenCalledWith({ drainTo: master });
+    expect(fx.hasChain('cave')).toBe(false);
+  });
+
+  it('expands a known chain preset (telephone → bandpass + distortion + compressor)', async () => {
+    const { cacophony, created } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    await fx.setChain({ id: 'phone', preset: 'telephone' });
+    expect(created.get('phone')!.addFilter).toHaveBeenCalledTimes(3);
+  });
+
+  it('treats an unknown chain preset as a no-op (does not disturb existing chains)', async () => {
+    const { cacophony } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    await fx.setChain({ id: 'cave', effects: [{ type: 'reverb' }] });
+    await fx.setChain({ id: 'cave', preset: 'no-such-preset' });
+    expect(fx.hasChain('cave')).toBe(true);
+    expect(cacophony.createBus).toHaveBeenCalledTimes(1); // unchanged
+  });
+
+  it('caps effects per chain at the advertised maximum', async () => {
+    const { cacophony, created } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    const many = Array.from({ length: 20 }, () => ({ type: 'reverb' }) as const);
+    await fx.setChain({ id: 'big', effects: many });
+    expect(created.get('big')!.addFilter).toHaveBeenCalledTimes(8); // maxEffectsPerChain
+  });
+
+  it('removeChain destroys the bus with a drain to master', async () => {
+    const { cacophony, created, master } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    await fx.setChain({ id: 'cave', effects: [{ type: 'reverb' }] });
+    const bus = created.get('cave')!;
+    fx.removeChain('cave');
+    expect(bus.destroy).toHaveBeenCalledWith({ drainTo: master });
+  });
+
+  it('shutdown tears down every chain', async () => {
+    const { cacophony, created } = makeCacophony();
+    const fx = new MediaEffects(cacophony);
+    await fx.setChain({ id: 'a', effects: [{ type: 'reverb' }] });
+    await fx.setChain({ id: 'b', effects: [{ type: 'distortion' }] });
+    fx.shutdown();
+    expect(created.get('a')!.destroy).toHaveBeenCalled();
+    expect(created.get('b')!.destroy).toHaveBeenCalled();
+    expect(fx.hasChain('a')).toBe(false);
+  });
+});
+
+describe('buildEffectsSupport', () => {
+  it('advertises only legal wire type names and P0 capabilities', () => {
+    const s = buildEffectsSupport();
+    expect(s.types).toContain('reverb');
+    expect(s.types).toContain('lowpass');
+    expect(s.types).not.toContain('biquad'); // V8: never advertise a non-wire name
+    expect(s.types).not.toContain('echo'); // alias, not advertised
+    expect(s.reverbAlgorithms).toEqual(['fdn', 'plate']);
+    expect(s.chains).toBe(true);
+    expect(s.automation).toBe(false); // P2
+  });
+});

--- a/src/audio/effects/MediaEffects.test.ts
+++ b/src/audio/effects/MediaEffects.test.ts
@@ -133,6 +133,6 @@ describe('buildEffectsSupport', () => {
     expect(s.types).not.toContain('echo'); // alias, not advertised
     expect(s.reverbAlgorithms).toEqual(['fdn', 'plate']);
     expect(s.chains).toBe(true);
-    expect(s.automation).toBe(false); // P2
+    expect(s.automation).toBe(true);
   });
 });

--- a/src/audio/effects/MediaEffects.ts
+++ b/src/audio/effects/MediaEffects.ts
@@ -30,7 +30,7 @@ export function buildEffectsSupport(): EffectsSupport {
     types: ADVERTISED_EFFECT_TYPES,
     reverbAlgorithms: ['fdn', 'plate'],
     presets: Object.keys(CHAIN_PRESETS),
-    automation: false, // P2
+    automation: true,
     chains: true,
     maxChains: MAX_CHAINS,
     maxEffectsPerChain: MAX_EFFECTS_PER_CHAIN,

--- a/src/audio/effects/MediaEffects.ts
+++ b/src/audio/effects/MediaEffects.ts
@@ -1,0 +1,124 @@
+// Owns the set of live named effect chains for the Client.Media handler and
+// translates the GMCP chain messages into EffectChain lifecycle calls.
+//
+// Degradation (§6): an unknown chain preset is a no-op (never silently removes
+// an existing chain); empty/absent effects remove the chain (rerouting its live
+// sounds to master first, via EffectChain.destroy → cacophony drain).
+
+import type { Cacophony } from 'cacophony';
+
+import { EffectChain } from './EffectChain';
+import { CHAIN_PRESETS } from './presets';
+import { ADVERTISED_EFFECT_TYPES, type ChainSpec, type EffectSpec } from './types';
+
+/** The `Client.Media.EffectsSupport` capability payload (client → server). */
+export interface EffectsSupport {
+  types: readonly string[];
+  reverbAlgorithms: readonly string[];
+  presets: readonly string[];
+  automation: boolean;
+  chains: boolean;
+  maxChains: number;
+  maxEffectsPerChain: number;
+}
+
+const MAX_CHAINS = 16;
+const MAX_EFFECTS_PER_CHAIN = 8;
+
+export function buildEffectsSupport(): EffectsSupport {
+  return {
+    types: ADVERTISED_EFFECT_TYPES,
+    reverbAlgorithms: ['fdn', 'plate'],
+    presets: Object.keys(CHAIN_PRESETS),
+    automation: false, // P2
+    chains: true,
+    maxChains: MAX_CHAINS,
+    maxEffectsPerChain: MAX_EFFECTS_PER_CHAIN,
+  };
+}
+
+export class MediaEffects {
+  private readonly cacophony: Cacophony;
+  private readonly chains = new Map<string, EffectChain>();
+
+  constructor(cacophony: Cacophony) {
+    this.cacophony = cacophony;
+  }
+
+  /** Look up a live chain (for routing a sound through it). */
+  getChain(id: string): EffectChain | undefined {
+    return this.chains.get(id);
+  }
+
+  hasChain(id: string): boolean {
+    return this.chains.has(id);
+  }
+
+  /**
+   * Apply a `Client.Media.Chain` message: create, replace, or remove the named
+   * chain. Effects come from `spec.effects`, or from a client chain preset when
+   * `spec.preset` is given. Empty effects remove the chain.
+   */
+  async setChain(spec: ChainSpec): Promise<void> {
+    if (!spec.id) {
+      return;
+    }
+    const effects = this.resolveChainEffects(spec);
+    if (effects === undefined) {
+      return; // unknown preset — no-op (do not disturb an existing chain)
+    }
+    if (effects.length === 0) {
+      this.removeChain(spec.id);
+      return;
+    }
+    if (this.chains.size >= MAX_CHAINS && !this.chains.has(spec.id)) {
+      console.warn(`MediaEffects: chain limit (${MAX_CHAINS}) reached; '${spec.id}' ignored`);
+      return;
+    }
+    const capped = effects.slice(0, MAX_EFFECTS_PER_CHAIN);
+    const options = { gain: spec.gain, fadein: spec.fadein };
+    const existing = this.chains.get(spec.id);
+    if (existing) {
+      await existing.replace(capped, options);
+    } else {
+      const chain = await EffectChain.create(this.cacophony, spec.id, capped, options);
+      this.chains.set(spec.id, chain);
+    }
+  }
+
+  /** Remove a named chain (`Client.Media.ChainStop` or empty `Chain`). */
+  removeChain(id: string): void {
+    const chain = this.chains.get(id);
+    if (!chain) {
+      return;
+    }
+    const master = this.cacophony.getBus('master');
+    if (master) {
+      chain.destroy(master);
+    }
+    this.chains.delete(id);
+  }
+
+  /** Tear down every chain (e.g. on package shutdown). */
+  shutdown(): void {
+    for (const id of [...this.chains.keys()]) {
+      this.removeChain(id);
+    }
+  }
+
+  /**
+   * Returns the ordered effects for a chain spec, or `undefined` to signal "do
+   * nothing" (an unknown preset name). An explicit empty list means "remove".
+   */
+  private resolveChainEffects(spec: ChainSpec): EffectSpec[] | undefined {
+    if (spec.preset !== undefined) {
+      const preset = CHAIN_PRESETS[spec.preset];
+      if (!preset) {
+        console.warn(`MediaEffects: unknown chain preset '${spec.preset}'; ignored`);
+        return undefined;
+      }
+      return preset;
+    }
+    return spec.effects ?? [];
+  }
+}

--- a/src/audio/effects/buildEffect.test.ts
+++ b/src/audio/effects/buildEffect.test.ts
@@ -1,0 +1,69 @@
+import type { Cacophony } from 'cacophony';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildEffect } from './buildEffect';
+import { resolveEffect } from './resolveEffect';
+import type { ResolvedEffect } from './types';
+
+/** A cacophony stub whose factories are spies returning sentinel objects. */
+function stubCacophony() {
+  const factories = [
+    'createFdnReverb',
+    'createReverb',
+    'createDelay',
+    'createChorus',
+    'createFlanger',
+    'createVibrato',
+    'createDoubling',
+    'createPhaser',
+    'createTremolo',
+    'createAutoPan',
+    'createDistortion',
+    'createCompressor',
+    'createLimiter',
+    'createGate',
+    'createBiquadFilter',
+  ] as const;
+  const c: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const f of factories) {
+    c[f] = vi.fn((opts: unknown) => ({ __factory: f, opts }));
+  }
+  return c as unknown as Cacophony & Record<string, ReturnType<typeof vi.fn>>;
+}
+
+describe('buildEffect', () => {
+  it('dispatches a worklet plan to the matching factory with its options', () => {
+    const c = stubCacophony();
+    const resolved = resolveEffect({ type: 'reverb', params: { mix: 0.4 } }) as ResolvedEffect;
+    buildEffect(c, resolved);
+    expect(c.createFdnReverb).toHaveBeenCalledWith({ mix: 0.4 });
+  });
+
+  it('dispatches plate reverb to createReverb', () => {
+    const c = stubCacophony();
+    buildEffect(
+      c,
+      resolveEffect({ type: 'reverb', algorithm: 'plate', params: { mix: 0.5 } }) as ResolvedEffect,
+    );
+    expect(c.createReverb).toHaveBeenCalledTimes(1);
+    expect(c.createFdnReverb).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a biquad plan to createBiquadFilter with the type included', () => {
+    const c = stubCacophony();
+    buildEffect(
+      c,
+      resolveEffect({ type: 'lowpass', params: { frequency: 800 } }) as ResolvedEffect,
+    );
+    expect(c.createBiquadFilter).toHaveBeenCalledWith({ type: 'lowpass', frequency: 800 });
+  });
+
+  it('forwards the string shape alias for distortion', () => {
+    const c = stubCacophony();
+    buildEffect(
+      c,
+      resolveEffect({ type: 'distortion', params: { curve: 'soft', drive: 3 } }) as ResolvedEffect,
+    );
+    expect(c.createDistortion).toHaveBeenCalledWith({ drive: 3, shape: 'tanh' });
+  });
+});

--- a/src/audio/effects/buildEffect.ts
+++ b/src/audio/effects/buildEffect.ts
@@ -1,0 +1,64 @@
+// The single boundary between the pure translation (`resolveEffect`) and live
+// cacophony nodes. Given a validated build plan it calls the matching factory.
+// `resolveEffect` is the type authority for each factory's option shape (it
+// validates + clamps), so the option record is cast to the factory parameter
+// type here, at this one dynamic-dispatch boundary, and nowhere else.
+
+import type { Cacophony, CacophonyEffect } from 'cacophony';
+
+import type { ResolvedEffect } from './types';
+
+/** Anything `Bus.addFilter` accepts: a cacophony effect or a built biquad node. */
+export type BuiltEffect = CacophonyEffect | ReturnType<Cacophony['createBiquadFilter']>;
+
+/** Cast helper naming the factory's first-parameter type for `f`. */
+type OptionsOf<F extends keyof Cacophony> = Cacophony[F] extends (
+  options?: infer O,
+  ...rest: never[]
+) => unknown
+  ? O
+  : never;
+
+/** Build a live cacophony effect (or biquad node) from a resolved plan. */
+export function buildEffect(cacophony: Cacophony, resolved: ResolvedEffect): BuiltEffect {
+  if (resolved.kind === 'biquad') {
+    return cacophony.createBiquadFilter(resolved.options);
+  }
+
+  const o = resolved.options;
+  switch (resolved.factory) {
+    case 'createFdnReverb':
+      return cacophony.createFdnReverb(o as OptionsOf<'createFdnReverb'>);
+    case 'createReverb':
+      return cacophony.createReverb(o as OptionsOf<'createReverb'>);
+    case 'createDelay':
+      return cacophony.createDelay(o as OptionsOf<'createDelay'>);
+    case 'createChorus':
+      return cacophony.createChorus(o as OptionsOf<'createChorus'>);
+    case 'createFlanger':
+      return cacophony.createFlanger(o as OptionsOf<'createFlanger'>);
+    case 'createVibrato':
+      return cacophony.createVibrato(o as OptionsOf<'createVibrato'>);
+    case 'createDoubling':
+      return cacophony.createDoubling(o as OptionsOf<'createDoubling'>);
+    case 'createPhaser':
+      return cacophony.createPhaser(o as OptionsOf<'createPhaser'>);
+    case 'createTremolo':
+      return cacophony.createTremolo(o as OptionsOf<'createTremolo'>);
+    case 'createAutoPan':
+      return cacophony.createAutoPan(o as OptionsOf<'createAutoPan'>);
+    case 'createDistortion':
+      return cacophony.createDistortion(o as OptionsOf<'createDistortion'>);
+    case 'createCompressor':
+      return cacophony.createCompressor(o as OptionsOf<'createCompressor'>);
+    case 'createLimiter':
+      return cacophony.createLimiter(o as OptionsOf<'createLimiter'>);
+    case 'createGate':
+      return cacophony.createGate(o as OptionsOf<'createGate'>);
+    default: {
+      // Exhaustiveness: every WorkletFactory is handled above.
+      const _never: never = resolved.factory;
+      throw new Error(`Unhandled effect factory: ${String(_never)}`);
+    }
+  }
+}

--- a/src/audio/effects/presets.ts
+++ b/src/audio/effects/presets.ts
@@ -1,0 +1,76 @@
+// Client-side preset tables for the MCMP effects extension.
+//
+// Two levels (design §4):
+//   - PER-EFFECT presets: `effect.preset` fills that effect's intent params
+//     (explicit `params` still override). Keyed by effect TYPE then preset name.
+//   - CHAIN presets: `Chain.preset` expands to a whole ordered effect list
+//     client-side (e.g. "telephone" = bandpass → distortion → compressor).
+//
+// Presets are plain data in engine-neutral wire vocabulary — the obvious place
+// to grow the library without touching the protocol or the translator.
+
+import type { EffectSpec } from './types';
+
+/** `PER_EFFECT_PRESETS[type][name]` → intent params merged under `effect.params`. */
+export const PER_EFFECT_PRESETS: Readonly<
+  Record<string, Record<string, Record<string, number | string>>>
+> = {
+  reverb: {
+    room: { decayTime: 0.8, damping: 0.3, diffusion: 0.5, mix: 0.25 },
+    hall: { decayTime: 1.8, damping: 0.25, diffusion: 0.6, mix: 0.35 },
+    plate: { decayTime: 1.2, damping: 0.2, diffusion: 0.8, mix: 0.4 },
+    cave: { decayTime: 2.8, damping: 0.4, diffusion: 0.7, mix: 0.45 },
+    cathedral: { decayTime: 5.0, damping: 0.3, diffusion: 0.75, mix: 0.5 },
+    dream: { decayTime: 8.0, damping: 0.5, diffusion: 0.9, mix: 0.6 },
+  },
+  distortion: {
+    light: { drive: 4, curve: 'soft', mix: 0.5 },
+    heavy: { drive: 16, curve: 'hard', mix: 0.9 },
+    fuzz: { drive: 40, curve: 'hard', mix: 1, output: 0.6 },
+  },
+  delay: {
+    slapback: { delayTime: 120, feedback: 0.15, mix: 0.4 },
+    echo: { delayTime: 350, feedback: 0.45, mix: 0.5 },
+  },
+};
+
+/**
+ * `CHAIN_PRESETS[name]` → an ordered effect list (engine-neutral wire specs).
+ * Expanded by `handleChain` when a `Chain.preset` is sent instead of `effects`.
+ */
+export const CHAIN_PRESETS: Readonly<Record<string, EffectSpec[]>> = {
+  // A narrow telephone band (~300–3400 Hz) plus light grit and leveling.
+  telephone: [
+    { type: 'bandpass', params: { frequency: 1010, Q: 0.4 } },
+    { type: 'distortion', preset: 'light', params: { mix: 0.3 } },
+    { type: 'compressor', params: { threshold: -28, ratio: 6 } },
+  ],
+  // Muffled highs + a long, dark reverb.
+  underwater: [
+    { type: 'lowpass', params: { frequency: 700, Q: 0.7 } },
+    {
+      type: 'reverb',
+      algorithm: 'fdn',
+      params: { decayTime: 3.5, damping: 0.75, diffusion: 0.8, mix: 0.5 },
+    },
+  ],
+  // AM-radio band + saturation.
+  radio: [
+    { type: 'bandpass', params: { frequency: 1500, Q: 0.5 } },
+    { type: 'distortion', params: { drive: 6, curve: 'soft', mix: 0.5 } },
+  ],
+  // Mid honk + hard saturation, band-limited.
+  megaphone: [
+    { type: 'peaking', params: { frequency: 1500, gain: 9, Q: 1 } },
+    { type: 'distortion', params: { drive: 8, curve: 'hard', mix: 0.8 } },
+    { type: 'bandpass', params: { frequency: 1500, Q: 0.7 } },
+  ],
+  // A big, dark, modulated space.
+  cathedral: [
+    {
+      type: 'reverb',
+      algorithm: 'fdn',
+      params: { decayTime: 6, damping: 0.35, diffusion: 0.8, mix: 0.5 },
+    },
+  ],
+};

--- a/src/audio/effects/presets.ts
+++ b/src/audio/effects/presets.ts
@@ -20,17 +20,46 @@ export const PER_EFFECT_PRESETS: Readonly<
     hall: { decayTime: 1.8, damping: 0.25, diffusion: 0.6, mix: 0.35 },
     plate: { decayTime: 1.2, damping: 0.2, diffusion: 0.8, mix: 0.4 },
     cave: { decayTime: 2.8, damping: 0.4, diffusion: 0.7, mix: 0.45 },
+    chamber: { decayTime: 1.4, damping: 0.35, diffusion: 0.65, mix: 0.3 },
     cathedral: { decayTime: 5.0, damping: 0.3, diffusion: 0.75, mix: 0.5 },
+    arena: { decayTime: 3.6, damping: 0.2, diffusion: 0.7, mix: 0.45 },
     dream: { decayTime: 8.0, damping: 0.5, diffusion: 0.9, mix: 0.6 },
   },
   distortion: {
+    warm: { drive: 2, curve: 'soft', mix: 0.4 },
     light: { drive: 4, curve: 'soft', mix: 0.5 },
+    crunch: { drive: 9, curve: 'soft', mix: 0.7 },
     heavy: { drive: 16, curve: 'hard', mix: 0.9 },
     fuzz: { drive: 40, curve: 'hard', mix: 1, output: 0.6 },
   },
   delay: {
     slapback: { delayTime: 120, feedback: 0.15, mix: 0.4 },
     echo: { delayTime: 350, feedback: 0.45, mix: 0.5 },
+    dub: { delayTime: 500, feedback: 0.6, mix: 0.55 },
+    canyon: { delayTime: 750, feedback: 0.5, mix: 0.5 },
+  },
+  chorus: {
+    subtle: { rate: 0.4, depth: 3, mix: 0.3 },
+    lush: { rate: 0.8, depth: 6, mix: 0.5 },
+  },
+  flanger: {
+    jet: { rate: 0.25, depth: 4, feedback: 0.7, mix: 0.5 },
+    sweep: { rate: 0.5, depth: 6, feedback: 0.5, mix: 0.5 },
+  },
+  phaser: {
+    slow: { frequency: 500, rate: 0.3, depth: 1.5, stages: 4, mix: 0.5 },
+    swirl: { frequency: 800, rate: 1.2, depth: 2, stages: 6, feedback: 0.4, mix: 0.6 },
+  },
+  tremolo: {
+    soft: { rate: 4, depth: 0.4, waveform: 'sine' },
+    chop: { rate: 8, depth: 0.9, waveform: 'square' },
+  },
+  compressor: {
+    glue: { threshold: -18, ratio: 3, knee: 6, attack: 0.01, release: 0.2 },
+    squash: { threshold: -28, ratio: 8, knee: 3, attack: 0.003, release: 0.1, makeup: 6 },
+  },
+  gate: {
+    tight: { threshold: -45, ratio: 0.05, attack: 0.001, release: 0.08 },
   },
 };
 
@@ -71,6 +100,54 @@ export const CHAIN_PRESETS: Readonly<Record<string, EffectSpec[]>> = {
       type: 'reverb',
       algorithm: 'fdn',
       params: { decayTime: 6, damping: 0.35, diffusion: 0.8, mix: 0.5 },
+    },
+  ],
+  // Intimate small room.
+  room: [
+    {
+      type: 'reverb',
+      algorithm: 'fdn',
+      params: { decayTime: 0.7, damping: 0.4, diffusion: 0.5, mix: 0.22 },
+    },
+  ],
+  // Huge open arena with a slapback tail.
+  stadium: [
+    { type: 'delay', params: { delayTime: 180, feedback: 0.25, mix: 0.3 } },
+    {
+      type: 'reverb',
+      algorithm: 'fdn',
+      params: { decayTime: 4.5, damping: 0.25, diffusion: 0.75, mix: 0.5 },
+    },
+  ],
+  // Lo-fi old recording: band-limited, gently distorted, wobbly.
+  vinyl: [
+    { type: 'highpass', params: { frequency: 120, Q: 0.7 } },
+    { type: 'lowpass', params: { frequency: 6500, Q: 0.7 } },
+    { type: 'distortion', params: { drive: 3, curve: 'soft', mix: 0.3 } },
+    { type: 'tremolo', params: { rate: 0.7, depth: 0.15, waveform: 'sine' } },
+  ],
+  // Damaged transmission: harsh band + heavy clip + gating pump.
+  brokenSpeaker: [
+    { type: 'bandpass', params: { frequency: 1200, Q: 1.2 } },
+    { type: 'distortion', params: { drive: 14, curve: 'hard', mix: 0.85 } },
+  ],
+  // Ethereal, detuned, far-away.
+  ghost: [
+    { type: 'chorus', params: { rate: 0.5, depth: 8, mix: 0.6 } },
+    { type: 'highpass', params: { frequency: 400, Q: 0.7 } },
+    {
+      type: 'reverb',
+      algorithm: 'fdn',
+      params: { decayTime: 5, damping: 0.5, diffusion: 0.9, mix: 0.6 },
+    },
+  ],
+  // Dizzy / intoxicated: slow pitch wobble + smear.
+  drunk: [
+    { type: 'vibrato', params: { rate: 1.2, depth: 6 } },
+    {
+      type: 'reverb',
+      algorithm: 'fdn',
+      params: { decayTime: 2, damping: 0.6, diffusion: 0.85, mix: 0.4 },
     },
   ],
 };

--- a/src/audio/effects/resolveEffect.test.ts
+++ b/src/audio/effects/resolveEffect.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveEffect } from './resolveEffect';
+import type { ResolvedEffect } from './types';
+
+/** Narrow a result to a worklet plan (throws in-test if it isn't). */
+function worklet(r: ResolvedEffect | null): Extract<ResolvedEffect, { kind: 'worklet' }> {
+  expect(r).not.toBeNull();
+  expect(r?.kind).toBe('worklet');
+  return r as Extract<ResolvedEffect, { kind: 'worklet' }>;
+}
+
+function biquad(r: ResolvedEffect | null): Extract<ResolvedEffect, { kind: 'biquad' }> {
+  expect(r).not.toBeNull();
+  expect(r?.kind).toBe('biquad');
+  return r as Extract<ResolvedEffect, { kind: 'biquad' }>;
+}
+
+describe('resolveEffect — type → factory mapping', () => {
+  it.each([
+    ['delay', 'createDelay'],
+    ['echo', 'createDelay'], // echo is an alias of delay
+    ['chorus', 'createChorus'],
+    ['flanger', 'createFlanger'],
+    ['vibrato', 'createVibrato'],
+    ['doubling', 'createDoubling'],
+    ['phaser', 'createPhaser'],
+    ['tremolo', 'createTremolo'],
+    ['autopan', 'createAutoPan'],
+    ['distortion', 'createDistortion'],
+    ['compressor', 'createCompressor'],
+    ['limiter', 'createLimiter'],
+    ['gate', 'createGate'],
+  ])('maps %s → %s', (type, factory) => {
+    expect(worklet(resolveEffect({ type })).factory).toBe(factory);
+  });
+
+  it('maps reverb to FDN by default and Dattorro for algorithm:plate', () => {
+    expect(worklet(resolveEffect({ type: 'reverb' })).factory).toBe('createFdnReverb');
+    expect(worklet(resolveEffect({ type: 'reverb', algorithm: 'plate' })).factory).toBe(
+      'createReverb',
+    );
+    // unknown algorithm falls back to fdn
+    expect(worklet(resolveEffect({ type: 'reverb', algorithm: 'bogus' })).factory).toBe(
+      'createFdnReverb',
+    );
+  });
+
+  it.each([
+    'lowpass',
+    'highpass',
+    'bandpass',
+    'lowshelf',
+    'highshelf',
+    'peaking',
+    'notch',
+    'allpass',
+  ])('maps biquad type %s', (type) => {
+    const r = biquad(resolveEffect({ type, params: { frequency: 1000 } }));
+    expect(r.options.type).toBe(type);
+    expect(r.options.frequency).toBe(1000);
+  });
+
+  it('returns null for an unknown type (caller skips, sound plays dry)', () => {
+    expect(resolveEffect({ type: 'warp-drive' })).toBeNull();
+    expect(resolveEffect({ type: '' })).toBeNull();
+  });
+});
+
+describe('resolveEffect — FDN reverb', () => {
+  it('passes the neutral vocabulary through 1:1', () => {
+    const r = worklet(
+      resolveEffect({
+        type: 'reverb',
+        params: { decayTime: 2.5, preDelay: 0.05, damping: 0.4, diffusion: 0.7, mix: 0.45 },
+      }),
+    );
+    expect(r.options).toEqual({
+      decayTime: 2.5,
+      preDelay: 0.05,
+      damping: 0.4,
+      diffusion: 0.7,
+      mix: 0.45,
+    });
+  });
+
+  it('clamps out-of-range values', () => {
+    const r = worklet(
+      resolveEffect({ type: 'reverb', params: { decayTime: 999, damping: 5, mix: -1 } }),
+    );
+    expect(r.options.decayTime).toBe(20);
+    expect(r.options.damping).toBe(1);
+    expect(r.options.mix).toBe(0);
+  });
+});
+
+describe('resolveEffect — plate (Dattorro) reverb translation', () => {
+  it('converts preDelay seconds → samples using the sample rate', () => {
+    const r = worklet(
+      resolveEffect({ type: 'reverb', algorithm: 'plate', params: { preDelay: 0.01 } }, 48000),
+    );
+    expect(r.options.preDelay).toBe(480); // 0.01s * 48000
+  });
+
+  it('splits mix into wet and dry = 1 − mix', () => {
+    const r = worklet(resolveEffect({ type: 'reverb', algorithm: 'plate', params: { mix: 0.3 } }));
+    expect(r.options.wet).toBeCloseTo(0.3);
+    expect(r.options.dry).toBeCloseTo(0.7);
+    expect(r.options.mix).toBeUndefined(); // never leaks the FDN name onto the plate
+  });
+
+  it('maps decayTime → a monotonic normalized decay in (0, 0.95]', () => {
+    const short = worklet(
+      resolveEffect({ type: 'reverb', algorithm: 'plate', params: { decayTime: 1 } }),
+    );
+    const long = worklet(
+      resolveEffect({ type: 'reverb', algorithm: 'plate', params: { decayTime: 10 } }),
+    );
+    expect(short.options.decay).toBeGreaterThan(0);
+    expect(long.options.decay).toBeGreaterThan(short.options.decay as number);
+    expect(long.options.decay).toBeLessThanOrEqual(0.95);
+  });
+
+  it('maps diffusion → both input-diffusion stages', () => {
+    const r = worklet(
+      resolveEffect({ type: 'reverb', algorithm: 'plate', params: { diffusion: 0.6 } }),
+    );
+    expect(r.options.inputDiffusion1).toBe(0.6);
+    expect(r.options.inputDiffusion2).toBe(0.6);
+  });
+});
+
+describe('resolveEffect — string mode params (engine-neutral)', () => {
+  it('maps distortion curve hard→hardclip, soft→tanh', () => {
+    expect(
+      worklet(resolveEffect({ type: 'distortion', params: { curve: 'hard' } })).options.shape,
+    ).toBe('hardclip');
+    expect(
+      worklet(resolveEffect({ type: 'distortion', params: { curve: 'soft' } })).options.shape,
+    ).toBe('tanh');
+  });
+
+  it('ignores an invalid curve (degradation — cacophony default stands)', () => {
+    expect(
+      worklet(resolveEffect({ type: 'distortion', params: { curve: 'spicy' } })).options.shape,
+    ).toBeUndefined();
+  });
+
+  it('passes a valid tremolo waveform through as the cacophony shape alias', () => {
+    expect(
+      worklet(resolveEffect({ type: 'tremolo', params: { waveform: 'triangle' } })).options.shape,
+    ).toBe('triangle');
+  });
+
+  it('ignores an invalid tremolo waveform', () => {
+    expect(
+      worklet(resolveEffect({ type: 'tremolo', params: { waveform: 'sawtooth' } })).options.shape,
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveEffect — delay family', () => {
+  it('maps delayTime/feedback directly and mix → feedforward (wet tap)', () => {
+    const r = worklet(
+      resolveEffect({ type: 'delay', params: { delayTime: 300, feedback: 0.4, mix: 0.5 } }),
+    );
+    expect(r.options.delayTime).toBe(300);
+    expect(r.options.feedback).toBe(0.4);
+    expect(r.options.feedforward).toBe(0.5);
+  });
+
+  it('clamps feedback below 1 to stay stable', () => {
+    const r = worklet(resolveEffect({ type: 'delay', params: { feedback: 5 } }));
+    expect(r.options.feedback as number).toBeLessThan(1);
+  });
+});
+
+describe('resolveEffect — dynamics', () => {
+  it('limiter ignores ratio but keeps threshold/attack/release', () => {
+    const r = worklet(
+      resolveEffect({ type: 'limiter', params: { threshold: -6, ratio: 8, attack: 0.01 } }),
+    );
+    expect(r.options.threshold).toBe(-6);
+    expect(r.options.attack).toBe(0.01);
+    expect(r.options.ratio).toBeUndefined();
+  });
+
+  it('compressor keeps ratio and makeup; gate keeps ratio but drops makeup', () => {
+    const comp = worklet(resolveEffect({ type: 'compressor', params: { ratio: 4, makeup: 6 } }));
+    expect(comp.options.ratio).toBe(4);
+    expect(comp.options.makeup).toBe(6);
+    const gate = worklet(resolveEffect({ type: 'gate', params: { ratio: 0.1, makeup: 6 } }));
+    expect(gate.options.ratio).toBe(0.1);
+    expect(gate.options.makeup).toBeUndefined();
+  });
+});
+
+describe('resolveEffect — biquad', () => {
+  it('clamps frequency/Q/gain and only writes provided params', () => {
+    const r = biquad(
+      resolveEffect({ type: 'peaking', params: { frequency: 99999, Q: 2, gain: 100 } }),
+    );
+    expect(r.options.frequency).toBe(24000);
+    expect(r.options.Q).toBe(2);
+    expect(r.options.gain).toBe(40);
+  });
+
+  it('omits absent params', () => {
+    const r = biquad(resolveEffect({ type: 'lowpass', params: { frequency: 800 } }));
+    expect(r.options).toEqual({ type: 'lowpass', frequency: 800 });
+  });
+});
+
+describe('resolveEffect — unknown params are ignored', () => {
+  it('drops params with no wire meaning for the type', () => {
+    const r = worklet(
+      resolveEffect({ type: 'tremolo', params: { rate: 5, nonsense: 42, frequency: 1000 } }),
+    );
+    expect(r.options).toEqual({ rate: 5 }); // nonsense + frequency (not a tremolo param) dropped
+  });
+});
+
+describe('resolveEffect — presets', () => {
+  it('fills params from a per-effect preset', () => {
+    const r = worklet(resolveEffect({ type: 'reverb', preset: 'cave' }));
+    expect(r.options.decayTime).toBe(2.8);
+    expect(r.options.mix).toBe(0.45);
+  });
+
+  it('lets explicit params override the preset', () => {
+    const r = worklet(resolveEffect({ type: 'reverb', preset: 'cave', params: { mix: 0.1 } }));
+    expect(r.options.decayTime).toBe(2.8); // from preset
+    expect(r.options.mix).toBe(0.1); // overridden
+  });
+
+  it('ignores an unknown preset name (degradation)', () => {
+    const r = worklet(
+      resolveEffect({ type: 'reverb', preset: 'no-such-preset', params: { mix: 0.2 } }),
+    );
+    expect(r.options).toEqual({ mix: 0.2 });
+  });
+
+  it('applies a string-mode preset value (distortion light → soft/tanh)', () => {
+    const r = worklet(resolveEffect({ type: 'distortion', preset: 'light' }));
+    expect(r.options.shape).toBe('tanh');
+    expect(r.options.drive).toBe(4);
+  });
+});

--- a/src/audio/effects/resolveEffect.ts
+++ b/src/audio/effects/resolveEffect.ts
@@ -1,0 +1,298 @@
+// Pure translation: an engine-neutral wire `EffectSpec` → a cacophony build
+// plan (`ResolvedEffect`). No AudioContext, no nodes — so the whole, detail-dense
+// mapping (factory choice, unit conversions, clamping, unknown-dropping) is
+// unit-testable in isolation. `buildEffect` turns the plan into a live effect.
+//
+// Degradation rules (design §6) live here:
+//   - unknown `type`            → return null (caller skips the effect, plays dry)
+//   - unknown param / bad mode  → ignored (only known wire names are read)
+//   - out-of-range value        → clamped to the documented range
+//
+// The cacophony option names that appear below are the ONLY place they exist in
+// the client — they never travel on the wire (design §0.3, V1).
+
+import { PER_EFFECT_PRESETS } from './presets';
+import {
+  BIQUAD_TYPES,
+  type BiquadType,
+  type DistortionCurve,
+  type EffectSpec,
+  type ResolvedEffect,
+  type Waveform,
+  type WorkletFactory,
+} from './types';
+
+/** Default sample rate for the plate-reverb pre-delay (seconds → samples). */
+const DEFAULT_SAMPLE_RATE = 48000;
+
+const WAVEFORMS: readonly Waveform[] = ['sine', 'triangle', 'square'];
+const DISTORTION_CURVES: readonly DistortionCurve[] = ['hard', 'soft'];
+/** Wire distortion curve → cacophony waveshaper `shape` alias. */
+const CURVE_TO_SHAPE: Record<DistortionCurve, 'hardclip' | 'tanh'> = {
+  hard: 'hardclip',
+  soft: 'tanh',
+};
+
+const BIQUAD_TYPE_SET: ReadonlySet<string> = new Set(BIQUAD_TYPES);
+
+const clamp = (value: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, value));
+
+/** Read a finite number from the merged params, or `undefined`. */
+function num(params: Record<string, number | string>, key: string): number | undefined {
+  const v = params[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+/** Read a string from the merged params, or `undefined`. */
+function str(params: Record<string, number | string>, key: string): string | undefined {
+  const v = params[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Copy `wireKey` from `params` into `out[outKey]`, clamped to `[lo, hi]`, only
+ * when present and finite. Unknown/absent params are simply never written, which
+ * is exactly the "unknown param ignored" degradation rule.
+ */
+function mapNum(
+  params: Record<string, number | string>,
+  wireKey: string,
+  out: Record<string, number | string>,
+  outKey: string,
+  lo: number,
+  hi: number,
+): void {
+  const v = num(params, wireKey);
+  if (v !== undefined) {
+    out[outKey] = clamp(v, lo, hi);
+  }
+}
+
+/** Merge a per-effect preset (if any) under the explicit params (params win). */
+function mergedParams(spec: EffectSpec): Record<string, number | string> {
+  const preset =
+    spec.preset !== undefined ? PER_EFFECT_PRESETS[spec.type]?.[spec.preset] : undefined;
+  return { ...(preset ?? {}), ...(spec.params ?? {}) };
+}
+
+/** FDN reverb: the neutral vocabulary maps almost 1:1. */
+function resolveFdnReverb(p: Record<string, number | string>): Record<string, number> {
+  const o: Record<string, number | string> = {};
+  mapNum(p, 'decayTime', o, 'decayTime', 0.001, 20);
+  mapNum(p, 'preDelay', o, 'preDelay', 0, 1);
+  mapNum(p, 'damping', o, 'damping', 0, 1);
+  mapNum(p, 'diffusion', o, 'diffusion', 0, 1);
+  mapNum(p, 'mix', o, 'mix', 0, 1);
+  return o as Record<string, number>;
+}
+
+/**
+ * Plate (Dattorro) reverb: the option set is disjoint from FDN, so the neutral
+ * vocabulary is translated and APPROXIMATED (design §4 reverb note):
+ *   preDelay(s) → samples;  mix → wet, dry = 1−mix;
+ *   decayTime(s) → normalized `decay`;  diffusion → inputDiffusion1/2.
+ */
+function resolvePlateReverb(
+  p: Record<string, number | string>,
+  sampleRate: number,
+): Record<string, number> {
+  const o: Record<string, number> = {};
+  const preDelay = num(p, 'preDelay');
+  if (preDelay !== undefined) {
+    o.preDelay = clamp(Math.round(preDelay * sampleRate), 0, sampleRate - 1);
+  }
+  const mix = num(p, 'mix');
+  if (mix !== undefined) {
+    const wet = clamp(mix, 0, 1);
+    o.wet = wet;
+    o.dry = 1 - wet;
+  }
+  const decayTime = num(p, 'decayTime');
+  if (decayTime !== undefined) {
+    // Monotonic T60(s) → 0..1 decay coefficient. Documented approximation: a
+    // longer tail maps toward (but never reaches) full regeneration.
+    o.decay = clamp(1 - Math.exp(-Math.max(0, decayTime) / 3), 0, 0.95);
+  }
+  const damping = num(p, 'damping');
+  if (damping !== undefined) {
+    o.damping = clamp(damping, 0, 1);
+  }
+  const diffusion = num(p, 'diffusion');
+  if (diffusion !== undefined) {
+    const d = clamp(diffusion, 0, 1);
+    o.inputDiffusion1 = d;
+    o.inputDiffusion2 = d;
+  }
+  return o;
+}
+
+/** Shared modulated-delay family mapping (delay/chorus/flanger/vibrato/doubling). */
+function resolveModulatedDelay(p: Record<string, number | string>): Record<string, number> {
+  const o: Record<string, number> = {};
+  mapNum(p, 'delayTime', o, 'delayTime', 0, 1000);
+  mapNum(p, 'depth', o, 'depth', 0, 50);
+  mapNum(p, 'rate', o, 'rate', 0, 20);
+  mapNum(p, 'feedback', o, 'feedback', -0.9999999, 0.9999999);
+  // `mix` has no direct option on the unified delay circuit; map it to the wet
+  // (feedforward) tap, leaving the preset's `blend`/character intact (§4 approx).
+  const mix = num(p, 'mix');
+  if (mix !== undefined) {
+    o.feedforward = clamp(mix, 0, 1);
+  }
+  return o;
+}
+
+function resolvePhaser(p: Record<string, number | string>): Record<string, number> {
+  const o: Record<string, number> = {};
+  mapNum(p, 'frequency', o, 'frequency', 20, 10000);
+  mapNum(p, 'rate', o, 'rate', 0, 20);
+  mapNum(p, 'depth', o, 'depth', 0, 4);
+  mapNum(p, 'stages', o, 'stages', 2, 12);
+  mapNum(p, 'feedback', o, 'feedback', -0.95, 0.95);
+  mapNum(p, 'mix', o, 'mix', 0, 1);
+  return o;
+}
+
+function resolveTremolo(p: Record<string, number | string>): Record<string, number | string> {
+  const o: Record<string, number | string> = {};
+  mapNum(p, 'rate', o, 'rate', 0, 20);
+  mapNum(p, 'depth', o, 'depth', 0, 1);
+  mapNum(p, 'stereoPhase', o, 'stereoPhase', 0, 180);
+  const waveform = str(p, 'waveform');
+  if (waveform !== undefined && (WAVEFORMS as readonly string[]).includes(waveform)) {
+    o.shape = waveform; // cacophony 0.25 accepts the string alias directly
+  }
+  return o;
+}
+
+function resolveAutoPan(p: Record<string, number | string>): Record<string, number> {
+  const o: Record<string, number> = {};
+  mapNum(p, 'rate', o, 'rate', 0, 20);
+  mapNum(p, 'depth', o, 'depth', 0, 1);
+  return o;
+}
+
+function resolveDistortion(p: Record<string, number | string>): Record<string, number | string> {
+  const o: Record<string, number | string> = {};
+  mapNum(p, 'drive', o, 'drive', 0, 100);
+  mapNum(p, 'mix', o, 'mix', 0, 1);
+  mapNum(p, 'output', o, 'output', 0, 4);
+  const curve = str(p, 'curve');
+  if (curve !== undefined && (DISTORTION_CURVES as readonly string[]).includes(curve)) {
+    o.shape = CURVE_TO_SHAPE[curve as DistortionCurve];
+  }
+  return o;
+}
+
+function resolveDynamics(
+  p: Record<string, number | string>,
+  factory: 'createCompressor' | 'createLimiter' | 'createGate',
+): Record<string, number> {
+  const o: Record<string, number> = {};
+  mapNum(p, 'threshold', o, 'threshold', -100, 0);
+  mapNum(p, 'knee', o, 'knee', 0, 40);
+  mapNum(p, 'attack', o, 'attack', 0, 1);
+  mapNum(p, 'release', o, 'release', 0, 5);
+  // `ratio` is meaningful for compressor and gate; the limiter ignores it.
+  if (factory !== 'createLimiter') {
+    mapNum(p, 'ratio', o, 'ratio', 0.05, 1000);
+  }
+  if (factory === 'createCompressor') {
+    mapNum(p, 'makeup', o, 'makeup', -24, 24);
+  }
+  return o;
+}
+
+function resolveBiquad(type: BiquadType, p: Record<string, number | string>): ResolvedEffect {
+  const options: { type: BiquadType; frequency?: number; Q?: number; gain?: number } = { type };
+  const frequency = num(p, 'frequency');
+  if (frequency !== undefined) {
+    options.frequency = clamp(frequency, 10, 24000);
+  }
+  const q = num(p, 'Q');
+  if (q !== undefined) {
+    options.Q = clamp(q, 0.0001, 1000);
+  }
+  const gain = num(p, 'gain');
+  if (gain !== undefined) {
+    options.gain = clamp(gain, -40, 40);
+  }
+  return { kind: 'biquad', type, options };
+}
+
+/** Map a worklet wire type to its cacophony factory (after the `echo` alias). */
+const SIMPLE_FACTORY: Partial<Record<string, WorkletFactory>> = {
+  chorus: 'createChorus',
+  flanger: 'createFlanger',
+  vibrato: 'createVibrato',
+  doubling: 'createDoubling',
+};
+
+/**
+ * Translate one wire {@link EffectSpec} into a cacophony build plan, or `null`
+ * if the `type` is unknown (the caller skips it and the sound still plays dry).
+ *
+ * @param spec       the wire effect.
+ * @param sampleRate used only for the plate-reverb pre-delay (seconds → samples).
+ */
+export function resolveEffect(
+  spec: EffectSpec,
+  sampleRate: number = DEFAULT_SAMPLE_RATE,
+): ResolvedEffect | null {
+  const type = spec.type === 'echo' ? 'delay' : spec.type;
+  const p = mergedParams(spec);
+
+  if (BIQUAD_TYPE_SET.has(type)) {
+    return resolveBiquad(type as BiquadType, p);
+  }
+
+  switch (type) {
+    case 'reverb': {
+      const plate = spec.algorithm === 'plate';
+      return {
+        kind: 'worklet',
+        factory: plate ? 'createReverb' : 'createFdnReverb',
+        options: plate ? resolvePlateReverb(p, sampleRate) : resolveFdnReverb(p),
+      };
+    }
+    case 'delay':
+      return { kind: 'worklet', factory: 'createDelay', options: resolveModulatedDelay(p) };
+    case 'chorus':
+    case 'flanger':
+    case 'vibrato':
+    case 'doubling':
+      return {
+        kind: 'worklet',
+        factory: SIMPLE_FACTORY[type] as WorkletFactory,
+        options: resolveModulatedDelay(p),
+      };
+    case 'phaser':
+      return { kind: 'worklet', factory: 'createPhaser', options: resolvePhaser(p) };
+    case 'tremolo':
+      return { kind: 'worklet', factory: 'createTremolo', options: resolveTremolo(p) };
+    case 'autopan':
+      return { kind: 'worklet', factory: 'createAutoPan', options: resolveAutoPan(p) };
+    case 'distortion':
+      return { kind: 'worklet', factory: 'createDistortion', options: resolveDistortion(p) };
+    case 'compressor':
+      return {
+        kind: 'worklet',
+        factory: 'createCompressor',
+        options: resolveDynamics(p, 'createCompressor'),
+      };
+    case 'limiter':
+      return {
+        kind: 'worklet',
+        factory: 'createLimiter',
+        options: resolveDynamics(p, 'createLimiter'),
+      };
+    case 'gate':
+      return {
+        kind: 'worklet',
+        factory: 'createGate',
+        options: resolveDynamics(p, 'createGate'),
+      };
+    default:
+      return null; // unknown type — caller skips, sound plays dry
+  }
+}

--- a/src/audio/effects/types.ts
+++ b/src/audio/effects/types.ts
@@ -1,0 +1,130 @@
+// Wire vocabulary for the MCMP effects extension (GMCP `Client.Media`).
+//
+// This is the ENGINE-NEUTRAL contract that travels on the wire. It describes
+// effect *intent* in real units (Hz, ms, dB, seconds; 0..1 for normalized
+// mixes) and names mode-like values with words ("sine", "hard"), NEVER with
+// cacophony's internal option names or integer enums. The translation to
+// cacophony lives entirely in `resolveEffect.ts`, so the same wire format could
+// drive a different audio engine. See `plans/mcmp-effects-design.md` §1, §4.
+
+/** Reverb algorithm discriminator (protocol-level, NOT a `params` key). */
+export type ReverbAlgorithm = 'fdn' | 'plate';
+
+/** Tremolo / auto-pan LFO waveform. Maps to cacophony's `shape` string alias. */
+export type Waveform = 'sine' | 'triangle' | 'square';
+
+/** Distortion nonlinearity. Maps to cacophony's waveshaper `shape` alias. */
+export type DistortionCurve = 'hard' | 'soft';
+
+/** Biquad filter wire types — the EQ/filter building blocks. */
+export const BIQUAD_TYPES = [
+  'lowpass',
+  'highpass',
+  'bandpass',
+  'lowshelf',
+  'highshelf',
+  'peaking',
+  'notch',
+  'allpass',
+] as const;
+export type BiquadType = (typeof BIQUAD_TYPES)[number];
+
+/**
+ * Worklet-backed effect wire types. `echo` is an accepted alias of `delay`
+ * (not advertised separately); every other name is advertised verbatim.
+ */
+export const WORKLET_EFFECT_TYPES = [
+  'reverb',
+  'delay',
+  'chorus',
+  'flanger',
+  'vibrato',
+  'doubling',
+  'phaser',
+  'tremolo',
+  'autopan',
+  'distortion',
+  'compressor',
+  'limiter',
+  'gate',
+] as const;
+export type WorkletEffectType = (typeof WORKLET_EFFECT_TYPES)[number];
+
+/** Every legal wire `type` value. `echo` is additionally accepted as an alias. */
+export type EffectType = WorkletEffectType | BiquadType;
+
+/**
+ * The exact set advertised in `Client.Media.EffectsSupport.types` — every name
+ * a server may legally send as a `type` (V8: never advertise a non-wire name
+ * like "biquad"). `echo` is intentionally omitted (it is an alias of `delay`).
+ */
+export const ADVERTISED_EFFECT_TYPES: readonly string[] = [
+  ...WORKLET_EFFECT_TYPES,
+  ...BIQUAD_TYPES,
+];
+
+/** One effect on the wire — shared by named chains and inline per-sound chains. */
+export interface EffectSpec {
+  /** REQUIRED. A value in {@link EffectType} (or the `echo` alias). Unknown → dropped. */
+  type: string;
+  /** Optional. Names this effect for automation targeting within a chain. */
+  id?: string;
+  /** Optional. Reverb only: `"fdn"` (default) or `"plate"`. */
+  algorithm?: string;
+  /** Optional. Per-effect preset name; explicit `params` override preset values. */
+  preset?: string;
+  /** Optional. Intent params (numbers) + mode strings (`waveform`, `curve`). */
+  params?: Record<string, number | string>;
+  /** Optional. Mute without removing (P2 — keeps the automation target alive). */
+  bypass?: boolean;
+}
+
+/** A named environment chain (`Client.Media.Chain`). */
+export interface ChainSpec {
+  /** REQUIRED. Names the bus. `"master"` is the global-overlay special case. */
+  id: string;
+  /** Ordered effect chain. Empty/absent = remove the chain. */
+  effects?: EffectSpec[];
+  /** Optional shorthand: a chain-preset name expanded client-side to `effects`. */
+  preset?: string;
+  /** Optional bus output level (0..). */
+  gain?: number;
+  /** Optional ms ramp applied to the bus gain when (dis)engaging. */
+  fadein?: number;
+}
+
+/** cacophony factory names this client builds worklet effects through. */
+export type WorkletFactory =
+  | 'createFdnReverb'
+  | 'createReverb'
+  | 'createDelay'
+  | 'createChorus'
+  | 'createFlanger'
+  | 'createVibrato'
+  | 'createDoubling'
+  | 'createPhaser'
+  | 'createTremolo'
+  | 'createAutoPan'
+  | 'createDistortion'
+  | 'createCompressor'
+  | 'createLimiter'
+  | 'createGate';
+
+/**
+ * The translated, engine-FACING plan produced by `resolveEffect`. A pure value
+ * (no audio nodes) so the translation is unit-testable without an AudioContext;
+ * `buildEffect` turns it into a live cacophony effect.
+ */
+export type ResolvedEffect =
+  | {
+      kind: 'biquad';
+      type: BiquadType;
+      /** cacophony `createBiquadFilter` options. */
+      options: { type: BiquadType; frequency?: number; Q?: number; gain?: number };
+    }
+  | {
+      kind: 'worklet';
+      factory: WorkletFactory;
+      /** cacophony factory options (string values allowed for mode params). */
+      options: Record<string, number | string>;
+    };

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,43 +1,31 @@
-import {
-  Stream,
-  TelnetCommand,
-  TelnetOption,
-  TelnetParser,
-  WebSocketStream,
-} from "./telnet";
-
-import { Buffer } from "buffer";
-import { EventEmitter } from "eventemitter3";
-import stripAnsi from "strip-ansi";
-import { EditorManager } from "./EditorManager";
-import { GMCPChar, GMCPClientFileTransfer } from "./gmcp";
-import type { GMCPPackage } from "./gmcp/package";
-import type {
-  GMCPHandlerMap,
-  KnownGMCPPackageMap,
-  KnownGMCPPackageName,
-} from "./gmcp/types";
-import {
-  MCPKeyvals,
-  MCPPackage,
-  McpAwnsGetSet,
-  McpNegotiate,
-  generateTag,
-  parseMcpMessage,
-  parseMcpMultiline,
-} from "./mcp";
-
-import { Cacophony } from "cacophony";
-import { AutoreadMode, preferencesStore } from "./PreferencesStore";
-import { WebRTCService } from "./WebRTCService";
-import FileTransferManager from "./FileTransferManager.js";
-import { GMCPMessageRoomInfo, RoomPlayer } from "./gmcp/Room"; // Import RoomPlayer
+import { Buffer } from 'buffer';
+import { Cacophony } from 'cacophony';
+import { EventEmitter } from 'eventemitter3';
+import stripAnsi from 'strip-ansi';
+import { EditorManager } from './EditorManager';
+import FileTransferManager from './FileTransferManager.js';
+import { GMCPChar, GMCPClientFileTransfer } from './gmcp';
 import type {
   SpatialEmitter,
   SpatialEntity,
   SpatialListenerOrientation,
   SpatialVector,
-} from "./gmcp/Client/Spatial";
+} from './gmcp/Client/Spatial';
+import type { GMCPPackage } from './gmcp/package';
+import type { GMCPMessageRoomInfo, RoomPlayer } from './gmcp/Room'; // Import RoomPlayer
+import type { GMCPHandlerMap, KnownGMCPPackageMap, KnownGMCPPackageName } from './gmcp/types';
+import {
+  generateTag,
+  type MCPKeyvals,
+  type MCPPackage,
+  McpAwnsGetSet,
+  McpNegotiate,
+  parseMcpMessage,
+  parseMcpMultiline,
+} from './mcp';
+import { AutoreadMode, preferencesStore } from './PreferencesStore';
+import { type Stream, TelnetCommand, TelnetOption, TelnetParser, WebSocketStream } from './telnet';
+import { WebRTCService } from './WebRTCService';
 
 export interface WorldData {
   liveKitTokens: string[];
@@ -55,18 +43,18 @@ export interface WorldData {
 function resetMidiIntentionalDisconnectFlags(): void {
   if (!preferencesStore.getState().midi.enabled) return;
 
-  import("./MidiService")
+  import('./MidiService')
     .then(({ midiService }) => {
       midiService.resetIntentionalDisconnectFlags();
     })
     .catch((error) => {
-      console.error("Failed to reset MIDI disconnect flags:", error);
+      console.error('Failed to reset MIDI disconnect flags:', error);
     });
 }
 
 class MudClient extends EventEmitter {
   private ws!: WebSocket;
-  private decoder = new TextDecoder("utf8");
+  private decoder = new TextDecoder('utf8');
   private telnet!: TelnetParser;
   private _connected: boolean = false;
   private intentionalDisconnect: boolean = false;
@@ -80,7 +68,7 @@ class MudClient extends EventEmitter {
   private host: string;
   private port: number;
   private telnetNegotiation: boolean = false;
-  private telnetBuffer: string = "";
+  private telnetBuffer: string = '';
   public gmcpHandlers: GMCPHandlerMap = {};
   public mcpHandlers: { [key: string]: MCPPackage } = {};
   public mcpMultilines: { [key: string]: MCPPackage } = {};
@@ -90,14 +78,14 @@ class MudClient extends EventEmitter {
   public gmcp_char: GMCPChar;
   public gmcp_fileTransfer: GMCPClientFileTransfer;
   public worldData: WorldData = {
-    playerId: "",
-    playerName: "",
-    roomId: "",
+    playerId: '',
+    playerName: '',
+    roomId: '',
     liveKitTokens: [],
     roomPlayers: [], // Initialized as RoomPlayer[]
     spatialEntities: {},
     spatialEmitters: {},
-    listenerEntityId: "",
+    listenerEntityId: '',
     listenerPosition: null,
     listenerOrientation: { forward: null, up: null },
   };
@@ -144,13 +132,10 @@ class MudClient extends EventEmitter {
     this.cacophony.setGlobalVolume(preferencesStore.getState().sound.volume);
     this.editors = new EditorManager(this);
     this.webRTCService = new WebRTCService(this);
-    this.fileTransferManager = new FileTransferManager(
-      this,
-      this.gmcp_fileTransfer
-    );
-    
-    window.addEventListener("focus", this.handleWindowFocus);
-    window.addEventListener("blur", this.handleWindowBlur);
+    this.fileTransferManager = new FileTransferManager(this, this.gmcp_fileTransfer);
+
+    window.addEventListener('focus', this.handleWindowFocus);
+    window.addEventListener('blur', this.handleWindowBlur);
 
     this.unsubscribePreferences = preferencesStore.subscribe(() => {
       this.updateBackgroundMuteState();
@@ -166,9 +151,9 @@ class MudClient extends EventEmitter {
   }
 
   acceptTransfer(sender: string, hash: string): void {
-    this.fileTransferManager.acceptTransfer(sender, hash).catch(error => {
-      console.error("[MudClient] Failed to accept transfer:", error);
-      this.onFileTransferError(hash, "unknown", "receive", error.message);
+    this.fileTransferManager.acceptTransfer(sender, hash).catch((error) => {
+      console.error('[MudClient] Failed to accept transfer:', error);
+      this.onFileTransferError(hash, 'unknown', 'receive', error.message);
     });
   }
 
@@ -182,16 +167,16 @@ class MudClient extends EventEmitter {
     hash: string,
     filename: string,
     filesize: number,
-    offerSdp: string
+    offerSdp: string,
   ): void {
-    console.log("[MudClient] Emitting fileTransferOffer event:", {
+    console.log('[MudClient] Emitting fileTransferOffer event:', {
       sender,
       hash,
       filename,
       filesize,
       offerSdp,
     });
-    this.emit("fileTransferOffer", {
+    this.emit('fileTransferOffer', {
       sender,
       hash,
       filename,
@@ -200,56 +185,47 @@ class MudClient extends EventEmitter {
     });
   }
 
-  onFileTransferAccept(
-    sender: string,
-    hash: string,
-    filename: string,
-    answerSdp: string
-  ): void {
-    console.log("[MudClient] Emitting fileTransferAccepted event:", {
+  onFileTransferAccept(sender: string, hash: string, filename: string, answerSdp: string): void {
+    console.log('[MudClient] Emitting fileTransferAccepted event:', {
       sender,
       hash,
       filename,
       answerSdp,
     });
-    this.emit("fileTransferAccepted", { sender, hash, filename, answerSdp });
+    this.emit('fileTransferAccepted', { sender, hash, filename, answerSdp });
   }
 
   onFileTransferReject(sender: string, hash: string): void {
-    this.emit("fileTransferRejected", { sender, hash });
+    this.emit('fileTransferRejected', { sender, hash });
   }
 
   onFileTransferCancel(sender: string, hash: string): void {
-    this.emit("fileTransferCancelled", { sender, hash });
+    this.emit('fileTransferCancelled', { sender, hash });
   }
 
   onFileSendComplete(hash: string, filename: string): void {
-    this.emit("fileSendComplete", { hash, filename });
+    this.emit('fileSendComplete', { hash, filename });
   }
 
   onFileTransferError(
     hash: string,
     filename: string,
-    direction: "send" | "receive",
-    error: string
+    direction: 'send' | 'receive',
+    error: string,
   ): void {
-    this.emit("fileTransferError", { hash, filename, direction, error });
+    this.emit('fileTransferError', { hash, filename, direction, error });
   }
 
   onConnectionRecovered(data: {
     filename: string;
-    direction: "send" | "receive";
+    direction: 'send' | 'receive';
     hash: string;
   }): void {
-    this.emit("connectionRecovered", data);
+    this.emit('connectionRecovered', data);
   }
 
-  onRecoveryFailed(data: {
-    filename: string;
-    direction: "send" | "receive";
-    error: string;
-  }): void {
-    this.emit("recoveryFailed", data);
+  onRecoveryFailed(data: { filename: string; direction: 'send' | 'receive'; error: string }): void {
+    this.emit('recoveryFailed', data);
   }
 
   // GMCP methods for file transfer
@@ -258,39 +234,24 @@ class MudClient extends EventEmitter {
     filename: string,
     hash: string,
     filesize: number,
-    offerSdp: string
+    offerSdp: string,
   ): void {
-    this.gmcp_fileTransfer.sendOffer(
-      recipient,
-      filename,
-      filesize,
-      offerSdp,
-      hash
-    );
+    this.gmcp_fileTransfer.sendOffer(recipient, filename, filesize, offerSdp, hash);
   }
 
-  sendFileTransferAccept(
-    sender: string,
-    filename: string,
-    hash: string,
-    answerSdp: string
-  ): void {
+  sendFileTransferAccept(sender: string, filename: string, hash: string, answerSdp: string): void {
     this.gmcp_fileTransfer.sendAccept(sender, hash, filename, answerSdp);
   }
 
   registerGMCPPackage<P extends GMCPPackage>(p: new (_: MudClient) => P): P {
     const gmcpPackage = new p(this);
     this.gmcpHandlers[gmcpPackage.packageName] = gmcpPackage;
-    console.log("Registered GMCP Package:", gmcpPackage.packageName);
+    console.log('Registered GMCP Package:', gmcpPackage.packageName);
     return gmcpPackage;
   }
 
-  requireGMCPPackage<K extends KnownGMCPPackageName>(
-    packageName: K
-  ): KnownGMCPPackageMap[K] {
-    const gmcpPackage = this.gmcpHandlers[packageName] as
-      | KnownGMCPPackageMap[K]
-      | undefined;
+  requireGMCPPackage<K extends KnownGMCPPackageName>(packageName: K): KnownGMCPPackageMap[K] {
+    const gmcpPackage = this.gmcpHandlers[packageName] as KnownGMCPPackageMap[K] | undefined;
     if (!gmcpPackage) {
       throw new Error(`Required GMCP package is not registered: ${packageName}`);
     }
@@ -307,51 +268,49 @@ class MudClient extends EventEmitter {
     this.intentionalDisconnect = false;
     this.connectionCleanupComplete = false;
     this.ws = new window.WebSocket(`wss://${this.host}:${this.port}`);
-    this.ws.binaryType = "arraybuffer";
+    this.ws.binaryType = 'arraybuffer';
     this.telnet = new TelnetParser(new WebSocketStream(this.ws));
     this.ws.onopen = () => {
       this._connected = true;
-      
+
       // Reset MIDI intentional disconnect flags when successfully reconnecting to server
       resetMidiIntentionalDisconnectFlags();
-      
-      this.emit("connect");
-      this.emit("connectionChange", true);
+
+      this.emit('connect');
+      this.emit('connectionChange', true);
     };
 
-    this.telnet.on("data", (data: ArrayBuffer) => {
+    this.telnet.on('data', (data: ArrayBuffer) => {
       this.handleData(data);
     });
 
-    this.telnet.on("negotiation", (command, option) => {
+    this.telnet.on('negotiation', (command, option) => {
       // Negotiation that we support GMCP
       if (command === TelnetCommand.WILL && option === TelnetOption.GMCP) {
-        console.log("GMCP Negotiation");
+        console.log('GMCP Negotiation');
         this.telnet.sendNegotiation(TelnetCommand.DO, TelnetOption.GMCP);
-        this.requireGMCPPackage("Core").sendHello();
-        this.requireGMCPPackage("Core.Supports").sendSet();
-        this.requireGMCPPackage("Auth.Autologin").sendLogin();
-      } else if (
-        command === TelnetCommand.DO &&
-        option === TelnetOption.TERMINAL_TYPE
-      ) {
-        console.log("TTYPE Negotiation");
-        this.telnet.sendNegotiation(
-          TelnetCommand.WILL,
-          TelnetOption.TERMINAL_TYPE
-        );
-        this.telnet.sendTerminalType("Mongoose Client");
-        this.telnet.sendTerminalType("ANSI");
-        this.telnet.sendTerminalType("PROXY");
+        this.requireGMCPPackage('Core').sendHello();
+        this.requireGMCPPackage('Core.Supports').sendSet();
+        this.requireGMCPPackage('Auth.Autologin').sendLogin();
+        // Advertise MCMP effect support so the server only sends what we can render.
+        (
+          this.gmcpHandlers['Client.Media'] as { sendEffectsSupport?: () => void } | undefined
+        )?.sendEffectsSupport?.();
+      } else if (command === TelnetCommand.DO && option === TelnetOption.TERMINAL_TYPE) {
+        console.log('TTYPE Negotiation');
+        this.telnet.sendNegotiation(TelnetCommand.WILL, TelnetOption.TERMINAL_TYPE);
+        this.telnet.sendTerminalType('Mongoose Client');
+        this.telnet.sendTerminalType('ANSI');
+        this.telnet.sendTerminalType('PROXY');
       }
     });
 
-    this.telnet.on("gmcp", (packageName, data) => {
-      console.log("GMCP Package:", packageName, data);
+    this.telnet.on('gmcp', (packageName, data) => {
+      console.log('GMCP Package:', packageName, data);
       try {
         this.handleGmcpData(packageName, data);
       } catch (e) {
-        console.error("Calling GMCP:", e);
+        console.error('Calling GMCP:', e);
       }
     });
 
@@ -366,7 +325,7 @@ class MudClient extends EventEmitter {
     };
 
     this.ws.onerror = (error: Event) => {
-      this.emit("error", error);
+      this.emit('error', error);
     };
   }
 
@@ -382,45 +341,43 @@ class MudClient extends EventEmitter {
     this.connectionCleanupComplete = false;
     this.telnet = new TelnetParser(stream);
 
-    this.telnet.on("data", (data: ArrayBuffer) => {
+    this.telnet.on('data', (data: ArrayBuffer) => {
       this.handleData(data);
     });
 
     // The WASM server does not send telnet negotiation (no IAC sequences),
     // so these handlers are unlikely to fire — but wire them up anyway
     // for correctness.
-    this.telnet.on("negotiation", (command, option) => {
+    this.telnet.on('negotiation', (command, option) => {
       if (command === TelnetCommand.WILL && option === TelnetOption.GMCP) {
-        console.log("GMCP Negotiation (local)");
+        console.log('GMCP Negotiation (local)');
         this.telnet.sendNegotiation(TelnetCommand.DO, TelnetOption.GMCP);
-        this.requireGMCPPackage("Core").sendHello();
-        this.requireGMCPPackage("Core.Supports").sendSet();
-        this.requireGMCPPackage("Auth.Autologin").sendLogin();
-      } else if (
-        command === TelnetCommand.DO &&
-        option === TelnetOption.TERMINAL_TYPE
-      ) {
-        console.log("TTYPE Negotiation (local)");
-        this.telnet.sendNegotiation(
-          TelnetCommand.WILL,
-          TelnetOption.TERMINAL_TYPE
-        );
-        this.telnet.sendTerminalType("Mongoose Client");
-        this.telnet.sendTerminalType("ANSI");
-        this.telnet.sendTerminalType("PROXY");
+        this.requireGMCPPackage('Core').sendHello();
+        this.requireGMCPPackage('Core.Supports').sendSet();
+        this.requireGMCPPackage('Auth.Autologin').sendLogin();
+        // Advertise MCMP effect support so the server only sends what we can render.
+        (
+          this.gmcpHandlers['Client.Media'] as { sendEffectsSupport?: () => void } | undefined
+        )?.sendEffectsSupport?.();
+      } else if (command === TelnetCommand.DO && option === TelnetOption.TERMINAL_TYPE) {
+        console.log('TTYPE Negotiation (local)');
+        this.telnet.sendNegotiation(TelnetCommand.WILL, TelnetOption.TERMINAL_TYPE);
+        this.telnet.sendTerminalType('Mongoose Client');
+        this.telnet.sendTerminalType('ANSI');
+        this.telnet.sendTerminalType('PROXY');
       }
     });
 
-    this.telnet.on("gmcp", (packageName, data) => {
-      console.log("GMCP Package (local):", packageName, data);
+    this.telnet.on('gmcp', (packageName, data) => {
+      console.log('GMCP Package (local):', packageName, data);
       try {
         this.handleGmcpData(packageName, data);
       } catch (e) {
-        console.error("Calling GMCP:", e);
+        console.error('Calling GMCP:', e);
       }
     });
 
-    stream.on("close", () => {
+    stream.on('close', () => {
       this.cleanupConnection();
     });
 
@@ -428,8 +385,8 @@ class MudClient extends EventEmitter {
     // message once the virtual connection is created.
     this._connected = true;
     resetMidiIntentionalDisconnectFlags();
-    this.emit("connect");
-    this.emit("connectionChange", true);
+    this.emit('connect');
+    this.emit('connectionChange', true);
   }
 
   public send(data: string) {
@@ -446,27 +403,26 @@ class MudClient extends EventEmitter {
     this.connectionCleanupComplete = true;
     this._connected = false;
     this.mcpAuthKey = null;
-    this.telnetBuffer = "";
+    this.telnetBuffer = '';
     this.telnetNegotiation = false;
     this.currentRoomInfo = null; // Reset room info on cleanup
     this.worldData.spatialEntities = {};
     this.worldData.spatialEmitters = {};
-    this.worldData.listenerEntityId = "";
+    this.worldData.listenerEntityId = '';
     this.worldData.listenerPosition = null;
     this.worldData.listenerOrientation = { forward: null, up: null };
     this.webRTCService.cleanup();
     this.fileTransferManager.cleanup();
-    
-    this.emit("disconnect");
-    this.emit("connectionChange", false);
+
+    this.emit('disconnect');
+    this.emit('connectionChange', false);
   }
 
   public close(): void {
     this.intentionalDisconnect = true;
     if (
       this.ws &&
-      (this.ws.readyState === WebSocket.CONNECTING ||
-        this.ws.readyState === WebSocket.OPEN)
+      (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)
     ) {
       this.ws.close();
     }
@@ -481,13 +437,13 @@ class MudClient extends EventEmitter {
   public sendCommand(command: string): void {
     const localEchoEnabled = preferencesStore.getState().general.localEcho;
     if (localEchoEnabled) {
-      this.emit("command", command);
+      this.emit('command', command);
     }
-    if (this.autosay && !command.startsWith("-") && !command.startsWith("'")) {
-      command = "say " + command;
+    if (this.autosay && !command.startsWith('-') && !command.startsWith("'")) {
+      command = 'say ' + command;
     }
-    this.send(command + "\r\n");
-    console.log("> " + command);
+    this.send(command + '\r\n');
+    console.log('> ' + command);
   }
 
   /*
@@ -500,8 +456,8 @@ An MCP message consists of three parts: the name of the message, the authenticat
 
   private handleData(data: ArrayBuffer) {
     const decoded = this.decoder.decode(data).trimEnd();
-    for (const line of decoded.split("\n")) {
-      if (line && line.startsWith("#$#")) {
+    for (const line of decoded.split('\n')) {
+      if (line && line.startsWith('#$#')) {
         // MCP
         this.handleMcp(line);
       } else {
@@ -511,20 +467,16 @@ An MCP message consists of three parts: the name of the message, the authenticat
   }
 
   private handleMcp(decoded: string) {
-    if (decoded.startsWith("#$#*")) {
+    if (decoded.startsWith('#$#*')) {
       // multiline
       const continuation = parseMcpMultiline(decoded.trimEnd());
       if (continuation)
         if (continuation.name in this.mcpMultilines)
           this.mcpMultilines[continuation.name].handleMultiline(continuation);
-        else
-          console.warn(
-            "Received continuation for unknown multiline",
-            continuation
-          );
+        else console.warn('Received continuation for unknown multiline', continuation);
       return;
     }
-    if (decoded.startsWith("#$#:")) {
+    if (decoded.startsWith('#$#:')) {
       const closure = parseMcpMultiline(decoded.trimEnd());
       if (closure) {
         this.mcpMultilines[closure.name].closeMultiline(closure);
@@ -533,59 +485,54 @@ An MCP message consists of three parts: the name of the message, the authenticat
       return;
     }
     const mcpMessage = parseMcpMessage(decoded.trimEnd());
-    console.log("MCP Message:", mcpMessage);
+    console.log('MCP Message:', mcpMessage);
     if (
-      mcpMessage?.name.toLowerCase() === "mcp" &&
+      mcpMessage?.name.toLowerCase() === 'mcp' &&
       mcpMessage.authKey == null &&
       this.mcpAuthKey == null
     ) {
       // Authenticate
       this.mcpAuthKey = generateTag();
-      this.sendCommand(
-        `#$#mcp authentication-key: ${this.mcpAuthKey} version: 2.1 to: 2.1`
-      );
+      this.sendCommand(`#$#mcp authentication-key: ${this.mcpAuthKey} version: 2.1 to: 2.1`);
       this.mcp_negotiate.sendNegotiate();
-    } else if (mcpMessage?.name === "mcp-negotiate-end") {
+    } else if (mcpMessage?.name === 'mcp-negotiate-end') {
       // spec says to refuse additional negotiations after this, but it's not really needed
     } else if (mcpMessage?.authKey === this.mcpAuthKey) {
       let name = mcpMessage.name;
       do {
         if (name in this.mcpHandlers) {
           this.mcpHandlers[name].handle(mcpMessage);
-          if ("_data-tag" in mcpMessage.keyvals) {
-            console.log("new multiline " + mcpMessage.keyvals["_data-tag"]);
-            this.mcpMultilines[mcpMessage.keyvals["_data-tag"]] =
-              this.mcpHandlers[name];
+          if ('_data-tag' in mcpMessage.keyvals) {
+            console.log('new multiline ' + mcpMessage.keyvals['_data-tag']);
+            this.mcpMultilines[mcpMessage.keyvals['_data-tag']] = this.mcpHandlers[name];
           }
           return;
         }
-        name = name.substring(0, name.lastIndexOf("-"));
+        name = name.substring(0, name.lastIndexOf('-'));
       } while (name);
       console.log(`No handler for ${mcpMessage.name}`);
     } else {
-      console.log(
-        `Unexpected authkey "${mcpMessage?.authKey}", probably a spoofed message.`
-      );
+      console.log(`Unexpected authkey "${mcpMessage?.authKey}", probably a spoofed message.`);
     }
   }
 
   private handleGmcpData(gmcpPackage: string, gmcpMessage: string) {
     //split to packageName and message type. the message name is after the last period of the gmcp package. the package can hav emultiple dots.
-    const lastDot = gmcpPackage.lastIndexOf(".");
+    const lastDot = gmcpPackage.lastIndexOf('.');
     const packageName = gmcpPackage.substring(0, lastDot);
     const messageType = gmcpPackage.substring(lastDot + 1);
 
-    console.log("GMCP Message:", packageName, messageType, gmcpMessage);
+    console.log('GMCP Message:', packageName, messageType, gmcpMessage);
     const handler = this.gmcpHandlers[packageName];
     if (!handler) {
-      console.log("No handler for GMCP package:", packageName);
+      console.log('No handler for GMCP package:', packageName);
       return;
     }
     // Look for the handler using the exact messageType from the package string
-    const messageHandler = (handler as any)["handle" + messageType];
+    const messageHandler = (handler as any)['handle' + messageType];
 
     if (messageHandler) {
-      console.log("Calling handler for:", messageType, messageHandler); // Log original type
+      console.log('Calling handler for:', messageType, messageHandler); // Log original type
 
       let jsonStringToParse: string;
       // Check if gmcpMessage is a valid, non-empty string
@@ -593,7 +540,10 @@ An MCP message consists of three parts: the name of the message, the authenticat
         jsonStringToParse = gmcpMessage;
       } else {
         // Log a warning and default to an empty JSON object string
-        console.warn(`GMCP message data for ${packageName}.${messageType} is missing or empty. Defaulting to {}. Original data:`, gmcpMessage);
+        console.warn(
+          `GMCP message data for ${packageName}.${messageType} is missing or empty. Defaulting to {}. Original data:`,
+          gmcpMessage,
+        );
         jsonStringToParse = '{}';
       }
 
@@ -603,13 +553,13 @@ An MCP message consists of three parts: the name of the message, the authenticat
       } catch (e) {
         // Add specific error handling for JSON parsing failure
         console.error(`Error parsing GMCP JSON for ${packageName}.${messageType}:`, e);
-        console.error("Attempted to parse:", jsonStringToParse); // Log the string we tried to parse
+        console.error('Attempted to parse:', jsonStringToParse); // Log the string we tried to parse
         // Optionally, you could decide whether to still call the handler with null/undefined/default data
         // messageHandler.call(handler, {}); // Example: Call with empty object on parse failure
       }
     } else {
       // Use original messageType in the error message
-      console.log("No handler on package:", packageName, messageType);
+      console.log('No handler on package:', packageName, messageType);
     }
   }
 
@@ -621,17 +571,17 @@ An MCP message consists of three parts: the name of the message, the authenticat
     if (autoreadMode === AutoreadMode.Unfocused && !document.hasFocus()) {
       this.speak(dataString);
     }
-    this.emit("message", dataString);
+    this.emit('message', dataString);
   }
 
   sendGmcp(packageName: string, data?: any) {
-    console.log("Sending GMCP:", packageName, data);
+    console.log('Sending GMCP:', packageName, data);
     this.telnet.sendGmcp(packageName, data);
   }
 
   sendMcp(command: string, data?: any) {
-    if (typeof data === "object") {
-      let str = "";
+    if (typeof data === 'object') {
+      let str = '';
       for (const [key, value] of Object.entries(data)) {
         str += ` ${key}: ${value || '""'}`;
       }
@@ -651,11 +601,11 @@ An MCP message consists of three parts: the name of the message, the authenticat
 
   sendMCPMultiline(mcpMessage: string, keyvals: MCPKeyvals, lines: string[]) {
     const MLTag = generateTag();
-    keyvals["_data-tag"] = MLTag;
+    keyvals['_data-tag'] = MLTag;
 
     this.sendMcp(mcpMessage, keyvals);
     for (const line of lines) {
-      this.sendMcpMLLine(MLTag, "content", line);
+      this.sendMcpMLLine(MLTag, 'content', line);
     }
     this.closeMcpML(MLTag);
   }
@@ -664,8 +614,8 @@ An MCP message consists of three parts: the name of the message, the authenticat
     if (this.shutdownComplete) return;
     this.shutdownComplete = true;
 
-    window.removeEventListener("focus", this.handleWindowFocus);
-    window.removeEventListener("blur", this.handleWindowBlur);
+    window.removeEventListener('focus', this.handleWindowFocus);
+    window.removeEventListener('blur', this.handleWindowBlur);
     this.unsubscribePreferences?.();
     this.unsubscribePreferences = null;
 
@@ -682,33 +632,33 @@ An MCP message consists of three parts: the name of the message, the authenticat
   requestNotificationPermission() {
     // handle notifications
     // may not be available in all browsers
-    if (!("Notification" in window)) {
-      console.log("This browser does not support desktop notification");
+    if (!('Notification' in window)) {
+      console.log('This browser does not support desktop notification');
       return;
     }
-    if (Notification.permission === "default") {
+    if (Notification.permission === 'default') {
       Notification.requestPermission();
     }
   }
 
   sendNotification(title: string, body: string) {
-    if (!("Notification" in window)) {
-      console.log("This browser does not support desktop notification");
+    if (!('Notification' in window)) {
+      console.log('This browser does not support desktop notification');
       return;
     }
 
-    if (Notification.permission === "granted") {
+    if (Notification.permission === 'granted') {
       new Notification(title, { body });
     }
   }
 
   speak(text: string) {
-    if (!("speechSynthesis" in window)) {
-      console.log("This browser does not support speech synthesis");
+    if (!('speechSynthesis' in window)) {
+      console.log('This browser does not support speech synthesis');
       return;
     }
     const utterance = new SpeechSynthesisUtterance(stripAnsi(text));
-    utterance.lang = "en-US";
+    utterance.lang = 'en-US';
     const { rate, pitch, voice, volume } = preferencesStore.getState().speech;
     utterance.rate = rate;
     utterance.pitch = pitch;
@@ -726,13 +676,13 @@ An MCP message consists of three parts: the name of the message, the authenticat
   }
 
   stopAllSounds() {
-    this.requireGMCPPackage("Client.Media").stopAllSounds();
+    this.requireGMCPPackage('Client.Media').stopAllSounds();
   }
 
   updateBackgroundMuteState() {
     const prefs = preferencesStore.getState();
     const shouldMuteInBackground = prefs.sound.muteInBackground && !this.isWindowFocused;
-    
+
     // Apply mute state: global mute OR background mute
     this.cacophony.muted = this.globalMuted || shouldMuteInBackground;
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,31 +1,43 @@
-import { Buffer } from 'buffer';
-import { Cacophony } from 'cacophony';
-import { EventEmitter } from 'eventemitter3';
-import stripAnsi from 'strip-ansi';
-import { EditorManager } from './EditorManager';
-import FileTransferManager from './FileTransferManager.js';
-import { GMCPChar, GMCPClientFileTransfer } from './gmcp';
+import {
+  Stream,
+  TelnetCommand,
+  TelnetOption,
+  TelnetParser,
+  WebSocketStream,
+} from "./telnet";
+
+import { Buffer } from "buffer";
+import { EventEmitter } from "eventemitter3";
+import stripAnsi from "strip-ansi";
+import { EditorManager } from "./EditorManager";
+import { GMCPChar, GMCPClientFileTransfer } from "./gmcp";
+import type { GMCPPackage } from "./gmcp/package";
+import type {
+  GMCPHandlerMap,
+  KnownGMCPPackageMap,
+  KnownGMCPPackageName,
+} from "./gmcp/types";
+import {
+  MCPKeyvals,
+  MCPPackage,
+  McpAwnsGetSet,
+  McpNegotiate,
+  generateTag,
+  parseMcpMessage,
+  parseMcpMultiline,
+} from "./mcp";
+
+import { Cacophony } from "cacophony";
+import { AutoreadMode, preferencesStore } from "./PreferencesStore";
+import { WebRTCService } from "./WebRTCService";
+import FileTransferManager from "./FileTransferManager.js";
+import { GMCPMessageRoomInfo, RoomPlayer } from "./gmcp/Room"; // Import RoomPlayer
 import type {
   SpatialEmitter,
   SpatialEntity,
   SpatialListenerOrientation,
   SpatialVector,
-} from './gmcp/Client/Spatial';
-import type { GMCPPackage } from './gmcp/package';
-import type { GMCPMessageRoomInfo, RoomPlayer } from './gmcp/Room'; // Import RoomPlayer
-import type { GMCPHandlerMap, KnownGMCPPackageMap, KnownGMCPPackageName } from './gmcp/types';
-import {
-  generateTag,
-  type MCPKeyvals,
-  type MCPPackage,
-  McpAwnsGetSet,
-  McpNegotiate,
-  parseMcpMessage,
-  parseMcpMultiline,
-} from './mcp';
-import { AutoreadMode, preferencesStore } from './PreferencesStore';
-import { type Stream, TelnetCommand, TelnetOption, TelnetParser, WebSocketStream } from './telnet';
-import { WebRTCService } from './WebRTCService';
+} from "./gmcp/Client/Spatial";
 
 export interface WorldData {
   liveKitTokens: string[];
@@ -43,18 +55,18 @@ export interface WorldData {
 function resetMidiIntentionalDisconnectFlags(): void {
   if (!preferencesStore.getState().midi.enabled) return;
 
-  import('./MidiService')
+  import("./MidiService")
     .then(({ midiService }) => {
       midiService.resetIntentionalDisconnectFlags();
     })
     .catch((error) => {
-      console.error('Failed to reset MIDI disconnect flags:', error);
+      console.error("Failed to reset MIDI disconnect flags:", error);
     });
 }
 
 class MudClient extends EventEmitter {
   private ws!: WebSocket;
-  private decoder = new TextDecoder('utf8');
+  private decoder = new TextDecoder("utf8");
   private telnet!: TelnetParser;
   private _connected: boolean = false;
   private intentionalDisconnect: boolean = false;
@@ -68,7 +80,7 @@ class MudClient extends EventEmitter {
   private host: string;
   private port: number;
   private telnetNegotiation: boolean = false;
-  private telnetBuffer: string = '';
+  private telnetBuffer: string = "";
   public gmcpHandlers: GMCPHandlerMap = {};
   public mcpHandlers: { [key: string]: MCPPackage } = {};
   public mcpMultilines: { [key: string]: MCPPackage } = {};
@@ -78,14 +90,14 @@ class MudClient extends EventEmitter {
   public gmcp_char: GMCPChar;
   public gmcp_fileTransfer: GMCPClientFileTransfer;
   public worldData: WorldData = {
-    playerId: '',
-    playerName: '',
-    roomId: '',
+    playerId: "",
+    playerName: "",
+    roomId: "",
     liveKitTokens: [],
     roomPlayers: [], // Initialized as RoomPlayer[]
     spatialEntities: {},
     spatialEmitters: {},
-    listenerEntityId: '',
+    listenerEntityId: "",
     listenerPosition: null,
     listenerOrientation: { forward: null, up: null },
   };
@@ -132,10 +144,13 @@ class MudClient extends EventEmitter {
     this.cacophony.setGlobalVolume(preferencesStore.getState().sound.volume);
     this.editors = new EditorManager(this);
     this.webRTCService = new WebRTCService(this);
-    this.fileTransferManager = new FileTransferManager(this, this.gmcp_fileTransfer);
-
-    window.addEventListener('focus', this.handleWindowFocus);
-    window.addEventListener('blur', this.handleWindowBlur);
+    this.fileTransferManager = new FileTransferManager(
+      this,
+      this.gmcp_fileTransfer
+    );
+    
+    window.addEventListener("focus", this.handleWindowFocus);
+    window.addEventListener("blur", this.handleWindowBlur);
 
     this.unsubscribePreferences = preferencesStore.subscribe(() => {
       this.updateBackgroundMuteState();
@@ -151,9 +166,9 @@ class MudClient extends EventEmitter {
   }
 
   acceptTransfer(sender: string, hash: string): void {
-    this.fileTransferManager.acceptTransfer(sender, hash).catch((error) => {
-      console.error('[MudClient] Failed to accept transfer:', error);
-      this.onFileTransferError(hash, 'unknown', 'receive', error.message);
+    this.fileTransferManager.acceptTransfer(sender, hash).catch(error => {
+      console.error("[MudClient] Failed to accept transfer:", error);
+      this.onFileTransferError(hash, "unknown", "receive", error.message);
     });
   }
 
@@ -167,16 +182,16 @@ class MudClient extends EventEmitter {
     hash: string,
     filename: string,
     filesize: number,
-    offerSdp: string,
+    offerSdp: string
   ): void {
-    console.log('[MudClient] Emitting fileTransferOffer event:', {
+    console.log("[MudClient] Emitting fileTransferOffer event:", {
       sender,
       hash,
       filename,
       filesize,
       offerSdp,
     });
-    this.emit('fileTransferOffer', {
+    this.emit("fileTransferOffer", {
       sender,
       hash,
       filename,
@@ -185,47 +200,56 @@ class MudClient extends EventEmitter {
     });
   }
 
-  onFileTransferAccept(sender: string, hash: string, filename: string, answerSdp: string): void {
-    console.log('[MudClient] Emitting fileTransferAccepted event:', {
+  onFileTransferAccept(
+    sender: string,
+    hash: string,
+    filename: string,
+    answerSdp: string
+  ): void {
+    console.log("[MudClient] Emitting fileTransferAccepted event:", {
       sender,
       hash,
       filename,
       answerSdp,
     });
-    this.emit('fileTransferAccepted', { sender, hash, filename, answerSdp });
+    this.emit("fileTransferAccepted", { sender, hash, filename, answerSdp });
   }
 
   onFileTransferReject(sender: string, hash: string): void {
-    this.emit('fileTransferRejected', { sender, hash });
+    this.emit("fileTransferRejected", { sender, hash });
   }
 
   onFileTransferCancel(sender: string, hash: string): void {
-    this.emit('fileTransferCancelled', { sender, hash });
+    this.emit("fileTransferCancelled", { sender, hash });
   }
 
   onFileSendComplete(hash: string, filename: string): void {
-    this.emit('fileSendComplete', { hash, filename });
+    this.emit("fileSendComplete", { hash, filename });
   }
 
   onFileTransferError(
     hash: string,
     filename: string,
-    direction: 'send' | 'receive',
-    error: string,
+    direction: "send" | "receive",
+    error: string
   ): void {
-    this.emit('fileTransferError', { hash, filename, direction, error });
+    this.emit("fileTransferError", { hash, filename, direction, error });
   }
 
   onConnectionRecovered(data: {
     filename: string;
-    direction: 'send' | 'receive';
+    direction: "send" | "receive";
     hash: string;
   }): void {
-    this.emit('connectionRecovered', data);
+    this.emit("connectionRecovered", data);
   }
 
-  onRecoveryFailed(data: { filename: string; direction: 'send' | 'receive'; error: string }): void {
-    this.emit('recoveryFailed', data);
+  onRecoveryFailed(data: {
+    filename: string;
+    direction: "send" | "receive";
+    error: string;
+  }): void {
+    this.emit("recoveryFailed", data);
   }
 
   // GMCP methods for file transfer
@@ -234,24 +258,39 @@ class MudClient extends EventEmitter {
     filename: string,
     hash: string,
     filesize: number,
-    offerSdp: string,
+    offerSdp: string
   ): void {
-    this.gmcp_fileTransfer.sendOffer(recipient, filename, filesize, offerSdp, hash);
+    this.gmcp_fileTransfer.sendOffer(
+      recipient,
+      filename,
+      filesize,
+      offerSdp,
+      hash
+    );
   }
 
-  sendFileTransferAccept(sender: string, filename: string, hash: string, answerSdp: string): void {
+  sendFileTransferAccept(
+    sender: string,
+    filename: string,
+    hash: string,
+    answerSdp: string
+  ): void {
     this.gmcp_fileTransfer.sendAccept(sender, hash, filename, answerSdp);
   }
 
   registerGMCPPackage<P extends GMCPPackage>(p: new (_: MudClient) => P): P {
     const gmcpPackage = new p(this);
     this.gmcpHandlers[gmcpPackage.packageName] = gmcpPackage;
-    console.log('Registered GMCP Package:', gmcpPackage.packageName);
+    console.log("Registered GMCP Package:", gmcpPackage.packageName);
     return gmcpPackage;
   }
 
-  requireGMCPPackage<K extends KnownGMCPPackageName>(packageName: K): KnownGMCPPackageMap[K] {
-    const gmcpPackage = this.gmcpHandlers[packageName] as KnownGMCPPackageMap[K] | undefined;
+  requireGMCPPackage<K extends KnownGMCPPackageName>(
+    packageName: K
+  ): KnownGMCPPackageMap[K] {
+    const gmcpPackage = this.gmcpHandlers[packageName] as
+      | KnownGMCPPackageMap[K]
+      | undefined;
     if (!gmcpPackage) {
       throw new Error(`Required GMCP package is not registered: ${packageName}`);
     }
@@ -268,49 +307,53 @@ class MudClient extends EventEmitter {
     this.intentionalDisconnect = false;
     this.connectionCleanupComplete = false;
     this.ws = new window.WebSocket(`wss://${this.host}:${this.port}`);
-    this.ws.binaryType = 'arraybuffer';
+    this.ws.binaryType = "arraybuffer";
     this.telnet = new TelnetParser(new WebSocketStream(this.ws));
     this.ws.onopen = () => {
       this._connected = true;
-
+      
       // Reset MIDI intentional disconnect flags when successfully reconnecting to server
       resetMidiIntentionalDisconnectFlags();
-
-      this.emit('connect');
-      this.emit('connectionChange', true);
+      
+      this.emit("connect");
+      this.emit("connectionChange", true);
     };
 
-    this.telnet.on('data', (data: ArrayBuffer) => {
+    this.telnet.on("data", (data: ArrayBuffer) => {
       this.handleData(data);
     });
 
-    this.telnet.on('negotiation', (command, option) => {
+    this.telnet.on("negotiation", (command, option) => {
       // Negotiation that we support GMCP
       if (command === TelnetCommand.WILL && option === TelnetOption.GMCP) {
-        console.log('GMCP Negotiation');
+        console.log("GMCP Negotiation");
         this.telnet.sendNegotiation(TelnetCommand.DO, TelnetOption.GMCP);
-        this.requireGMCPPackage('Core').sendHello();
-        this.requireGMCPPackage('Core.Supports').sendSet();
-        this.requireGMCPPackage('Auth.Autologin').sendLogin();
+        this.requireGMCPPackage("Core").sendHello();
+        this.requireGMCPPackage("Core.Supports").sendSet();
+        this.requireGMCPPackage("Auth.Autologin").sendLogin();
         // Advertise MCMP effect support so the server only sends what we can render.
-        (
-          this.gmcpHandlers['Client.Media'] as { sendEffectsSupport?: () => void } | undefined
-        )?.sendEffectsSupport?.();
-      } else if (command === TelnetCommand.DO && option === TelnetOption.TERMINAL_TYPE) {
-        console.log('TTYPE Negotiation');
-        this.telnet.sendNegotiation(TelnetCommand.WILL, TelnetOption.TERMINAL_TYPE);
-        this.telnet.sendTerminalType('Mongoose Client');
-        this.telnet.sendTerminalType('ANSI');
-        this.telnet.sendTerminalType('PROXY');
+        this.requireGMCPPackage("Client.Media").sendEffectsSupport();
+      } else if (
+        command === TelnetCommand.DO &&
+        option === TelnetOption.TERMINAL_TYPE
+      ) {
+        console.log("TTYPE Negotiation");
+        this.telnet.sendNegotiation(
+          TelnetCommand.WILL,
+          TelnetOption.TERMINAL_TYPE
+        );
+        this.telnet.sendTerminalType("Mongoose Client");
+        this.telnet.sendTerminalType("ANSI");
+        this.telnet.sendTerminalType("PROXY");
       }
     });
 
-    this.telnet.on('gmcp', (packageName, data) => {
-      console.log('GMCP Package:', packageName, data);
+    this.telnet.on("gmcp", (packageName, data) => {
+      console.log("GMCP Package:", packageName, data);
       try {
         this.handleGmcpData(packageName, data);
       } catch (e) {
-        console.error('Calling GMCP:', e);
+        console.error("Calling GMCP:", e);
       }
     });
 
@@ -325,7 +368,7 @@ class MudClient extends EventEmitter {
     };
 
     this.ws.onerror = (error: Event) => {
-      this.emit('error', error);
+      this.emit("error", error);
     };
   }
 
@@ -341,43 +384,47 @@ class MudClient extends EventEmitter {
     this.connectionCleanupComplete = false;
     this.telnet = new TelnetParser(stream);
 
-    this.telnet.on('data', (data: ArrayBuffer) => {
+    this.telnet.on("data", (data: ArrayBuffer) => {
       this.handleData(data);
     });
 
     // The WASM server does not send telnet negotiation (no IAC sequences),
     // so these handlers are unlikely to fire — but wire them up anyway
     // for correctness.
-    this.telnet.on('negotiation', (command, option) => {
+    this.telnet.on("negotiation", (command, option) => {
       if (command === TelnetCommand.WILL && option === TelnetOption.GMCP) {
-        console.log('GMCP Negotiation (local)');
+        console.log("GMCP Negotiation (local)");
         this.telnet.sendNegotiation(TelnetCommand.DO, TelnetOption.GMCP);
-        this.requireGMCPPackage('Core').sendHello();
-        this.requireGMCPPackage('Core.Supports').sendSet();
-        this.requireGMCPPackage('Auth.Autologin').sendLogin();
+        this.requireGMCPPackage("Core").sendHello();
+        this.requireGMCPPackage("Core.Supports").sendSet();
+        this.requireGMCPPackage("Auth.Autologin").sendLogin();
         // Advertise MCMP effect support so the server only sends what we can render.
-        (
-          this.gmcpHandlers['Client.Media'] as { sendEffectsSupport?: () => void } | undefined
-        )?.sendEffectsSupport?.();
-      } else if (command === TelnetCommand.DO && option === TelnetOption.TERMINAL_TYPE) {
-        console.log('TTYPE Negotiation (local)');
-        this.telnet.sendNegotiation(TelnetCommand.WILL, TelnetOption.TERMINAL_TYPE);
-        this.telnet.sendTerminalType('Mongoose Client');
-        this.telnet.sendTerminalType('ANSI');
-        this.telnet.sendTerminalType('PROXY');
+        this.requireGMCPPackage("Client.Media").sendEffectsSupport();
+      } else if (
+        command === TelnetCommand.DO &&
+        option === TelnetOption.TERMINAL_TYPE
+      ) {
+        console.log("TTYPE Negotiation (local)");
+        this.telnet.sendNegotiation(
+          TelnetCommand.WILL,
+          TelnetOption.TERMINAL_TYPE
+        );
+        this.telnet.sendTerminalType("Mongoose Client");
+        this.telnet.sendTerminalType("ANSI");
+        this.telnet.sendTerminalType("PROXY");
       }
     });
 
-    this.telnet.on('gmcp', (packageName, data) => {
-      console.log('GMCP Package (local):', packageName, data);
+    this.telnet.on("gmcp", (packageName, data) => {
+      console.log("GMCP Package (local):", packageName, data);
       try {
         this.handleGmcpData(packageName, data);
       } catch (e) {
-        console.error('Calling GMCP:', e);
+        console.error("Calling GMCP:", e);
       }
     });
 
-    stream.on('close', () => {
+    stream.on("close", () => {
       this.cleanupConnection();
     });
 
@@ -385,8 +432,8 @@ class MudClient extends EventEmitter {
     // message once the virtual connection is created.
     this._connected = true;
     resetMidiIntentionalDisconnectFlags();
-    this.emit('connect');
-    this.emit('connectionChange', true);
+    this.emit("connect");
+    this.emit("connectionChange", true);
   }
 
   public send(data: string) {
@@ -403,26 +450,27 @@ class MudClient extends EventEmitter {
     this.connectionCleanupComplete = true;
     this._connected = false;
     this.mcpAuthKey = null;
-    this.telnetBuffer = '';
+    this.telnetBuffer = "";
     this.telnetNegotiation = false;
     this.currentRoomInfo = null; // Reset room info on cleanup
     this.worldData.spatialEntities = {};
     this.worldData.spatialEmitters = {};
-    this.worldData.listenerEntityId = '';
+    this.worldData.listenerEntityId = "";
     this.worldData.listenerPosition = null;
     this.worldData.listenerOrientation = { forward: null, up: null };
     this.webRTCService.cleanup();
     this.fileTransferManager.cleanup();
-
-    this.emit('disconnect');
-    this.emit('connectionChange', false);
+    
+    this.emit("disconnect");
+    this.emit("connectionChange", false);
   }
 
   public close(): void {
     this.intentionalDisconnect = true;
     if (
       this.ws &&
-      (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)
+      (this.ws.readyState === WebSocket.CONNECTING ||
+        this.ws.readyState === WebSocket.OPEN)
     ) {
       this.ws.close();
     }
@@ -437,13 +485,13 @@ class MudClient extends EventEmitter {
   public sendCommand(command: string): void {
     const localEchoEnabled = preferencesStore.getState().general.localEcho;
     if (localEchoEnabled) {
-      this.emit('command', command);
+      this.emit("command", command);
     }
-    if (this.autosay && !command.startsWith('-') && !command.startsWith("'")) {
-      command = 'say ' + command;
+    if (this.autosay && !command.startsWith("-") && !command.startsWith("'")) {
+      command = "say " + command;
     }
-    this.send(command + '\r\n');
-    console.log('> ' + command);
+    this.send(command + "\r\n");
+    console.log("> " + command);
   }
 
   /*
@@ -456,8 +504,8 @@ An MCP message consists of three parts: the name of the message, the authenticat
 
   private handleData(data: ArrayBuffer) {
     const decoded = this.decoder.decode(data).trimEnd();
-    for (const line of decoded.split('\n')) {
-      if (line && line.startsWith('#$#')) {
+    for (const line of decoded.split("\n")) {
+      if (line && line.startsWith("#$#")) {
         // MCP
         this.handleMcp(line);
       } else {
@@ -467,16 +515,20 @@ An MCP message consists of three parts: the name of the message, the authenticat
   }
 
   private handleMcp(decoded: string) {
-    if (decoded.startsWith('#$#*')) {
+    if (decoded.startsWith("#$#*")) {
       // multiline
       const continuation = parseMcpMultiline(decoded.trimEnd());
       if (continuation)
         if (continuation.name in this.mcpMultilines)
           this.mcpMultilines[continuation.name].handleMultiline(continuation);
-        else console.warn('Received continuation for unknown multiline', continuation);
+        else
+          console.warn(
+            "Received continuation for unknown multiline",
+            continuation
+          );
       return;
     }
-    if (decoded.startsWith('#$#:')) {
+    if (decoded.startsWith("#$#:")) {
       const closure = parseMcpMultiline(decoded.trimEnd());
       if (closure) {
         this.mcpMultilines[closure.name].closeMultiline(closure);
@@ -485,54 +537,59 @@ An MCP message consists of three parts: the name of the message, the authenticat
       return;
     }
     const mcpMessage = parseMcpMessage(decoded.trimEnd());
-    console.log('MCP Message:', mcpMessage);
+    console.log("MCP Message:", mcpMessage);
     if (
-      mcpMessage?.name.toLowerCase() === 'mcp' &&
+      mcpMessage?.name.toLowerCase() === "mcp" &&
       mcpMessage.authKey == null &&
       this.mcpAuthKey == null
     ) {
       // Authenticate
       this.mcpAuthKey = generateTag();
-      this.sendCommand(`#$#mcp authentication-key: ${this.mcpAuthKey} version: 2.1 to: 2.1`);
+      this.sendCommand(
+        `#$#mcp authentication-key: ${this.mcpAuthKey} version: 2.1 to: 2.1`
+      );
       this.mcp_negotiate.sendNegotiate();
-    } else if (mcpMessage?.name === 'mcp-negotiate-end') {
+    } else if (mcpMessage?.name === "mcp-negotiate-end") {
       // spec says to refuse additional negotiations after this, but it's not really needed
     } else if (mcpMessage?.authKey === this.mcpAuthKey) {
       let name = mcpMessage.name;
       do {
         if (name in this.mcpHandlers) {
           this.mcpHandlers[name].handle(mcpMessage);
-          if ('_data-tag' in mcpMessage.keyvals) {
-            console.log('new multiline ' + mcpMessage.keyvals['_data-tag']);
-            this.mcpMultilines[mcpMessage.keyvals['_data-tag']] = this.mcpHandlers[name];
+          if ("_data-tag" in mcpMessage.keyvals) {
+            console.log("new multiline " + mcpMessage.keyvals["_data-tag"]);
+            this.mcpMultilines[mcpMessage.keyvals["_data-tag"]] =
+              this.mcpHandlers[name];
           }
           return;
         }
-        name = name.substring(0, name.lastIndexOf('-'));
+        name = name.substring(0, name.lastIndexOf("-"));
       } while (name);
       console.log(`No handler for ${mcpMessage.name}`);
     } else {
-      console.log(`Unexpected authkey "${mcpMessage?.authKey}", probably a spoofed message.`);
+      console.log(
+        `Unexpected authkey "${mcpMessage?.authKey}", probably a spoofed message.`
+      );
     }
   }
 
   private handleGmcpData(gmcpPackage: string, gmcpMessage: string) {
     //split to packageName and message type. the message name is after the last period of the gmcp package. the package can hav emultiple dots.
-    const lastDot = gmcpPackage.lastIndexOf('.');
+    const lastDot = gmcpPackage.lastIndexOf(".");
     const packageName = gmcpPackage.substring(0, lastDot);
     const messageType = gmcpPackage.substring(lastDot + 1);
 
-    console.log('GMCP Message:', packageName, messageType, gmcpMessage);
+    console.log("GMCP Message:", packageName, messageType, gmcpMessage);
     const handler = this.gmcpHandlers[packageName];
     if (!handler) {
-      console.log('No handler for GMCP package:', packageName);
+      console.log("No handler for GMCP package:", packageName);
       return;
     }
     // Look for the handler using the exact messageType from the package string
-    const messageHandler = (handler as any)['handle' + messageType];
+    const messageHandler = (handler as any)["handle" + messageType];
 
     if (messageHandler) {
-      console.log('Calling handler for:', messageType, messageHandler); // Log original type
+      console.log("Calling handler for:", messageType, messageHandler); // Log original type
 
       let jsonStringToParse: string;
       // Check if gmcpMessage is a valid, non-empty string
@@ -540,10 +597,7 @@ An MCP message consists of three parts: the name of the message, the authenticat
         jsonStringToParse = gmcpMessage;
       } else {
         // Log a warning and default to an empty JSON object string
-        console.warn(
-          `GMCP message data for ${packageName}.${messageType} is missing or empty. Defaulting to {}. Original data:`,
-          gmcpMessage,
-        );
+        console.warn(`GMCP message data for ${packageName}.${messageType} is missing or empty. Defaulting to {}. Original data:`, gmcpMessage);
         jsonStringToParse = '{}';
       }
 
@@ -553,13 +607,13 @@ An MCP message consists of three parts: the name of the message, the authenticat
       } catch (e) {
         // Add specific error handling for JSON parsing failure
         console.error(`Error parsing GMCP JSON for ${packageName}.${messageType}:`, e);
-        console.error('Attempted to parse:', jsonStringToParse); // Log the string we tried to parse
+        console.error("Attempted to parse:", jsonStringToParse); // Log the string we tried to parse
         // Optionally, you could decide whether to still call the handler with null/undefined/default data
         // messageHandler.call(handler, {}); // Example: Call with empty object on parse failure
       }
     } else {
       // Use original messageType in the error message
-      console.log('No handler on package:', packageName, messageType);
+      console.log("No handler on package:", packageName, messageType);
     }
   }
 
@@ -571,17 +625,17 @@ An MCP message consists of three parts: the name of the message, the authenticat
     if (autoreadMode === AutoreadMode.Unfocused && !document.hasFocus()) {
       this.speak(dataString);
     }
-    this.emit('message', dataString);
+    this.emit("message", dataString);
   }
 
   sendGmcp(packageName: string, data?: any) {
-    console.log('Sending GMCP:', packageName, data);
+    console.log("Sending GMCP:", packageName, data);
     this.telnet.sendGmcp(packageName, data);
   }
 
   sendMcp(command: string, data?: any) {
-    if (typeof data === 'object') {
-      let str = '';
+    if (typeof data === "object") {
+      let str = "";
       for (const [key, value] of Object.entries(data)) {
         str += ` ${key}: ${value || '""'}`;
       }
@@ -601,11 +655,11 @@ An MCP message consists of three parts: the name of the message, the authenticat
 
   sendMCPMultiline(mcpMessage: string, keyvals: MCPKeyvals, lines: string[]) {
     const MLTag = generateTag();
-    keyvals['_data-tag'] = MLTag;
+    keyvals["_data-tag"] = MLTag;
 
     this.sendMcp(mcpMessage, keyvals);
     for (const line of lines) {
-      this.sendMcpMLLine(MLTag, 'content', line);
+      this.sendMcpMLLine(MLTag, "content", line);
     }
     this.closeMcpML(MLTag);
   }
@@ -614,8 +668,8 @@ An MCP message consists of three parts: the name of the message, the authenticat
     if (this.shutdownComplete) return;
     this.shutdownComplete = true;
 
-    window.removeEventListener('focus', this.handleWindowFocus);
-    window.removeEventListener('blur', this.handleWindowBlur);
+    window.removeEventListener("focus", this.handleWindowFocus);
+    window.removeEventListener("blur", this.handleWindowBlur);
     this.unsubscribePreferences?.();
     this.unsubscribePreferences = null;
 
@@ -632,33 +686,33 @@ An MCP message consists of three parts: the name of the message, the authenticat
   requestNotificationPermission() {
     // handle notifications
     // may not be available in all browsers
-    if (!('Notification' in window)) {
-      console.log('This browser does not support desktop notification');
+    if (!("Notification" in window)) {
+      console.log("This browser does not support desktop notification");
       return;
     }
-    if (Notification.permission === 'default') {
+    if (Notification.permission === "default") {
       Notification.requestPermission();
     }
   }
 
   sendNotification(title: string, body: string) {
-    if (!('Notification' in window)) {
-      console.log('This browser does not support desktop notification');
+    if (!("Notification" in window)) {
+      console.log("This browser does not support desktop notification");
       return;
     }
 
-    if (Notification.permission === 'granted') {
+    if (Notification.permission === "granted") {
       new Notification(title, { body });
     }
   }
 
   speak(text: string) {
-    if (!('speechSynthesis' in window)) {
-      console.log('This browser does not support speech synthesis');
+    if (!("speechSynthesis" in window)) {
+      console.log("This browser does not support speech synthesis");
       return;
     }
     const utterance = new SpeechSynthesisUtterance(stripAnsi(text));
-    utterance.lang = 'en-US';
+    utterance.lang = "en-US";
     const { rate, pitch, voice, volume } = preferencesStore.getState().speech;
     utterance.rate = rate;
     utterance.pitch = pitch;
@@ -676,13 +730,13 @@ An MCP message consists of three parts: the name of the message, the authenticat
   }
 
   stopAllSounds() {
-    this.requireGMCPPackage('Client.Media').stopAllSounds();
+    this.requireGMCPPackage("Client.Media").stopAllSounds();
   }
 
   updateBackgroundMuteState() {
     const prefs = preferencesStore.getState();
     const shouldMuteInBackground = prefs.sound.muteInBackground && !this.isWindowFocused;
-
+    
     // Apply mute state: global mute OR background mute
     this.cacophony.muted = this.globalMuted || shouldMuteInBackground;
   }

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -36,6 +36,7 @@ type MockSound = {
   playbacks: MockPlayback[];
   position: number[];
   priority?: number;
+  routeTo: ReturnType<typeof vi.fn>;
   seek: ReturnType<typeof vi.fn>;
   stereoPan: number;
   tag?: string;
@@ -73,6 +74,7 @@ function createMockSound(url: string): MockSound {
     playbacks: [playback],
     position: [0, 0, 0],
     priority: undefined,
+    routeTo: vi.fn(),
     seek: vi.fn(),
     stereoPan: 0,
     tag: undefined,
@@ -175,6 +177,69 @@ describe("GMCPClientMedia", () => {
       "html",
       "stereo",
     );
+  });
+
+  describe("effect chain routing", () => {
+    it("routes a played sound through a named chain", async () => {
+      const sound = createMockSound("https://media.example/spell.ogg");
+      mockCreateSound.mockResolvedValue(sound);
+      await handler.handlePlay({
+        name: "spell.ogg",
+        type: "sound",
+        volume: 50,
+        chain: "cave",
+      } as unknown as GMCPMessageClientMediaPlay);
+      expect(sound.routeTo).toHaveBeenCalledWith("cave");
+    });
+
+    it("uses an aux send when `send` is provided (sound stays dry on master)", async () => {
+      const sound = createMockSound("https://media.example/spell.ogg");
+      mockCreateSound.mockResolvedValue(sound);
+      await handler.handlePlay({
+        name: "spell.ogg",
+        type: "sound",
+        volume: 50,
+        chain: "cave",
+        send: 0.3,
+      } as unknown as GMCPMessageClientMediaPlay);
+      expect(sound.routeTo).toHaveBeenCalledWith("cave", 0.3);
+    });
+
+    it("does not route ambisonic sounds through a chain (out of scope for P0)", async () => {
+      const sound = createMockSound("https://media.example/amb.ogg");
+      mockCreateSound.mockResolvedValue(sound);
+      await handler.handlePlay({
+        name: "amb.ogg",
+        type: "sound",
+        volume: 50,
+        chain: "cave",
+        upmix: "ambisonic",
+      } as unknown as GMCPMessageClientMediaPlay);
+      expect(sound.routeTo).not.toHaveBeenCalled();
+    });
+
+    it("plays dry (and never crashes) when the chain is unavailable", async () => {
+      const sound = createMockSound("https://media.example/spell.ogg");
+      sound.routeTo.mockImplementation(() => {
+        throw new Error("No bus registered with name 'ghost'");
+      });
+      mockCreateSound.mockResolvedValue(sound);
+      await handler.handlePlay({
+        name: "spell.ogg",
+        type: "sound",
+        volume: 50,
+        chain: "ghost",
+      } as unknown as GMCPMessageClientMediaPlay);
+      expect(sound.play).toHaveBeenCalledOnce(); // the sound still played
+    });
+
+    it("advertises EffectsSupport to the server", () => {
+      handler.sendEffectsSupport();
+      expect(client.sendGmcp).toHaveBeenCalledWith(
+        "Client.Media.EffectsSupport",
+        expect.stringContaining("reverb"),
+      );
+    });
   });
 
   it("stores tag and type so stop-by-tag and stop-by-type work", async () => {

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -341,6 +341,33 @@ describe('GMCPClientMedia', () => {
       handler.handleAutomate({ key: 'k1', target: 'env', bypass: true } as never);
       expect(anonBus.setFilterBypassed).toHaveBeenCalledWith(expect.anything(), true);
     });
+
+    it("routes an ambisonic sound's binaural output through its inline effect bus (V11)", async () => {
+      const renderer = {
+        attachPlayback: vi.fn(),
+        cleanup: vi.fn(),
+        setRotationMatrixFromYaw: vi.fn(),
+      };
+      mockAmbisonicRendererCreate.mockResolvedValue(renderer);
+      const sound = createMockSound('https://media.example/amb.ogg');
+      mockCreateSound.mockResolvedValue(sound);
+      await handler.handlePlay({
+        name: 'amb.ogg',
+        type: 'sound',
+        volume: 50,
+        key: 'amb',
+        upmix: 'ambisonic',
+        channels: 4,
+        effects: [{ type: 'reverb' }],
+      } as unknown as GMCPMessageClientMediaPlay);
+
+      const anonBus = client.effectBuses.anon[0];
+      expect(anonBus).toBeDefined();
+      // The renderer's binaural output is targeted at the inline bus input, NOT master.
+      expect(renderer.attachPlayback).toHaveBeenCalledWith(expect.anything(), anonBus.input);
+      // An ambisonic sound's playback is not routeTo'd (it feeds the FOA decoder).
+      expect(sound.routeTo).not.toHaveBeenCalled();
+    });
   });
 
   it('stores tag and type so stop-by-tag and stop-by-type work', async () => {
@@ -488,7 +515,7 @@ describe('GMCPClientMedia', () => {
 
     const renderer = await mockAmbisonicRendererCreate.mock.results[0].value;
     expect(mockAmbisonicRendererCreate).toHaveBeenCalledWith(client.cacophony, 2);
-    expect(renderer.attachPlayback).toHaveBeenCalledWith(sound.playbacks[0]);
+    expect(renderer.attachPlayback).toHaveBeenCalledWith(sound.playbacks[0], undefined);
     expect(renderer.setRotationMatrixFromYaw).toHaveBeenCalledWith(0);
 
     handler.handleListenerOrientation({
@@ -516,7 +543,7 @@ describe('GMCPClientMedia', () => {
 
     const renderer = await mockAmbisonicRendererCreate.mock.results[0].value;
     expect(mockAmbisonicRendererCreate).toHaveBeenCalledWith(client.cacophony, 4);
-    expect(renderer.attachPlayback).toHaveBeenCalledWith(sound.playbacks[0]);
+    expect(renderer.attachPlayback).toHaveBeenCalledWith(sound.playbacks[0], undefined);
     expect(sound.inputChannels).toBe(4);
   });
 

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -1,11 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockAmbisonicRendererCreate, mockCreateSound } = vi.hoisted(() => ({
   mockAmbisonicRendererCreate: vi.fn(),
   mockCreateSound: vi.fn(),
 }));
 
-vi.mock("../../audio/AmbisonicRenderer", () => ({
+vi.mock('../../audio/AmbisonicRenderer', () => ({
   AmbisonicRenderer: {
     create: mockAmbisonicRendererCreate,
   },
@@ -13,10 +13,10 @@ vi.mock("../../audio/AmbisonicRenderer", () => ({
 
 import {
   GMCPClientMedia,
-  GMCPMessageClientMediaPlay,
-  GMCPMessageClientMediaStop,
-  GMCPMessageClientMediaUpdate,
-} from "./Media";
+  type GMCPMessageClientMediaPlay,
+  type GMCPMessageClientMediaStop,
+  type GMCPMessageClientMediaUpdate,
+} from './Media';
 
 type MockPlayback = {
   connect: ReturnType<typeof vi.fn>;
@@ -91,14 +91,63 @@ function createMockSound(url: string): MockSound {
   return sound;
 }
 
+function makeEffectBus(name: string | null) {
+  return {
+    name,
+    input: { __input: name },
+    output: { gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() } },
+    addFilter: vi.fn(async (arg: unknown) => arg),
+    removeFilter: vi.fn(),
+    destroy: vi.fn(),
+    drainTo: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    rampFilterParam: vi.fn(),
+    setFilterBypassed: vi.fn(),
+    destroyed: false,
+    gain: 1,
+  };
+}
+
 function createMockClient() {
   const listeners = new Map<string, Set<(data: unknown) => void>>();
+  const master = makeEffectBus('master');
+  const created: Record<string, ReturnType<typeof makeEffectBus>> = {};
+  const anon: Array<ReturnType<typeof makeEffectBus>> = [];
+  const effectFactory = () => vi.fn((opts: unknown) => ({ __effect: opts }));
   return {
+    effectBuses: { master, created, anon },
     cacophony: {
       context: {
         currentTime: 100,
+        sampleRate: 48000,
       },
       createSound: mockCreateSound,
+      createBus: vi.fn((name?: string) => {
+        const bus = makeEffectBus(name ?? null);
+        if (name) {
+          created[name] = bus;
+        } else {
+          anon.push(bus);
+        }
+        return bus;
+      }),
+      getBus: vi.fn((name: string) => (name === 'master' ? master : created[name])),
+      createFdnReverb: effectFactory(),
+      createReverb: effectFactory(),
+      createDelay: effectFactory(),
+      createChorus: effectFactory(),
+      createFlanger: effectFactory(),
+      createVibrato: effectFactory(),
+      createDoubling: effectFactory(),
+      createPhaser: effectFactory(),
+      createTremolo: effectFactory(),
+      createAutoPan: effectFactory(),
+      createDistortion: effectFactory(),
+      createCompressor: effectFactory(),
+      createLimiter: effectFactory(),
+      createGate: effectFactory(),
+      createBiquadFilter: vi.fn((opts: unknown) => ({ __biquad: opts })),
       listenerForwardOrientation: [0, 0, -1],
       listenerUpOrientation: [0, 1, 0],
       listenerPosition: [0, 0, 0],
@@ -122,7 +171,7 @@ function createMockClient() {
   };
 }
 
-describe("GMCPClientMedia", () => {
+describe('GMCPClientMedia', () => {
   let handler: GMCPClientMedia;
   let client: ReturnType<typeof createMockClient>;
 
@@ -141,143 +190,195 @@ describe("GMCPClientMedia", () => {
     vi.useRealTimers();
   });
 
-  it("uses the resolved URL as the load and play key when data.url is missing", async () => {
-    handler.handleDefault("https://media.example/");
-    const sound = createMockSound("https://media.example/chime.ogg");
+  it('uses the resolved URL as the load and play key when data.url is missing', async () => {
+    handler.handleDefault('https://media.example/');
+    const sound = createMockSound('https://media.example/chime.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handleLoad({
-      name: "chime.ogg",
+      name: 'chime.ogg',
     });
 
-    expect(handler.sounds["https://media.example/chime.ogg"]).toBe(sound);
+    expect(handler.sounds['https://media.example/chime.ogg']).toBe(sound);
 
     await handler.handlePlay({
-      name: "chime.ogg",
-      type: "sound",
+      name: 'chime.ogg',
+      type: 'sound',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
     expect(mockCreateSound).toHaveBeenCalledTimes(1);
     expect(sound.play).toHaveBeenCalledOnce();
-    expect(handler.sounds["https://media.example/chime.ogg"]).toBe(sound);
+    expect(handler.sounds['https://media.example/chime.ogg']).toBe(sound);
   });
 
-  it("passes string sound types to Cacophony", async () => {
-    mockCreateSound.mockResolvedValue(createMockSound("https://media.example/theme.ogg"));
+  it('passes string sound types to Cacophony', async () => {
+    mockCreateSound.mockResolvedValue(createMockSound('https://media.example/theme.ogg'));
 
     await handler.handlePlay({
-      name: "theme.ogg",
-      type: "music",
+      name: 'theme.ogg',
+      type: 'music',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
     expect(mockCreateSound).toHaveBeenCalledWith(
-      "https://mongoose.world:9080/?url=theme.ogg",
-      "html",
-      "stereo",
+      'https://mongoose.world:9080/?url=theme.ogg',
+      'html',
+      'stereo',
     );
   });
 
-  describe("effect chain routing", () => {
-    it("routes a played sound through a named chain", async () => {
-      const sound = createMockSound("https://media.example/spell.ogg");
+  describe('effect chain routing', () => {
+    it('routes a played sound through a named chain', async () => {
+      const sound = createMockSound('https://media.example/spell.ogg');
       mockCreateSound.mockResolvedValue(sound);
       await handler.handlePlay({
-        name: "spell.ogg",
-        type: "sound",
+        name: 'spell.ogg',
+        type: 'sound',
         volume: 50,
-        chain: "cave",
+        chain: 'cave',
       } as unknown as GMCPMessageClientMediaPlay);
-      expect(sound.routeTo).toHaveBeenCalledWith("cave");
+      expect(sound.routeTo).toHaveBeenCalledWith('cave');
     });
 
-    it("uses an aux send when `send` is provided (sound stays dry on master)", async () => {
-      const sound = createMockSound("https://media.example/spell.ogg");
+    it('uses an aux send when `send` is provided (sound stays dry on master)', async () => {
+      const sound = createMockSound('https://media.example/spell.ogg');
       mockCreateSound.mockResolvedValue(sound);
       await handler.handlePlay({
-        name: "spell.ogg",
-        type: "sound",
+        name: 'spell.ogg',
+        type: 'sound',
         volume: 50,
-        chain: "cave",
+        chain: 'cave',
         send: 0.3,
       } as unknown as GMCPMessageClientMediaPlay);
-      expect(sound.routeTo).toHaveBeenCalledWith("cave", 0.3);
+      expect(sound.routeTo).toHaveBeenCalledWith('cave', 0.3);
     });
 
-    it("does not route ambisonic sounds through a chain (out of scope for P0)", async () => {
-      const sound = createMockSound("https://media.example/amb.ogg");
+    it('does not route ambisonic sounds through a chain (out of scope for P0)', async () => {
+      const sound = createMockSound('https://media.example/amb.ogg');
       mockCreateSound.mockResolvedValue(sound);
       await handler.handlePlay({
-        name: "amb.ogg",
-        type: "sound",
+        name: 'amb.ogg',
+        type: 'sound',
         volume: 50,
-        chain: "cave",
-        upmix: "ambisonic",
+        chain: 'cave',
+        upmix: 'ambisonic',
       } as unknown as GMCPMessageClientMediaPlay);
       expect(sound.routeTo).not.toHaveBeenCalled();
     });
 
-    it("plays dry (and never crashes) when the chain is unavailable", async () => {
-      const sound = createMockSound("https://media.example/spell.ogg");
+    it('plays dry (and never crashes) when the chain is unavailable', async () => {
+      const sound = createMockSound('https://media.example/spell.ogg');
       sound.routeTo.mockImplementation(() => {
         throw new Error("No bus registered with name 'ghost'");
       });
       mockCreateSound.mockResolvedValue(sound);
       await handler.handlePlay({
-        name: "spell.ogg",
-        type: "sound",
+        name: 'spell.ogg',
+        type: 'sound',
         volume: 50,
-        chain: "ghost",
+        chain: 'ghost',
       } as unknown as GMCPMessageClientMediaPlay);
       expect(sound.play).toHaveBeenCalledOnce(); // the sound still played
     });
 
-    it("advertises EffectsSupport to the server", () => {
+    it('advertises EffectsSupport to the server', () => {
       handler.sendEffectsSupport();
       expect(client.sendGmcp).toHaveBeenCalledWith(
-        "Client.Media.EffectsSupport",
-        expect.stringContaining("reverb"),
+        'Client.Media.EffectsSupport',
+        expect.stringContaining('reverb'),
       );
     });
   });
 
-  it("stores tag and type so stop-by-tag and stop-by-type work", async () => {
-    const sound = createMockSound("https://media.example/ambience/rain.ogg");
+  describe('inline effects and automation', () => {
+    async function playWithInline(key: string, effects: unknown[]) {
+      const sound = createMockSound(`https://media.example/${key}.ogg`);
+      mockCreateSound.mockResolvedValue(sound);
+      await handler.handlePlay({
+        name: `${key}.ogg`,
+        type: 'sound',
+        volume: 50,
+        key,
+        effects,
+      } as unknown as GMCPMessageClientMediaPlay);
+      return sound;
+    }
+
+    it('builds an inline chain and routes the sound through its anonymous bus', async () => {
+      const sound = await playWithInline('k1', [{ type: 'reverb' }]);
+      const anonBus = client.effectBuses.anon[0];
+      expect(anonBus).toBeDefined();
+      expect(anonBus.addFilter).toHaveBeenCalledTimes(1);
+      expect(sound.routeTo).toHaveBeenCalledWith(anonBus);
+    });
+
+    it('tears down inline effect buses on stop-all (single release funnel, V4)', async () => {
+      await playWithInline('k1', [{ type: 'reverb' }]);
+      const anonBus = client.effectBuses.anon[0];
+      handler.handleStop({} as GMCPMessageClientMediaStop);
+      expect(anonBus.destroy).toHaveBeenCalled();
+    });
+
+    it('automates an inline effect addressed by media key', async () => {
+      await playWithInline('k1', [{ type: 'reverb', id: 'env' }]);
+      const anonBus = client.effectBuses.anon[0];
+      handler.handleAutomate({
+        key: 'k1',
+        target: 'env',
+        params: { mix: 0.8 },
+        ramp: 1000,
+      } as never);
+      expect(anonBus.rampFilterParam).toHaveBeenCalledWith(expect.anything(), 'mix', 0.8, {
+        duration: 1000,
+        type: 'linear',
+      });
+    });
+
+    it('toggles inline effect bypass addressed by media key', async () => {
+      await playWithInline('k1', [{ type: 'reverb', id: 'env' }]);
+      const anonBus = client.effectBuses.anon[0];
+      handler.handleAutomate({ key: 'k1', target: 'env', bypass: true } as never);
+      expect(anonBus.setFilterBypassed).toHaveBeenCalledWith(expect.anything(), true);
+    });
+  });
+
+  it('stores tag and type so stop-by-tag and stop-by-type work', async () => {
+    const sound = createMockSound('https://media.example/ambience/rain.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
-      key: "rain-loop",
-      name: "ambience/rain.ogg",
-      tag: "weather",
-      type: "music",
+      key: 'rain-loop',
+      name: 'ambience/rain.ogg',
+      tag: 'weather',
+      type: 'music',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
-    expect(sound.tag).toBe("weather");
-    expect(sound.mediaType).toBe("music");
+    expect(sound.tag).toBe('weather');
+    expect(sound.mediaType).toBe('music');
 
-    handler.handleStop({ tag: "weather" } as GMCPMessageClientMediaStop);
+    handler.handleStop({ tag: 'weather' } as GMCPMessageClientMediaStop);
     expect(sound.cleanup).toHaveBeenCalledOnce();
     expect(handler.sounds).toEqual({});
   });
 
-  it("cleans up the replaced sound and stores only the replacement", async () => {
-    const oldSound = createMockSound("one.ogg");
-    const newSound = createMockSound("two.ogg");
+  it('cleans up the replaced sound and stores only the replacement', async () => {
+    const oldSound = createMockSound('one.ogg');
+    const newSound = createMockSound('two.ogg');
     mockCreateSound.mockResolvedValueOnce(oldSound).mockResolvedValueOnce(newSound);
 
     await handler.handlePlay({
-      key: "effect",
-      name: "one.ogg",
-      type: "sound",
+      key: 'effect',
+      name: 'one.ogg',
+      type: 'sound',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
     await handler.handlePlay({
-      key: "effect",
-      name: "two.ogg",
-      type: "sound",
+      key: 'effect',
+      name: 'two.ogg',
+      type: 'sound',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
@@ -285,16 +386,16 @@ describe("GMCPClientMedia", () => {
     expect(handler.sounds.effect).toBe(newSound);
   });
 
-  it("cleans up a sound when its explicit end timer fires", async () => {
+  it('cleans up a sound when its explicit end timer fires', async () => {
     vi.useFakeTimers();
-    const sound = createMockSound("bell.ogg");
+    const sound = createMockSound('bell.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
       end: 100,
-      key: "bell",
-      name: "bell.ogg",
-      type: "sound",
+      key: 'bell',
+      name: 'bell.ogg',
+      type: 'sound',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
@@ -304,48 +405,48 @@ describe("GMCPClientMedia", () => {
     expect(handler.sounds).toEqual({});
   });
 
-  it("cleans up a finite sound after natural playback completion", async () => {
-    const sound = createMockSound("pop.ogg");
+  it('cleans up a finite sound after natural playback completion', async () => {
+    const sound = createMockSound('pop.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
-      key: "pop",
-      name: "pop.ogg",
-      type: "sound",
+      key: 'pop',
+      name: 'pop.ogg',
+      type: 'sound',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
-    sound.trigger("ended");
+    sound.trigger('ended');
 
     expect(sound.cleanup).toHaveBeenCalledOnce();
     expect(handler.sounds).toEqual({});
   });
 
-  it("stops sounds by full name suffix instead of last-character matching", async () => {
-    const sound = createMockSound("https://media.example/birds/chirp.ogg");
+  it('stops sounds by full name suffix instead of last-character matching', async () => {
+    const sound = createMockSound('https://media.example/birds/chirp.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
-      key: "bird-1",
-      name: "birds/chirp.ogg",
-      type: "sound",
+      key: 'bird-1',
+      name: 'birds/chirp.ogg',
+      type: 'sound',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
-    handler.handleStop({ name: "birds/chirp.ogg" } as GMCPMessageClientMediaStop);
+    handler.handleStop({ name: 'birds/chirp.ogg' } as GMCPMessageClientMediaStop);
 
     expect(sound.cleanup).toHaveBeenCalledOnce();
     expect(handler.sounds).toEqual({});
   });
 
-  it("updates an existing sound in place without replaying it", async () => {
-    const sound = createMockSound("https://media.example/radio.ogg");
+  it('updates an existing sound in place without replaying it', async () => {
+    const sound = createMockSound('https://media.example/radio.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
-      key: "radio-1",
-      name: "radio.ogg",
-      type: "sound",
+      key: 'radio-1',
+      name: 'radio.ogg',
+      type: 'sound',
       volume: 50,
       is3d: true,
       position: [0, 0, 0],
@@ -354,7 +455,7 @@ describe("GMCPClientMedia", () => {
     expect(sound.play).toHaveBeenCalledTimes(1);
 
     handler.handleUpdate({
-      key: "radio-1",
+      key: 'radio-1',
       volume: 25,
       pan: 50,
       start: 2000,
@@ -368,20 +469,20 @@ describe("GMCPClientMedia", () => {
     expect(sound.position).toEqual([4, 5, 6]);
     expect(sound.seek).toHaveBeenCalledWith(2);
     expect(sound.threeDOptions).toMatchObject({
-      distanceModel: "inverse",
-      panningModel: "HRTF",
+      distanceModel: 'inverse',
+      panningModel: 'HRTF',
     });
   });
 
-  it("routes ambisonic upmix playback through the renderer and follows listener yaw", async () => {
-    const sound = createMockSound("https://media.example/show.ogg");
+  it('routes ambisonic upmix playback through the renderer and follows listener yaw', async () => {
+    const sound = createMockSound('https://media.example/show.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
-      key: "show-1",
-      name: "show.ogg",
-      type: "music",
-      upmix: "ambisonic",
+      key: 'show-1',
+      name: 'show.ogg',
+      type: 'music',
+      upmix: 'ambisonic',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
@@ -396,20 +497,20 @@ describe("GMCPClientMedia", () => {
 
     expect(renderer.setRotationMatrixFromYaw).toHaveBeenLastCalledWith(Math.PI / 2);
 
-    handler.handleStop({ key: "show-1" } as GMCPMessageClientMediaStop);
+    handler.handleStop({ key: 'show-1' } as GMCPMessageClientMediaStop);
     expect(renderer.cleanup).toHaveBeenCalledOnce();
   });
 
-  it("routes declared four-channel ambisonic playback through FOA passthrough", async () => {
-    const sound = createMockSound("https://media.example/foa.ogg");
+  it('routes declared four-channel ambisonic playback through FOA passthrough', async () => {
+    const sound = createMockSound('https://media.example/foa.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
       channels: 4,
-      key: "foa-1",
-      name: "foa.ogg",
-      type: "music",
-      upmix: "ambisonic",
+      key: 'foa-1',
+      name: 'foa.ogg',
+      type: 'music',
+      upmix: 'ambisonic',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
@@ -419,23 +520,23 @@ describe("GMCPClientMedia", () => {
     expect(sound.inputChannels).toBe(4);
   });
 
-  it("updates ambisonic renderer rotation on Client.Spatial orientation events", async () => {
-    const sound = createMockSound("https://media.example/show.ogg");
+  it('updates ambisonic renderer rotation on Client.Spatial orientation events', async () => {
+    const sound = createMockSound('https://media.example/show.ogg');
     mockCreateSound.mockResolvedValue(sound);
 
     await handler.handlePlay({
-      key: "show-1",
-      name: "show.ogg",
-      type: "music",
-      upmix: "ambisonic",
+      key: 'show-1',
+      name: 'show.ogg',
+      type: 'music',
+      upmix: 'ambisonic',
       volume: 50,
     } as GMCPMessageClientMediaPlay);
 
     const renderer = await mockAmbisonicRendererCreate.mock.results[0].value;
 
     client.cacophony.listenerForwardOrientation = [-1, 0, 0];
-    client.trigger("spatialListenerOrientation", {
-      listenerId: "player-1",
+    client.trigger('spatialListenerOrientation', {
+      listenerId: 'player-1',
       forward: [-1, 0, 0],
       up: [0, 1, 0],
     });

--- a/src/gmcp/Client/Media.ts
+++ b/src/gmcp/Client/Media.ts
@@ -1,4 +1,10 @@
-import type { Cacophony, Playback, Position, Sound } from 'cacophony';
+import type {
+  Cacophony,
+  AudioNode as CacophonyAudioNode,
+  Playback,
+  Position,
+  Sound,
+} from 'cacophony';
 
 import { AmbisonicRenderer } from '../../audio/AmbisonicRenderer';
 import { EffectChain } from '../../audio/effects/EffectChain';
@@ -165,17 +171,9 @@ export class GMCPClientMedia extends GMCPPackage {
    */
   private applyChainRouting(
     sound: ExtendedSound,
-    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'send' | 'upmix'>,
+    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'send'>,
   ): void {
     if (!data.chain) {
-      return;
-    }
-    if (data.upmix === 'ambisonic') {
-      // The ambisonic renderer hard-wires its output to master and would clobber
-      // a chain route (V11). Effects on ambisonic sounds are out of scope for P0.
-      console.warn(
-        `Client.Media: chain routing not supported for ambisonic sounds; '${data.chain}' ignored`,
-      );
       return;
     }
     try {
@@ -189,17 +187,21 @@ export class GMCPClientMedia extends GMCPPackage {
     }
   }
 
-  /** Dispatch a sound to an inline effect chain (one-off) or a named chain. */
+  /**
+   * Dispatch a (non-ambisonic) sound to an inline effect chain or a named chain.
+   * Ambisonic sounds are routed via the renderer's output target in the
+   * ambisonic-setup path instead (their playback output feeds the FOA decoder,
+   * not a bus), so this is a no-op for them.
+   */
   private async applyEffectRouting(
     sound: ExtendedSound,
     soundKey: string,
     data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'send' | 'effects' | 'upmix'>,
   ): Promise<void> {
+    if (data.upmix === 'ambisonic') {
+      return;
+    }
     if (data.effects && data.effects.length > 0) {
-      if (data.upmix === 'ambisonic') {
-        console.warn('Client.Media: inline effects not supported for ambisonic sounds; ignored');
-        return;
-      }
       await this.applyInlineEffects(sound, soundKey, data);
       return;
     }
@@ -207,18 +209,19 @@ export class GMCPClientMedia extends GMCPPackage {
   }
 
   /**
-   * Build an anonymous per-sound effect chain and route the sound through it
-   * (`sound → inline → named chain | master`). Guarded by a per-sound generation
-   * so a sound released during the async build never gets a worklet bus attached
-   * to a corpse (V5).
+   * Build an anonymous per-sound effect chain, generation-guarded so a sound
+   * released during the async build never gets a worklet bus attached to a
+   * corpse (V5). Stores it on the sound (torn down in `releaseSound`) and wires
+   * its downstream target, but does NOT route the sound — the caller decides how
+   * the sound reaches the inline bus (playback route vs ambisonic renderer).
    */
-  private async applyInlineEffects(
+  private async buildInlineChain(
     sound: ExtendedSound,
     soundKey: string,
-    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'effects'>,
-  ): Promise<void> {
+    effects: EffectSpec[],
+    downstream?: ReturnType<MediaEffects['getChain']> | null,
+  ): Promise<EffectChain | undefined> {
     const master = this.client.cacophony.getBus('master');
-    // Replace any prior inline chain.
     if (sound.effectChain && master) {
       sound.effectChain.destroy(master);
       sound.effectChain = undefined;
@@ -226,7 +229,7 @@ export class GMCPClientMedia extends GMCPPackage {
     const generation = (sound.effectGeneration ?? 0) + 1;
     sound.effectGeneration = generation;
 
-    const inline = await EffectChain.createAnonymous(this.client.cacophony, data.effects ?? []);
+    const inline = await EffectChain.createAnonymous(this.client.cacophony, effects);
 
     const stale =
       sound.effectGeneration !== generation ||
@@ -236,13 +239,29 @@ export class GMCPClientMedia extends GMCPPackage {
       if (master) {
         inline.destroy(master);
       }
-      return;
+      return undefined;
     }
 
     sound.effectChain = inline;
-    if (data.chain) {
-      const downstream = this.effects.getChain(data.chain);
+    if (downstream !== undefined) {
       inline.connectDownstream(downstream ? downstream.bus : null);
+    }
+    return inline;
+  }
+
+  /**
+   * Build an inline chain and route the (non-ambisonic) sound through it
+   * (`sound → inline → named chain | master`).
+   */
+  private async applyInlineEffects(
+    sound: ExtendedSound,
+    soundKey: string,
+    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'effects'>,
+  ): Promise<void> {
+    const downstream = data.chain ? this.effects.getChain(data.chain) : undefined;
+    const inline = await this.buildInlineChain(sound, soundKey, data.effects ?? [], downstream);
+    if (!inline) {
+      return;
     }
     try {
       sound.routeTo(inline.bus);
@@ -399,6 +418,7 @@ export class GMCPClientMedia extends GMCPPackage {
     sound: ExtendedSound,
     playback: Playback,
     inputChannels: number,
+    outputTarget?: CacophonyAudioNode,
   ) {
     this.cleanupUpmix(sound);
     let renderer: AmbisonicRenderer;
@@ -412,9 +432,32 @@ export class GMCPClientMedia extends GMCPPackage {
       });
       return;
     }
-    renderer.attachPlayback(playback);
+    renderer.attachPlayback(playback, outputTarget);
     renderer.setRotationMatrixFromYaw(this.currentListenerYaw());
     sound.ambisonicRenderer = renderer;
+  }
+
+  /**
+   * For an ambisonic sound, resolve the node its binaural output should feed:
+   * the input of an inline effect bus (built here, P3/V11), or master. Named
+   * chains are not supported for ambisonic sounds — the renderer's manual output
+   * connection is not tracked by the bus, so chain-removal could not reroute it.
+   */
+  private async resolveAmbisonicTarget(
+    sound: ExtendedSound,
+    soundKey: string,
+    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'effects'>,
+  ): Promise<CacophonyAudioNode | undefined> {
+    if (data.effects && data.effects.length > 0) {
+      const inline = await this.buildInlineChain(sound, soundKey, data.effects);
+      return inline?.bus.input;
+    }
+    if (data.chain) {
+      console.warn(
+        `Client.Media: named chain '${data.chain}' is not supported for ambisonic sounds; use inline effects`,
+      );
+    }
+    return undefined;
   }
 
   private applySoundState(
@@ -537,7 +580,8 @@ export class GMCPClientMedia extends GMCPPackage {
 
       if (data.upmix === 'ambisonic') {
         const inputChannels = this.resolveAmbisonicInputChannels(sound, data);
-        await this.configureAmbisonicPlayback(sound, playback, inputChannels);
+        const target = await this.resolveAmbisonicTarget(sound, soundKey, data);
+        await this.configureAmbisonicPlayback(sound, playback, inputChannels, target);
       }
     }
 

--- a/src/gmcp/Client/Media.ts
+++ b/src/gmcp/Client/Media.ts
@@ -1,6 +1,7 @@
 import type { Cacophony, Playback, Position, Sound } from 'cacophony';
 
 import { AmbisonicRenderer } from '../../audio/AmbisonicRenderer';
+import { EffectChain } from '../../audio/effects/EffectChain';
 import { buildEffectsSupport, MediaEffects } from '../../audio/effects/MediaEffects';
 import type { EffectSpec } from '../../audio/effects/types';
 import { GMCPMessage, GMCPPackage } from '../package';
@@ -40,6 +41,7 @@ export class GMCPMessageClientMediaPlay extends GMCPMessage {
   // MCMP effects extension
   public readonly chain?: string; // Route this sound through the named effect chain.
   public readonly send?: number; // Aux-send level into `chain` (stays dry on master).
+  public readonly effects?: EffectSpec[]; // Inline per-sound effect chain (one-off).
 }
 
 export class GMCPMessageClientMediaStop extends GMCPMessage {
@@ -72,6 +74,7 @@ export class GMCPMessageClientMediaUpdate extends GMCPMessage {
   // MCMP effects extension
   public readonly chain?: string;
   public readonly send?: number;
+  public readonly effects?: EffectSpec[];
 }
 
 /** Define / replace / remove a named effect chain. Empty `effects` removes it. */
@@ -86,6 +89,17 @@ export class GMCPMessageClientMediaChain extends GMCPMessage {
 /** Remove a named effect chain by id (rerouting its live sounds to master). */
 export class GMCPMessageClientMediaChainStop extends GMCPMessage {
   public readonly id!: string;
+}
+
+/** Ramp an effect's params (or toggle bypass) on a chain or a playing sound's inline chain. */
+export class GMCPMessageClientMediaAutomate extends GMCPMessage {
+  public readonly chain?: string; // target a named chain…
+  public readonly key?: string; // …or a playing sound's inline chain (by media key)
+  public readonly target!: string | number; // effect id or index within the chain
+  public readonly params?: Record<string, number | string>; // wire params to ramp
+  public readonly ramp?: number; // ms (0 / absent = instant)
+  public readonly curve?: 'linear' | 'exponential';
+  public readonly bypass?: boolean; // toggle bypass instead of ramping
 }
 
 export class GMCPMessageClientMediaListenerOrientation extends GMCPMessage {
@@ -105,6 +119,10 @@ export interface ExtendedSound extends Sound {
   key?: string;
   mediaType?: MediaType;
   upmix?: string;
+  /** Inline per-sound effect chain (anonymous bus), torn down with the sound. */
+  effectChain?: EffectChain;
+  /** Bumped each time inline effects are (re)built, to discard stale async builds. */
+  effectGeneration?: number;
 }
 
 export class GMCPClientMedia extends GMCPPackage {
@@ -171,6 +189,95 @@ export class GMCPClientMedia extends GMCPPackage {
     }
   }
 
+  /** Dispatch a sound to an inline effect chain (one-off) or a named chain. */
+  private async applyEffectRouting(
+    sound: ExtendedSound,
+    soundKey: string,
+    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'send' | 'effects' | 'upmix'>,
+  ): Promise<void> {
+    if (data.effects && data.effects.length > 0) {
+      if (data.upmix === 'ambisonic') {
+        console.warn('Client.Media: inline effects not supported for ambisonic sounds; ignored');
+        return;
+      }
+      await this.applyInlineEffects(sound, soundKey, data);
+      return;
+    }
+    this.applyChainRouting(sound, data);
+  }
+
+  /**
+   * Build an anonymous per-sound effect chain and route the sound through it
+   * (`sound → inline → named chain | master`). Guarded by a per-sound generation
+   * so a sound released during the async build never gets a worklet bus attached
+   * to a corpse (V5).
+   */
+  private async applyInlineEffects(
+    sound: ExtendedSound,
+    soundKey: string,
+    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'effects'>,
+  ): Promise<void> {
+    const master = this.client.cacophony.getBus('master');
+    // Replace any prior inline chain.
+    if (sound.effectChain && master) {
+      sound.effectChain.destroy(master);
+      sound.effectChain = undefined;
+    }
+    const generation = (sound.effectGeneration ?? 0) + 1;
+    sound.effectGeneration = generation;
+
+    const inline = await EffectChain.createAnonymous(this.client.cacophony, data.effects ?? []);
+
+    const stale =
+      sound.effectGeneration !== generation ||
+      this.cleanedSounds.has(sound) ||
+      this.sounds[soundKey] !== sound;
+    if (stale) {
+      if (master) {
+        inline.destroy(master);
+      }
+      return;
+    }
+
+    sound.effectChain = inline;
+    if (data.chain) {
+      const downstream = this.effects.getChain(data.chain);
+      inline.connectDownstream(downstream ? downstream.bus : null);
+    }
+    try {
+      sound.routeTo(inline.bus);
+    } catch (error) {
+      console.warn('Client.Media: failed to route sound through inline effects', error);
+    }
+  }
+
+  /** `Client.Media.Automate` — ramp an effect's params or toggle its bypass. */
+  handleAutomate(data: GMCPMessageClientMediaAutomate): void {
+    const chain = this.resolveAutomateTarget(data);
+    if (!chain) {
+      console.warn('Client.Media.Automate: target chain/sound not found; ignored');
+      return;
+    }
+    if (typeof data.bypass === 'boolean') {
+      chain.setBypass(data.target, data.bypass);
+      return;
+    }
+    if (data.params) {
+      chain.automate(data.target, data.params, { duration: data.ramp, curve: data.curve });
+    }
+  }
+
+  private resolveAutomateTarget(data: GMCPMessageClientMediaAutomate): EffectChain | undefined {
+    if (data.chain) {
+      return this.effects.getChain(data.chain);
+    }
+    if (data.key) {
+      const [sound] = this.soundsByKey(data.key);
+      return sound?.effectChain;
+    }
+    return undefined;
+  }
+
   private assignSoundMetadata(
     sound: ExtendedSound,
     data: Pick<GMCPMessageClientMediaPlay, 'key' | 'tag' | 'type' | 'upmix' | 'channels'>,
@@ -201,6 +308,10 @@ export class GMCPClientMedia extends GMCPPackage {
       }
     }
 
+    // Destroy the inline effect chain BEFORE the cleaned-sounds guard, so a
+    // partial/out-of-order release can never skip the worklet-bus teardown (V4).
+    this.destroyInlineChain(sound);
+
     if (this.cleanedSounds.has(sound)) {
       return;
     }
@@ -208,6 +319,20 @@ export class GMCPClientMedia extends GMCPPackage {
     this.cleanedSounds.add(sound);
     this.cleanupUpmix(sound);
     sound.cleanup();
+  }
+
+  /** Tear down a sound's inline effect chain, if any (idempotent). */
+  private destroyInlineChain(sound: ExtendedSound): void {
+    const chain = sound.effectChain;
+    if (!chain) {
+      return;
+    }
+    sound.effectChain = undefined;
+    sound.effectGeneration = undefined;
+    const master = this.client.cacophony.getBus('master');
+    if (master) {
+      chain.destroy(master);
+    }
   }
 
   private releaseSoundWhenPlaybackEnds(sound: ExtendedSound, key: string): void {
@@ -416,7 +541,7 @@ export class GMCPClientMedia extends GMCPPackage {
       }
     }
 
-    this.applyChainRouting(sound, data);
+    await this.applyEffectRouting(sound, soundKey, data);
   }
 
   handleUpdate(data: GMCPMessageClientMediaUpdate) {
@@ -435,7 +560,9 @@ export class GMCPClientMedia extends GMCPPackage {
         channels: data.channels ?? sound.inputChannels,
       });
       this.applySoundState(sound, data);
-      this.applyChainRouting(sound, data);
+      void this.applyEffectRouting(sound, sound.key ?? data.key ?? '', data).catch((error) =>
+        console.error('Client.Media.Update: effect routing failed', error),
+      );
       const [playback] = sound.playbacks;
       if (data.upmix === 'ambisonic' && playback) {
         const inputChannels = this.resolveAmbisonicInputChannels(sound, data);
@@ -473,11 +600,9 @@ export class GMCPClientMedia extends GMCPPackage {
       });
     }
     if (!data.name && !data.type && !data.tag && !data.key) {
-      this.allSounds.forEach((sound) => {
-        this.cleanupUpmix(sound);
-        sound.cleanup();
-      });
-      this.sounds = {};
+      // Route through the single release funnel so inline effect buses are torn
+      // down too (V4) — never a bare sound.cleanup() that bypasses releaseSound.
+      this.stopAllSounds();
     }
   }
 

--- a/src/gmcp/Client/Media.ts
+++ b/src/gmcp/Client/Media.ts
@@ -1,24 +1,26 @@
-import type { Cacophony, Playback, Position, Sound } from "cacophony";
+import type { Cacophony, Playback, Position, Sound } from 'cacophony';
 
-import { AmbisonicRenderer } from "../../audio/AmbisonicRenderer";
-import { GMCPMessage, GMCPPackage } from "../package";
+import { AmbisonicRenderer } from '../../audio/AmbisonicRenderer';
+import { buildEffectsSupport, MediaEffects } from '../../audio/effects/MediaEffects';
+import type { EffectSpec } from '../../audio/effects/types';
+import { GMCPMessage, GMCPPackage } from '../package';
 
-const CORS_PROXY = "https://mongoose.world:9080/?url=";
-type CacophonySoundKind = NonNullable<Parameters<Cacophony["createSound"]>[1]>;
-const CACOPHONY_BUFFER = "buffer" satisfies CacophonySoundKind;
-const CACOPHONY_HTML = "html" satisfies CacophonySoundKind;
+const CORS_PROXY = 'https://mongoose.world:9080/?url=';
+type CacophonySoundKind = NonNullable<Parameters<Cacophony['createSound']>[1]>;
+const CACOPHONY_BUFFER = 'buffer' satisfies CacophonySoundKind;
+const CACOPHONY_HTML = 'html' satisfies CacophonySoundKind;
 
 export class GMCPMessageClientMediaLoad extends GMCPMessage {
   public readonly url?: string;
   public readonly name!: string;
 }
 
-export type MediaType = "sound" | "music" | "video";
+export type MediaType = 'sound' | 'music' | 'video';
 
 export class GMCPMessageClientMediaPlay extends GMCPMessage {
   public readonly name!: string;
   public readonly url?: string;
-  public readonly type?: MediaType = "sound";
+  public readonly type?: MediaType = 'sound';
   public readonly tag?: string;
   public readonly volume: number = 50; // Relative to the volume set on the player's client.
   public readonly fadein?: number = 0; // Volume increases, or fades in, ranged across a linear pattern from one to the volume set with the "volume" key.
@@ -35,6 +37,9 @@ export class GMCPMessageClientMediaPlay extends GMCPMessage {
   public position: number[] = [0, 0, 0]; // x, y, z
   public readonly upmix?: string;
   public readonly channels?: number;
+  // MCMP effects extension
+  public readonly chain?: string; // Route this sound through the named effect chain.
+  public readonly send?: number; // Aux-send level into `chain` (stays dry on master).
 }
 
 export class GMCPMessageClientMediaStop extends GMCPMessage {
@@ -48,7 +53,7 @@ export class GMCPMessageClientMediaStop extends GMCPMessage {
 export class GMCPMessageClientMediaUpdate extends GMCPMessage {
   public readonly name?: string;
   public readonly url?: string;
-  public readonly type?: MediaType = "sound";
+  public readonly type?: MediaType = 'sound';
   public readonly tag?: string;
   public readonly volume?: number;
   public readonly fadein?: number = 0;
@@ -64,6 +69,23 @@ export class GMCPMessageClientMediaUpdate extends GMCPMessage {
   public position?: number[] = [0, 0, 0];
   public upmix?: string;
   public channels?: number;
+  // MCMP effects extension
+  public readonly chain?: string;
+  public readonly send?: number;
+}
+
+/** Define / replace / remove a named effect chain. Empty `effects` removes it. */
+export class GMCPMessageClientMediaChain extends GMCPMessage {
+  public readonly id!: string;
+  public readonly effects?: EffectSpec[];
+  public readonly preset?: string;
+  public readonly gain?: number;
+  public readonly fadein?: number;
+}
+
+/** Remove a named effect chain by id (rerouting its live sounds to master). */
+export class GMCPMessageClientMediaChainStop extends GMCPMessage {
+  public readonly id!: string;
 }
 
 export class GMCPMessageClientMediaListenerOrientation extends GMCPMessage {
@@ -86,20 +108,72 @@ export interface ExtendedSound extends Sound {
 }
 
 export class GMCPClientMedia extends GMCPPackage {
-  public packageName: string = "Client.Media";
+  public packageName: string = 'Client.Media';
   sounds: { [key: string]: ExtendedSound } = {};
-  defaultUrl: string = "";
+  defaultUrl: string = '';
   private cleanedSounds = new WeakSet<ExtendedSound>();
+  private readonly effects: MediaEffects;
 
-  constructor(client: GMCPPackage["client"]) {
+  constructor(client: GMCPPackage['client']) {
     super(client);
-    this.client.on("spatialListenerOrientation", this.handleSpatialListenerOrientation);
-    this.client.on("spatialScene", this.handleSpatialScene);
+    this.effects = new MediaEffects(this.client.cacophony);
+    this.client.on('spatialListenerOrientation', this.handleSpatialListenerOrientation);
+    this.client.on('spatialScene', this.handleSpatialScene);
+  }
+
+  /** Advertise effect support to the server (client → server). Sent on GMCP negotiation. */
+  sendEffectsSupport(): void {
+    this.sendData('EffectsSupport', buildEffectsSupport());
+  }
+
+  /** `Client.Media.Chain` — define / replace / remove a named effect chain. */
+  handleChain(data: GMCPMessageClientMediaChain): void {
+    this.effects
+      .setChain(data)
+      .catch((error) => console.error(`Client.Media.Chain '${data.id}' failed`, error));
+  }
+
+  /** `Client.Media.ChainStop` — remove a named effect chain by id. */
+  handleChainStop(data: GMCPMessageClientMediaChainStop): void {
+    if (data.id) {
+      this.effects.removeChain(data.id);
+    }
+  }
+
+  /**
+   * Route a sound through an effect chain when `data.chain` is set. A missing
+   * chain plays dry (routeTo throws on an unregistered bus name) — the sound is
+   * never dropped for an effect's sake (§6).
+   */
+  private applyChainRouting(
+    sound: ExtendedSound,
+    data: Pick<GMCPMessageClientMediaPlay, 'chain' | 'send' | 'upmix'>,
+  ): void {
+    if (!data.chain) {
+      return;
+    }
+    if (data.upmix === 'ambisonic') {
+      // The ambisonic renderer hard-wires its output to master and would clobber
+      // a chain route (V11). Effects on ambisonic sounds are out of scope for P0.
+      console.warn(
+        `Client.Media: chain routing not supported for ambisonic sounds; '${data.chain}' ignored`,
+      );
+      return;
+    }
+    try {
+      if (typeof data.send === 'number') {
+        sound.routeTo(data.chain, data.send);
+      } else {
+        sound.routeTo(data.chain);
+      }
+    } catch (error) {
+      console.warn(`Client.Media: chain '${data.chain}' unavailable; playing dry`, error);
+    }
   }
 
   private assignSoundMetadata(
     sound: ExtendedSound,
-    data: Pick<GMCPMessageClientMediaPlay, "key" | "tag" | "type" | "upmix" | "channels">,
+    data: Pick<GMCPMessageClientMediaPlay, 'key' | 'tag' | 'type' | 'upmix' | 'channels'>,
   ) {
     sound.key = data.key;
     sound.tag = data.tag;
@@ -136,12 +210,9 @@ export class GMCPClientMedia extends GMCPPackage {
     sound.cleanup();
   }
 
-  private releaseSoundWhenPlaybackEnds(
-    sound: ExtendedSound,
-    key: string,
-  ): void {
+  private releaseSoundWhenPlaybackEnds(sound: ExtendedSound, key: string): void {
     let unsubscribe: (() => void) | undefined;
-    unsubscribe = sound.on("ended", () => {
+    unsubscribe = sound.on('ended', () => {
       unsubscribe?.();
       if (this.sounds[key] === sound) {
         this.releaseSound(sound, key);
@@ -149,7 +220,7 @@ export class GMCPClientMedia extends GMCPPackage {
     });
   }
 
-  private resolvedUrl(data: Pick<GMCPMessageClientMediaLoad, "name" | "url">): string {
+  private resolvedUrl(data: Pick<GMCPMessageClientMediaLoad, 'name' | 'url'>): string {
     return (data.url || this.defaultUrl) + data.name;
   }
 
@@ -189,7 +260,7 @@ export class GMCPClientMedia extends GMCPPackage {
 
   private resolveAmbisonicInputChannels(
     sound: ExtendedSound,
-    data: Pick<GMCPMessageClientMediaPlay, "channels">,
+    data: Pick<GMCPMessageClientMediaPlay, 'channels'>,
   ): number {
     return (
       this.normalizeInputChannels(data.channels) ??
@@ -209,7 +280,7 @@ export class GMCPClientMedia extends GMCPPackage {
     try {
       renderer = await AmbisonicRenderer.create(this.client.cacophony, inputChannels);
     } catch (error) {
-      console.warn("Unsupported ambisonic input channel count", {
+      console.warn('Unsupported ambisonic input channel count', {
         error,
         inputChannels,
         sound: sound.key ?? sound.url,
@@ -225,7 +296,7 @@ export class GMCPClientMedia extends GMCPPackage {
     sound: ExtendedSound,
     data: Pick<
       GMCPMessageClientMediaUpdate,
-      "volume" | "pan" | "loops" | "is3d" | "position" | "start" | "priority"
+      'volume' | 'pan' | 'loops' | 'is3d' | 'position' | 'start' | 'priority'
     >,
   ) {
     if (data.volume !== undefined) {
@@ -245,8 +316,8 @@ export class GMCPClientMedia extends GMCPPackage {
       sound.threeDOptions = {
         coneInnerAngle: 360,
         coneOuterAngle: 0,
-        panningModel: "HRTF",
-        distanceModel: "inverse",
+        panningModel: 'HRTF',
+        distanceModel: 'inverse',
       };
     }
 
@@ -288,18 +359,18 @@ export class GMCPClientMedia extends GMCPPackage {
 
   mediaUrl(data: GMCPMessageClientMediaPlay): string {
     let mediaUrl = this.resolvedUrl(data);
-    if (data.type?.toLowerCase() === "music") {
+    if (data.type?.toLowerCase() === 'music') {
       mediaUrl = CORS_PROXY + encodeURIComponent(mediaUrl);
     }
     return mediaUrl;
   }
 
   async handlePlay(data: GMCPMessageClientMediaPlay) {
-    let mediaUrl = this.mediaUrl(data);
+    const mediaUrl = this.mediaUrl(data);
     data.key = data.key || mediaUrl;
     const soundKey = data.key;
     let sound = this.sounds[soundKey] as ExtendedSound;
-    const panType = data.is3d ? "HRTF" : "stereo";
+    const panType = data.is3d ? 'HRTF' : 'stereo';
     // Sound creation or updating
     if (!sound || sound.url !== mediaUrl) {
       // Cleanup old sound before replacing
@@ -307,18 +378,10 @@ export class GMCPClientMedia extends GMCPPackage {
         this.releaseSound(sound, soundKey);
       }
       // Create a new sound object
-      if (data.type === "music") {
-        sound = await this.client.cacophony.createSound(
-          mediaUrl,
-          CACOPHONY_HTML,
-          panType
-        );
+      if (data.type === 'music') {
+        sound = await this.client.cacophony.createSound(mediaUrl, CACOPHONY_HTML, panType);
       } else {
-        sound = await this.client.cacophony.createSound(
-          mediaUrl,
-          CACOPHONY_BUFFER,
-          panType
-        );
+        sound = await this.client.cacophony.createSound(mediaUrl, CACOPHONY_BUFFER, panType);
       }
     }
 
@@ -347,11 +410,13 @@ export class GMCPClientMedia extends GMCPPackage {
         sound.seek(data.start / 1000);
       }
 
-      if (data.upmix === "ambisonic") {
+      if (data.upmix === 'ambisonic') {
         const inputChannels = this.resolveAmbisonicInputChannels(sound, data);
         await this.configureAmbisonicPlayback(sound, playback, inputChannels);
       }
     }
+
+    this.applyChainRouting(sound, data);
   }
 
   handleUpdate(data: GMCPMessageClientMediaUpdate) {
@@ -370,11 +435,12 @@ export class GMCPClientMedia extends GMCPPackage {
         channels: data.channels ?? sound.inputChannels,
       });
       this.applySoundState(sound, data);
+      this.applyChainRouting(sound, data);
       const [playback] = sound.playbacks;
-      if (data.upmix === "ambisonic" && playback) {
+      if (data.upmix === 'ambisonic' && playback) {
         const inputChannels = this.resolveAmbisonicInputChannels(sound, data);
         this.configureAmbisonicPlayback(sound, playback, inputChannels).catch(console.error);
-      } else if (data.upmix && data.upmix !== "ambisonic") {
+      } else if (data.upmix && data.upmix !== 'ambisonic') {
         this.cleanupUpmix(sound);
       }
       const soundKey = sound.key ?? data.key;
@@ -387,16 +453,24 @@ export class GMCPClientMedia extends GMCPPackage {
 
   handleStop(data: GMCPMessageClientMediaStop): void {
     if (data.name) {
-      this.soundsByName(data.name).forEach((sound) => this.stopSound(sound));
+      this.soundsByName(data.name).forEach((sound) => {
+        this.stopSound(sound);
+      });
     }
     if (data.type) {
-      this.soundsByType(data.type).forEach((sound) => this.stopSound(sound));
+      this.soundsByType(data.type).forEach((sound) => {
+        this.stopSound(sound);
+      });
     }
     if (data.tag) {
-      this.soundsByTag(data.tag).forEach((sound) => this.stopSound(sound));
+      this.soundsByTag(data.tag).forEach((sound) => {
+        this.stopSound(sound);
+      });
     }
     if (data.key) {
-      this.soundsByKey(data.key).forEach((sound) => this.stopSound(sound));
+      this.soundsByKey(data.key).forEach((sound) => {
+        this.stopSound(sound);
+      });
     }
     if (!data.name && !data.type && !data.tag && !data.key) {
       this.allSounds.forEach((sound) => {
@@ -429,7 +503,7 @@ export class GMCPClientMedia extends GMCPPackage {
 
   soundsByName(name: string) {
     return Object.values(this.sounds).filter((sound) => {
-      return typeof sound.url === "string" && sound.url.endsWith(name);
+      return typeof sound.url === 'string' && sound.url.endsWith(name);
     });
   }
 
@@ -443,9 +517,7 @@ export class GMCPClientMedia extends GMCPPackage {
   }
 
   soundsByType(type: MediaType) {
-    return Object.values(this.sounds).filter(
-      (sound: ExtendedSound) => sound.mediaType === type
-    );
+    return Object.values(this.sounds).filter((sound: ExtendedSound) => sound.mediaType === type);
   }
 
   get allSounds() {
@@ -460,7 +532,8 @@ export class GMCPClientMedia extends GMCPPackage {
   }
 
   override shutdown() {
-    this.client.off("spatialListenerOrientation", this.handleSpatialListenerOrientation);
-    this.client.off("spatialScene", this.handleSpatialScene);
+    this.effects.shutdown();
+    this.client.off('spatialListenerOrientation', this.handleSpatialListenerOrientation);
+    this.client.off('spatialScene', this.handleSpatialScene);
   }
 }


### PR DESCRIPTION
## What

Adds an effects layer to the client's MCMP (`Client.Media`) handler so the server can place sounds in acoustic environments, apply per-sound effects, and automate them live. Built on Cacophony 0.25's effects API (bus filter chains, drain-based rerouting, parameter ramps, bypass).

Three capabilities, gated behind a capability handshake so a server only uses what this client advertises:

- **Environment chains** — named, reusable effect chains (e.g. a "cave" reverb). Sounds route into a chain by name; removing a chain cleanly reroutes its live sounds back to master.
- **Inline effects** — a per-sound effect list on `Play`/`Update`, with optional bypass, for one-off treatments without a named chain.
- **Live automation** — ramp an effect parameter to a target value over a duration (e.g. open a filter, swell reverb mix).

## Wire format

The wire vocabulary is engine-neutral — intent names and real units (seconds, Hz, dB, 0–1 mix), not Cacophony's internal option names — so the protocol isn't welded to one audio engine. A pure `resolveEffect` translates wire specs into Cacophony factory options; unknown effect types and unknown params degrade to no-ops rather than erroring.

Capability payload (`Client.Media.EffectsSupport`, client → server) advertises supported effect types, reverb algorithms, built-in presets, automation/chain support, and limits (max chains, max effects/chain).

## Capability handshake

On GMCP negotiation the client sends `Client.Media.EffectsSupport` right after login, so effects are strictly opt-in per client.

## New messages

- `Client.Media.Chain` / `Client.Media.ChainStop` — create/replace/remove a named chain
- `Client.Media.Automate` — ramp a parameter on a chain or inline effect
- `chain` / `send` / `effects` keys added to `Client.Media.Play` and `Update`

## Notes

- Named-chain routing on ambisonic (3D) sounds is intentionally unsupported (the ambisonic renderer's output edge isn't bus-tracked, so chain teardown can't reroute it) — it warns. Inline effects on ambisonic sounds do work.
- Bumps `cacophony` `^0.23.0` → `^0.25.1` (the effects API).

## Tests

New unit suites for `resolveEffect`, `buildEffect`, `EffectChain`, `MediaEffects`, plus extended `Client.Media` and `AmbisonicRenderer` coverage (routing, inline, automation, ambisonic→inline). Full `src` suite passes; typecheck clean.
