### PR TITLE
feat(audio): Media Session controls + spatial overlay scaffolding

### DIFF
--- a/src/audio/MediaSessionController.test.ts
+++ b/src/audio/MediaSessionController.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MediaSessionController } from './MediaSessionController';
+
+type ActionHandlers = Record<string, MediaSessionActionHandler>;
+
+function installMockSession() {
+  const handlers: ActionHandlers = {};
+  const session = {
+    metadata: null as MediaMetadata | null,
+    playbackState: 'none' as MediaSessionPlaybackState,
+    setActionHandler: vi.fn((action: string, handler: MediaSessionActionHandler | null) => {
+      if (handler) {
+        handlers[action] = handler;
+      } else {
+        delete handlers[action];
+      }
+    }),
+    setPositionState: vi.fn(),
+  };
+  Object.defineProperty(navigator, 'mediaSession', {
+    value: session,
+    configurable: true,
+    writable: true,
+  });
+  // jsdom has no MediaMetadata constructor — provide a minimal stand-in.
+  (globalThis as unknown as { MediaMetadata: unknown }).MediaMetadata = class {
+    title?: string;
+    artist?: string;
+    album?: string;
+    artwork?: MediaImage[];
+    constructor(init: MediaMetadataInit = {}) {
+      this.title = init.title;
+      this.artist = init.artist;
+      this.album = init.album;
+      this.artwork = init.artwork as MediaImage[] | undefined;
+    }
+  };
+  return { session, handlers };
+}
+
+function removeMockSession() {
+  Reflect.deleteProperty(navigator, 'mediaSession');
+  Reflect.deleteProperty(globalThis as object, 'MediaMetadata');
+}
+
+function makeActions() {
+  return {
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    seekTo: vi.fn(),
+    seekBackward: vi.fn(),
+    seekForward: vi.fn(),
+  };
+}
+
+describe('MediaSessionController', () => {
+  afterEach(() => {
+    removeMockSession();
+    vi.restoreAllMocks();
+  });
+
+  describe('with a Media Session available', () => {
+    let session: ReturnType<typeof installMockSession>['session'];
+    let handlers: ActionHandlers;
+    let controller: MediaSessionController;
+    let actions: ReturnType<typeof makeActions>;
+
+    beforeEach(() => {
+      ({ session, handlers } = installMockSession());
+      controller = new MediaSessionController();
+      actions = makeActions();
+    });
+
+    it('publishes track metadata and a playing state on setNowPlaying', () => {
+      controller.setNowPlaying(
+        { title: 'Cantina Band', artist: 'Figrin D’an', album: 'Mos Eisley' },
+        actions,
+      );
+      expect(session.metadata?.title).toBe('Cantina Band');
+      expect(session.metadata?.artist).toBe('Figrin D’an');
+      expect(session.playbackState).toBe('playing');
+    });
+
+    it('routes OS transport actions to the supplied callbacks', () => {
+      controller.setNowPlaying({ title: 'Track' }, actions);
+
+      handlers.play?.({ action: 'play' });
+      handlers.pause?.({ action: 'pause' });
+      handlers.stop?.({ action: 'stop' });
+      expect(actions.play).toHaveBeenCalledOnce();
+      expect(actions.pause).toHaveBeenCalledOnce();
+      expect(actions.stop).toHaveBeenCalledOnce();
+    });
+
+    it('forwards seekto with the OS-supplied time', () => {
+      controller.setNowPlaying({ title: 'Track' }, actions);
+      handlers.seekto?.({ action: 'seekto', seekTime: 42 });
+      expect(actions.seekTo).toHaveBeenCalledWith(42);
+    });
+
+    it('falls back to a default offset for seekforward/backward', () => {
+      controller.setNowPlaying({ title: 'Track' }, actions);
+      handlers.seekforward?.({ action: 'seekforward' });
+      handlers.seekbackward?.({ action: 'seekbackward', seekOffset: 5 });
+      expect(actions.seekForward).toHaveBeenCalledWith(10);
+      expect(actions.seekBackward).toHaveBeenCalledWith(5);
+    });
+
+    it('re-targets the once-registered handlers to the latest track', () => {
+      controller.setNowPlaying({ title: 'First' }, actions);
+      const second = makeActions();
+      controller.setNowPlaying({ title: 'Second' }, second);
+
+      // Handlers are registered exactly once per action (6 actions total).
+      expect(session.setActionHandler).toHaveBeenCalledTimes(6);
+
+      handlers.pause?.({ action: 'pause' });
+      expect(second.pause).toHaveBeenCalledOnce();
+      expect(actions.pause).not.toHaveBeenCalled();
+    });
+
+    it('reports a finite position to the scrubber', () => {
+      controller.setPositionState(120, 30, 1);
+      expect(session.setPositionState).toHaveBeenCalledWith({
+        duration: 120,
+        position: 30,
+        playbackRate: 1,
+      });
+    });
+
+    it('clamps position into [0, duration]', () => {
+      controller.setPositionState(100, 250, 1);
+      expect(session.setPositionState).toHaveBeenCalledWith({
+        duration: 100,
+        position: 100,
+        playbackRate: 1,
+      });
+    });
+
+    it('skips position reporting when the duration is unknown', () => {
+      controller.setPositionState(NaN, 10);
+      controller.setPositionState(0, 10);
+      expect(session.setPositionState).not.toHaveBeenCalled();
+    });
+
+    it('clears metadata, state, and position on clear', () => {
+      controller.setNowPlaying({ title: 'Track' }, actions);
+      controller.clear();
+      expect(session.metadata).toBeNull();
+      expect(session.playbackState).toBe('none');
+      expect(session.setPositionState).toHaveBeenLastCalledWith();
+    });
+  });
+
+  describe('without a Media Session (unsupported browser / SSR)', () => {
+    it('no-ops on every method instead of throwing', () => {
+      // No installMockSession(): navigator.mediaSession is undefined.
+      const controller = new MediaSessionController();
+      const actions = makeActions();
+      expect(() => {
+        controller.setNowPlaying({ title: 'Track' }, actions);
+        controller.setPlaybackState('paused');
+        controller.setPositionState(100, 10);
+        controller.clear();
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/audio/MediaSessionController.ts
+++ b/src/audio/MediaSessionController.ts
@@ -1,0 +1,149 @@
+/**
+ * Bridges playing media to the browser's Media Session API
+ * (`navigator.mediaSession`), which is what drives OS-level "now playing"
+ * surfaces: the lock screen, notification-shade transport controls, hardware
+ * media keys, smartwatch remotes, and car head units.
+ *
+ * The controller owns NO audio. It is a presentation surface: callers tell it
+ * what is playing and supply callbacks the OS controls invoke, and it relays
+ * those to the platform. Everything is feature-detected, so on a browser (or
+ * test environment) without the API every method is a silent no-op.
+ */
+
+/** Lock-screen track info. `title` is the only required field. */
+export interface MediaSessionTrack {
+  title: string;
+  artist?: string;
+  album?: string;
+  artwork?: MediaImage[];
+}
+
+/**
+ * Callbacks the OS transport controls invoke. The controller never decides what
+ * these do — it forwards the user's lock-screen gesture to the owner, which acts
+ * on whatever it currently considers "now playing".
+ */
+export interface MediaSessionActions {
+  play(): void;
+  pause(): void;
+  stop(): void;
+  seekTo(time: number): void;
+  seekBackward(offset: number): void;
+  seekForward(offset: number): void;
+}
+
+/** Default jump (seconds) for seek-forward/backward when the OS omits an offset. */
+const DEFAULT_SEEK_OFFSET_SECONDS = 10;
+
+export class MediaSessionController {
+  /** Active forwarding target; null when nothing is playing. */
+  private actions: MediaSessionActions | null = null;
+  /** Platform action handlers are registered once, then re-target via `actions`. */
+  private handlersBound = false;
+
+  /** The live MediaSession, or null where the API is unavailable. */
+  private get session(): MediaSession | null {
+    if (typeof navigator === 'undefined') {
+      return null;
+    }
+    return navigator.mediaSession ?? null;
+  }
+
+  /**
+   * Announce a new now-playing track and bind the OS controls to `actions`.
+   * Re-targets the (once-registered) platform handlers so the controls always
+   * drive the most recently started track.
+   */
+  setNowPlaying(track: MediaSessionTrack, actions: MediaSessionActions): void {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    this.actions = actions;
+    this.bindHandlers(session);
+    session.metadata = this.buildMetadata(track);
+    session.playbackState = 'playing';
+  }
+
+  /** Reflect play/pause state so the OS shows the right transport icon. */
+  setPlaybackState(state: MediaSessionPlaybackState): void {
+    const session = this.session;
+    if (session) {
+      session.playbackState = state;
+    }
+  }
+
+  /**
+   * Report the scrubber position. The OS extrapolates position from
+   * `playbackRate`, so this only needs calling on play/pause/seek — not on a
+   * timer. Skipped entirely when the duration is unknown (NaN/0), which is the
+   * common case for open-ended streams.
+   */
+  setPositionState(duration: number, position: number, playbackRate = 1): void {
+    const session = this.session;
+    if (!session || typeof session.setPositionState !== 'function') {
+      return;
+    }
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return;
+    }
+    const clamped = Math.min(Math.max(position, 0), duration);
+    session.setPositionState({ duration, position: clamped, playbackRate: playbackRate || 1 });
+  }
+
+  /** Tear down the now-playing surface (track ended/stopped). */
+  clear(): void {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    this.actions = null;
+    session.metadata = null;
+    session.playbackState = 'none';
+    if (typeof session.setPositionState === 'function') {
+      session.setPositionState();
+    }
+  }
+
+  private buildMetadata(track: MediaSessionTrack): MediaMetadata | null {
+    if (typeof MediaMetadata === 'undefined') {
+      return null;
+    }
+    return new MediaMetadata({
+      title: track.title,
+      artist: track.artist ?? '',
+      album: track.album ?? '',
+      artwork: track.artwork ?? [],
+    });
+  }
+
+  private bindHandlers(session: MediaSession): void {
+    if (this.handlersBound) {
+      return;
+    }
+    this.handlersBound = true;
+
+    const set = (action: MediaSessionAction, handler: MediaSessionActionHandler): void => {
+      try {
+        session.setActionHandler(action, handler);
+      } catch {
+        // The browser doesn't support this action — expected; nothing to do.
+      }
+    };
+
+    set('play', () => this.actions?.play());
+    set('pause', () => this.actions?.pause());
+    set('stop', () => this.actions?.stop());
+    set('seekto', (details) => {
+      if (typeof details.seekTime === 'number') {
+        this.actions?.seekTo(details.seekTime);
+      }
+    });
+    set('seekbackward', (details) => {
+      this.actions?.seekBackward(details.seekOffset ?? DEFAULT_SEEK_OFFSET_SECONDS);
+    });
+    set('seekforward', (details) => {
+      this.actions?.seekForward(details.seekOffset ?? DEFAULT_SEEK_OFFSET_SECONDS);
+    });
+  }
+}

--- a/src/audio/SpatialOverlay.test.ts
+++ b/src/audio/SpatialOverlay.test.ts
@@ -1,0 +1,135 @@
+import type { Cacophony } from 'cacophony';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AmbisonicRenderer } from './AmbisonicRenderer';
+import { SpatialOverlay } from './SpatialOverlay';
+
+// Mock the omnitone-backed renderer so the overlay's rotation POLICY can be
+// tested without a real FOARenderer / Web Audio context.
+vi.mock('./AmbisonicRenderer', () => ({
+  AmbisonicRenderer: { create: vi.fn() },
+}));
+
+type MockBus = {
+  name: string | null;
+  input: Record<string, unknown>;
+  destroy: ReturnType<typeof vi.fn>;
+  destroyed: boolean;
+  gain: number;
+  output: {
+    gain: {
+      value: number;
+      setValueAtTime: ReturnType<typeof vi.fn>;
+      linearRampToValueAtTime: ReturnType<typeof vi.fn>;
+    };
+  };
+};
+
+function makeBus(name: string | null): MockBus {
+  return {
+    name,
+    input: { __input: name },
+    destroy: vi.fn(),
+    destroyed: false,
+    gain: 1,
+    output: { gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() } },
+  };
+}
+
+function makeCacophony() {
+  const created: MockBus[] = [];
+  const cacophony = {
+    context: { sampleRate: 48000, currentTime: 0 },
+    createBus: vi.fn((name?: string) => {
+      const b = makeBus(name ?? null);
+      created.push(b);
+      return b;
+    }),
+  };
+  return { cacophony: cacophony as unknown as Cacophony, created };
+}
+
+function makeRenderer() {
+  return { setRotationMatrixFromYaw: vi.fn(), attachPlayback: vi.fn(), cleanup: vi.fn() };
+}
+
+describe('SpatialOverlay', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a named overlay bus and exposes it', () => {
+    const { cacophony, created } = makeCacophony();
+    const overlay = SpatialOverlay.create(cacophony, { name: 'sensor-sphere' });
+    expect(cacophony.createBus).toHaveBeenCalledWith('sensor-sphere');
+    expect(overlay.bus).toBe(created[0] as unknown);
+  });
+
+  it('applies an initial gain to the bus', () => {
+    const { cacophony, created } = makeCacophony();
+    SpatialOverlay.create(cacophony, { gain: 0.5 });
+    expect(created[0].gain).toBe(0.5);
+  });
+
+  it('head-stable overlay ignores world yaw but honors instrument yaw', async () => {
+    const { cacophony } = makeCacophony();
+    const renderer = makeRenderer();
+    vi.mocked(AmbisonicRenderer.create).mockResolvedValue(renderer as unknown as AmbisonicRenderer);
+    const overlay = SpatialOverlay.create(cacophony, { headStable: true });
+    await overlay.attachRenderer(4);
+
+    overlay.setWorldYaw(1.2);
+    expect(renderer.setRotationMatrixFromYaw).not.toHaveBeenCalled();
+
+    overlay.setInstrumentYaw(0.7);
+    expect(renderer.setRotationMatrixFromYaw).toHaveBeenCalledWith(0.7);
+  });
+
+  it('world-tracking overlay rotates with world yaw', async () => {
+    const { cacophony } = makeCacophony();
+    const renderer = makeRenderer();
+    vi.mocked(AmbisonicRenderer.create).mockResolvedValue(renderer as unknown as AmbisonicRenderer);
+    const overlay = SpatialOverlay.create(cacophony, { headStable: false });
+    await overlay.attachRenderer(4);
+
+    overlay.setWorldYaw(1.2);
+    expect(renderer.setRotationMatrixFromYaw).toHaveBeenCalledWith(1.2);
+  });
+
+  it('routes a member playback through the renderer into the overlay bus', async () => {
+    const { cacophony, created } = makeCacophony();
+    const renderer = makeRenderer();
+    vi.mocked(AmbisonicRenderer.create).mockResolvedValue(renderer as unknown as AmbisonicRenderer);
+    const overlay = SpatialOverlay.create(cacophony, { name: 'ov' });
+    await overlay.attachRenderer(4);
+
+    const playback = { disconnect: vi.fn(), connect: vi.fn() };
+    overlay.addMember(playback as never);
+    expect(renderer.attachPlayback).toHaveBeenCalledWith(playback, created[0].input);
+  });
+
+  it('rampGain ramps the bus output gain over time, or sets instantly', () => {
+    const { cacophony, created } = makeCacophony();
+    const overlay = SpatialOverlay.create(cacophony);
+
+    overlay.rampGain(0.2, 500);
+    expect(created[0].output.gain.setValueAtTime).toHaveBeenCalled();
+    expect(created[0].output.gain.linearRampToValueAtTime).toHaveBeenCalledWith(0.2, 0.5);
+
+    overlay.rampGain(0.8);
+    expect(created[0].gain).toBe(0.8);
+  });
+
+  it('destroy cleans up the renderer and destroys the bus, idempotently', async () => {
+    const { cacophony, created } = makeCacophony();
+    const renderer = makeRenderer();
+    vi.mocked(AmbisonicRenderer.create).mockResolvedValue(renderer as unknown as AmbisonicRenderer);
+    const overlay = SpatialOverlay.create(cacophony, { name: 'x' });
+    await overlay.attachRenderer(4);
+
+    overlay.destroy();
+    expect(renderer.cleanup).toHaveBeenCalledTimes(1);
+    expect(created[0].destroy).toHaveBeenCalledTimes(1);
+
+    overlay.destroy();
+    expect(created[0].destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/audio/SpatialOverlay.ts
+++ b/src/audio/SpatialOverlay.ts
@@ -1,0 +1,142 @@
+import type { Bus, Cacophony } from 'cacophony';
+
+import { AmbisonicRenderer } from './AmbisonicRenderer';
+
+export interface SpatialOverlayOptions {
+  /** Stable name for the overlay's bus (registry lookup), or undefined for anonymous. */
+  name?: string;
+  /**
+   * Head-stable overlay (e.g. a sensor-sphere instrument on a headset with NO
+   * head tracking): its FOA rotation does NOT follow the world listener yaw, so
+   * the field stays put when the operator turns (chair spin). `setWorldYaw()` is
+   * ignored; only `setInstrumentYaw()` (ship heading / contact bearing) rotates
+   * it. A non-head-stable overlay tracks the world yaw like the world scene.
+   *
+   * This is the corrected sensor-sphere anchor model (design §13): a head-stable
+   * heading-up instrument, NOT head-tracked AR — no "subtract head orientation".
+   */
+  headStable?: boolean;
+  /** Initial bus output gain (0..1). Default leaves the bus at its own default. */
+  gain?: number;
+}
+
+/**
+ * One overlay submix: a cacophony {@link Bus} that member sounds sum into,
+ * optionally decoded through its OWN omnitone FOA renderer with an independent
+ * rotation.
+ *
+ * This is the "overlay = bus + own FOA renderer + members + own rotation" object
+ * the sound-scene design (P5) needs and the engine does not provide — a
+ * composition of existing cacophony/omnitone primitives, not an engine change.
+ *
+ * Rotation independence is the enabler for the sensor sphere: omnitone's FOA
+ * rotation is set directly on the renderer (`setRotationMatrix3`), decoupled from
+ * the Web Audio AudioListener that the world's PannerNode sounds follow. A
+ * head-stable overlay therefore stays put when the operator turns; only ship
+ * maneuvering / a contact moving rotates its field.
+ */
+export class SpatialOverlay {
+  readonly bus: Bus;
+  readonly headStable: boolean;
+  private renderer?: AmbisonicRenderer;
+  private destroyed = false;
+
+  private constructor(private readonly cacophony: Cacophony, bus: Bus, headStable: boolean) {
+    this.bus = bus;
+    this.headStable = headStable;
+  }
+
+  /** Create an overlay submix bus (named or anonymous), auto-connected to master. */
+  static create(cacophony: Cacophony, options: SpatialOverlayOptions = {}): SpatialOverlay {
+    const bus = cacophony.createBus(options.name);
+    const overlay = new SpatialOverlay(cacophony, bus, options.headStable ?? false);
+    if (options.gain !== undefined) {
+      bus.gain = options.gain;
+    }
+    return overlay;
+  }
+
+  /**
+   * Attach an omnitone FOA renderer to this overlay. Member ambisonic playbacks
+   * decode through it and its binaural output feeds THIS overlay's bus (not
+   * master), so the overlay can be ducked/occluded as a unit. The renderer's
+   * rotation is this overlay's own — independent of the world listener.
+   */
+  async attachRenderer(inputChannels: number): Promise<AmbisonicRenderer> {
+    this.renderer = await AmbisonicRenderer.create(this.cacophony, inputChannels);
+    return this.renderer;
+  }
+
+  /**
+   * Route a decoded member playback into this overlay: through the FOA renderer
+   * (if attached) whose output feeds the overlay bus, or straight to the bus
+   * input. Member sounds sum on the overlay bus, so they share its rotation,
+   * gain, and any occlusion filter.
+   */
+  addMember(playback: Parameters<AmbisonicRenderer['attachPlayback']>[0]): void {
+    if (this.destroyed) {
+      return;
+    }
+    if (this.renderer) {
+      this.renderer.attachPlayback(playback, this.bus.input);
+    } else {
+      playback.disconnect();
+      playback.connect(this.bus.input);
+    }
+  }
+
+  /**
+   * Apply the world listener yaw. A head-stable overlay IGNORES it (stays at its
+   * instrument-driven rotation); a world-tracking overlay rotates its renderer to
+   * match. The global `syncAmbisonicRendererYaw` loop routes world yaw HERE, and
+   * a head-stable overlay drops it — the opt-out the feasibility survey flagged.
+   */
+  setWorldYaw(yaw: number): void {
+    if (this.headStable || !this.renderer) {
+      return;
+    }
+    this.renderer.setRotationMatrixFromYaw(yaw);
+  }
+
+  /**
+   * Rotate the overlay's field by an instrument-driven yaw (ship heading /
+   * contact bearing for the sensor sphere). Applies regardless of head-stable —
+   * this is the ONLY rotation source for a head-stable overlay.
+   */
+  setInstrumentYaw(yaw: number): void {
+    this.renderer?.setRotationMatrixFromYaw(yaw);
+  }
+
+  /**
+   * Ramp the overlay bus output gain to `gain` over `rampMs` (0 = instant). Used
+   * to fade an overlay in/out and as the transparency duck handle (dipping this
+   * overlay, or — applied to the world bus — dipping the world under this
+   * overlay).
+   */
+  rampGain(gain: number, rampMs = 0): void {
+    if (this.destroyed) {
+      return;
+    }
+    if (rampMs > 0) {
+      const param = this.bus.output.gain;
+      const now = this.cacophony.context.currentTime;
+      param.setValueAtTime(param.value, now);
+      param.linearRampToValueAtTime(gain, now + rampMs / 1000);
+    } else {
+      this.bus.gain = gain;
+    }
+  }
+
+  /** Tear down the overlay: clean up its renderer and destroy its bus. Idempotent. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.renderer?.cleanup();
+    this.renderer = undefined;
+    if (!this.bus.destroyed) {
+      this.bus.destroy();
+    }
+  }
+}

--- a/src/audio/SpatialOverlayController.test.ts
+++ b/src/audio/SpatialOverlayController.test.ts
@@ -1,0 +1,112 @@
+import type { Cacophony } from 'cacophony';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SpatialEmitter } from '../gmcp/Client/Spatial';
+import { SpatialOverlayController } from './SpatialOverlayController';
+import type { OverlayMember } from './SpatialOverlayScene';
+
+// Mock the leaf units so the controller's wiring is tested in isolation.
+const managerInstances: Array<{
+  setWorldYaw: ReturnType<typeof vi.fn>;
+  setInstrumentYaw: ReturnType<typeof vi.fn>;
+  destroyAll: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock('./SpatialOverlayManager', () => ({
+  SpatialOverlayManager: vi.fn().mockImplementation(() => {
+    const inst = {
+      setWorldYaw: vi.fn(),
+      setInstrumentYaw: vi.fn(),
+      destroyAll: vi.fn(),
+      addOverlay: vi.fn(),
+      removeOverlay: vi.fn(),
+      get: vi.fn(),
+    };
+    managerInstances.push(inst);
+    return inst;
+  }),
+}));
+
+function makeBus(name: string | null) {
+  return {
+    name,
+    input: { __input: name },
+    destroy: vi.fn(),
+    destroyed: false,
+    gain: 1,
+    output: { gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() } },
+  };
+}
+
+function emitter(over: Partial<SpatialEmitter> & { id: string }): SpatialEmitter {
+  return { binding: 'world', ...over };
+}
+
+describe('SpatialOverlayController', () => {
+  let cacophony: Cacophony;
+  let worldSink: { rampGain: ReturnType<typeof vi.fn> };
+  let memberFactory: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    managerInstances.length = 0;
+    vi.clearAllMocks();
+    cacophony = {
+      context: { sampleRate: 48000, currentTime: 0 },
+      createBus: vi.fn((name?: string) => makeBus(name ?? null)),
+    } as unknown as Cacophony;
+    worldSink = { rampGain: vi.fn() };
+    memberFactory = vi.fn(
+      (): OverlayMember => ({ stop: vi.fn() }),
+    );
+  });
+
+  function make() {
+    return new SpatialOverlayController(cacophony, { worldSink, memberFactory });
+  }
+
+  it('handleScene reconciles overlay emitters into the scene (factory invoked)', () => {
+    const ctrl = make();
+    ctrl.handleScene([
+      emitter({ id: 'c1', overlay: 'sphere', frame: 'head', transparency: 0.3 }),
+      emitter({ id: 'w1' }),
+    ]);
+    expect(memberFactory).toHaveBeenCalledTimes(1);
+    expect(memberFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'c1', overlay: 'sphere' }),
+      'sphere',
+    );
+    // duck dipped to the overlay transparency
+    expect(worldSink.rampGain).toHaveBeenCalledWith(0.3, expect.any(Number));
+  });
+
+  it('handleWorldYaw drives the manager', () => {
+    const ctrl = make();
+    ctrl.handleWorldYaw(1.1);
+    expect(managerInstances[0].setWorldYaw).toHaveBeenCalledWith(1.1);
+  });
+
+  it('setInstrumentYaw targets one overlay on the manager', () => {
+    const ctrl = make();
+    ctrl.setInstrumentYaw('sphere', 0.4);
+    expect(managerInstances[0].setInstrumentYaw).toHaveBeenCalledWith('sphere', 0.4);
+  });
+
+  it('clear tears down scene + manager + duck and restores the world', () => {
+    const ctrl = make();
+    ctrl.handleScene([emitter({ id: 'c1', overlay: 'sphere', frame: 'head', transparency: 0.5 })]);
+    worldSink.rampGain.mockClear();
+    ctrl.clear();
+    expect(managerInstances[0].destroyAll).toHaveBeenCalledTimes(1);
+    // duck restored world to unity
+    expect(worldSink.rampGain).toHaveBeenCalledWith(1, expect.any(Number));
+  });
+
+  it('a member is dropped when its emitter leaves the scene', () => {
+    const ctrl = make();
+    const stop = vi.fn();
+    memberFactory.mockReturnValueOnce({ stop });
+    ctrl.handleScene([emitter({ id: 'c1', overlay: 'sphere', frame: 'head' })]);
+    ctrl.handleScene([]); // c1 gone
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/audio/SpatialOverlayController.ts
+++ b/src/audio/SpatialOverlayController.ts
@@ -1,0 +1,68 @@
+import type { Cacophony } from 'cacophony';
+
+import type { SpatialEmitter } from '../gmcp/Client/Spatial';
+import { SpatialOverlayManager } from './SpatialOverlayManager';
+import { SpatialOverlayScene, type OverlayMemberFactory } from './SpatialOverlayScene';
+import { TransparencyDuck, type DuckSink } from './TransparencyDuck';
+
+export interface SpatialOverlayControllerOptions {
+  /** What the transparency duck dips (the world submix bus, or master). */
+  worldSink: DuckSink;
+  /**
+   * Turns one overlay-bound emitter into a routed {@link OverlayMember}. This is
+   * the single point that couples to Client.Media (correlate `emitter.mediaKey`
+   * to the live sound and route it into the overlay's bus/renderer); injected so
+   * the orchestration here stays testable and engine-agnostic.
+   */
+  memberFactory: OverlayMemberFactory;
+  /** Duck ramp time (ms). */
+  duckRampMs?: number;
+}
+
+/**
+ * The single client-side entry point for the overlay system. Owns the
+ * {@link SpatialOverlayManager}, {@link TransparencyDuck}, and
+ * {@link SpatialOverlayScene}, and exposes the four drives the GMCP client wires
+ * to live events:
+ *
+ * - `handleScene(emitters)` ← Client.Spatial `spatialScene` / emitter start+stop
+ * - `handleWorldYaw(yaw)`   ← world listener orientation updates
+ * - `setInstrumentYaw(...)` ← ship heading / contact bearing for a sensor sphere
+ * - `clear()`               ← disconnect / scene reset
+ *
+ * Everything below is composed from already-tested units; this class is the thin
+ * wiring that keeps the live hookup (in the GMCP client) a few line calls.
+ */
+export class SpatialOverlayController {
+  readonly manager: SpatialOverlayManager;
+  readonly duck: TransparencyDuck;
+  readonly scene: SpatialOverlayScene;
+
+  constructor(cacophony: Cacophony, options: SpatialOverlayControllerOptions) {
+    this.manager = new SpatialOverlayManager(cacophony);
+    this.duck = new TransparencyDuck(options.worldSink, options.duckRampMs);
+    this.scene = new SpatialOverlayScene(this.manager, this.duck, options.memberFactory);
+  }
+
+  /** Reconcile overlays + members + duck against a full scene snapshot. */
+  handleScene(emitters: SpatialEmitter[]): void {
+    this.scene.syncScene(emitters);
+  }
+
+  /** Rotate world-tracking overlays to the world listener yaw (head-stable opt out). */
+  handleWorldYaw(yaw: number): void {
+    this.manager.setWorldYaw(yaw);
+  }
+
+  /** Rotate one overlay by an instrument-driven yaw (ship heading / contact bearing). */
+  setInstrumentYaw(overlayId: string, yaw: number): void {
+    this.manager.setInstrumentYaw(overlayId, yaw);
+  }
+
+  /** Tear down every overlay, member, and duck state (disconnect / reset). */
+  clear(): void {
+    this.scene.clear();
+    this.manager.destroyAll();
+    this.duck.clear();
+  }
+}

--- a/src/audio/SpatialOverlayManager.test.ts
+++ b/src/audio/SpatialOverlayManager.test.ts
@@ -1,0 +1,107 @@
+import type { Cacophony } from 'cacophony';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SpatialOverlay } from './SpatialOverlay';
+import { SpatialOverlayManager } from './SpatialOverlayManager';
+
+// Mock SpatialOverlay so the manager's bookkeeping + yaw routing are tested in
+// isolation from bus/renderer wiring.
+const instances: Array<{
+  options: unknown;
+  setWorldYaw: ReturnType<typeof vi.fn>;
+  setInstrumentYaw: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock('./SpatialOverlay', () => ({
+  SpatialOverlay: {
+    create: vi.fn((_cacophony: unknown, options: unknown) => {
+      const inst = {
+        options,
+        setWorldYaw: vi.fn(),
+        setInstrumentYaw: vi.fn(),
+        destroy: vi.fn(),
+      };
+      instances.push(inst);
+      return inst;
+    }),
+  },
+}));
+
+const cacophony = {} as unknown as Cacophony;
+
+describe('SpatialOverlayManager', () => {
+  beforeEach(() => {
+    instances.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('creates an overlay under its id (name passed through)', () => {
+    const mgr = new SpatialOverlayManager(cacophony);
+    const overlay = mgr.addOverlay('sensor-sphere', { headStable: true });
+    expect(SpatialOverlay.create).toHaveBeenCalledWith(cacophony, {
+      name: 'sensor-sphere',
+      headStable: true,
+    });
+    expect(mgr.get('sensor-sphere')).toBe(overlay as unknown);
+    expect(mgr.has('sensor-sphere')).toBe(true);
+    expect(mgr.size).toBe(1);
+  });
+
+  it('re-adding an id destroys the previous overlay', () => {
+    const mgr = new SpatialOverlayManager(cacophony);
+    mgr.addOverlay('ov');
+    mgr.addOverlay('ov');
+    expect(instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(mgr.size).toBe(1);
+  });
+
+  it('setWorldYaw fans out to every overlay (head-stable opt-out is internal)', () => {
+    const mgr = new SpatialOverlayManager(cacophony);
+    mgr.addOverlay('a');
+    mgr.addOverlay('b');
+    instances.forEach((i) => {
+      i.setWorldYaw.mockClear();
+    });
+
+    mgr.setWorldYaw(0.9);
+    expect(instances[0].setWorldYaw).toHaveBeenCalledWith(0.9);
+    expect(instances[1].setWorldYaw).toHaveBeenCalledWith(0.9);
+  });
+
+  it('a newly added overlay adopts the current world yaw', () => {
+    const mgr = new SpatialOverlayManager(cacophony);
+    mgr.setWorldYaw(1.4);
+    mgr.addOverlay('late');
+    expect(instances[0].setWorldYaw).toHaveBeenCalledWith(1.4);
+  });
+
+  it('setInstrumentYaw targets one overlay only', () => {
+    const mgr = new SpatialOverlayManager(cacophony);
+    mgr.addOverlay('a');
+    mgr.addOverlay('b');
+
+    mgr.setInstrumentYaw('b', 0.3);
+    expect(instances[0].setInstrumentYaw).not.toHaveBeenCalled();
+    expect(instances[1].setInstrumentYaw).toHaveBeenCalledWith(0.3);
+  });
+
+  it('removeOverlay destroys and drops it', () => {
+    const mgr = new SpatialOverlayManager(cacophony);
+    mgr.addOverlay('a');
+    mgr.removeOverlay('a');
+    expect(instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(mgr.has('a')).toBe(false);
+    expect(mgr.size).toBe(0);
+  });
+
+  it('destroyAll tears down every overlay', () => {
+    const mgr = new SpatialOverlayManager(cacophony);
+    mgr.addOverlay('a');
+    mgr.addOverlay('b');
+    mgr.destroyAll();
+    expect(instances[0].destroy).toHaveBeenCalledTimes(1);
+    expect(instances[1].destroy).toHaveBeenCalledTimes(1);
+    expect(mgr.size).toBe(0);
+  });
+});

--- a/src/audio/SpatialOverlayManager.ts
+++ b/src/audio/SpatialOverlayManager.ts
@@ -1,0 +1,77 @@
+import type { Cacophony } from 'cacophony';
+
+import { SpatialOverlay, type SpatialOverlayOptions } from './SpatialOverlay';
+
+/**
+ * Owns the live set of {@link SpatialOverlay}s by id and is the single place the
+ * world listener yaw is applied to them.
+ *
+ * This replaces the old `syncAmbisonicRendererYaw` "rotate EVERY sound's renderer
+ * to world yaw" loop, which had no way to keep an instrument head-stable. Here a
+ * head-stable overlay simply ignores `setWorldYaw` (the opt-out lives in
+ * {@link SpatialOverlay}), so one call rotates the world-tracking overlays and
+ * leaves the sensor sphere put.
+ */
+export class SpatialOverlayManager {
+  private readonly overlays = new Map<string, SpatialOverlay>();
+  private worldYaw = 0;
+
+  constructor(private readonly cacophony: Cacophony) {}
+
+  /** Add an overlay by id. Re-adding an existing id destroys the previous one first. */
+  addOverlay(id: string, options: SpatialOverlayOptions = {}): SpatialOverlay {
+    this.removeOverlay(id);
+    const overlay = SpatialOverlay.create(this.cacophony, { name: id, ...options });
+    this.overlays.set(id, overlay);
+    // A world-tracking overlay should adopt the current world yaw immediately so
+    // it does not start at identity until the next listener update.
+    overlay.setWorldYaw(this.worldYaw);
+    return overlay;
+  }
+
+  get(id: string): SpatialOverlay | undefined {
+    return this.overlays.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.overlays.has(id);
+  }
+
+  removeOverlay(id: string): void {
+    const existing = this.overlays.get(id);
+    if (existing) {
+      existing.destroy();
+      this.overlays.delete(id);
+    }
+  }
+
+  /**
+   * Apply the world listener yaw to every overlay. Head-stable overlays ignore it
+   * internally; world-tracking overlays rotate to match. Idempotent per yaw value
+   * is not assumed — callers drive this from listener-orientation updates.
+   */
+  setWorldYaw(yaw: number): void {
+    this.worldYaw = yaw;
+    for (const overlay of this.overlays.values()) {
+      overlay.setWorldYaw(yaw);
+    }
+  }
+
+  /** Rotate one overlay by an instrument-driven yaw (ship heading / contact bearing). */
+  setInstrumentYaw(id: string, yaw: number): void {
+    this.overlays.get(id)?.setInstrumentYaw(yaw);
+  }
+
+  /** Number of live overlays. */
+  get size(): number {
+    return this.overlays.size;
+  }
+
+  /** Destroy every overlay (scene teardown / disconnect). */
+  destroyAll(): void {
+    for (const overlay of this.overlays.values()) {
+      overlay.destroy();
+    }
+    this.overlays.clear();
+  }
+}

--- a/src/audio/SpatialOverlayScene.test.ts
+++ b/src/audio/SpatialOverlayScene.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SpatialEmitter } from '../gmcp/Client/Spatial';
+import { SpatialOverlayScene, type OverlayMember } from './SpatialOverlayScene';
+import type { SpatialOverlayManager } from './SpatialOverlayManager';
+import type { TransparencyDuck } from './TransparencyDuck';
+
+function emitter(over: Partial<SpatialEmitter> & { id: string }): SpatialEmitter {
+  return { binding: 'world', ...over };
+}
+
+function makeManager() {
+  return {
+    addOverlay: vi.fn(),
+    removeOverlay: vi.fn(),
+  } as unknown as SpatialOverlayManager & {
+    addOverlay: ReturnType<typeof vi.fn>;
+    removeOverlay: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeDuck() {
+  return {
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+  } as unknown as TransparencyDuck & {
+    activate: ReturnType<typeof vi.fn>;
+    deactivate: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('SpatialOverlayScene', () => {
+  let manager: ReturnType<typeof makeManager>;
+  let duck: ReturnType<typeof makeDuck>;
+  let made: Array<{ emitterId: string; overlayId: string; member: OverlayMember & { stop: ReturnType<typeof vi.fn> } }>;
+  let factory: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    manager = makeManager();
+    duck = makeDuck();
+    made = [];
+    factory = vi.fn((e: SpatialEmitter, overlayId: string) => {
+      const member = { stop: vi.fn() };
+      made.push({ emitterId: e.id, overlayId, member });
+      return member;
+    });
+  });
+
+  function scene() {
+    return new SpatialOverlayScene(manager, duck, factory);
+  }
+
+  it('ignores world (non-overlay) emitters entirely', () => {
+    const s = scene();
+    s.syncScene([emitter({ id: 'w1' }), emitter({ id: 'w2' })]);
+    expect(manager.addOverlay).not.toHaveBeenCalled();
+    expect(factory).not.toHaveBeenCalled();
+    expect(s.size).toBe(0);
+  });
+
+  it('creates a head-stable overlay + members + duck for head-frame emitters', () => {
+    const s = scene();
+    s.syncScene([
+      emitter({ id: 'c1', overlay: 'sphere', frame: 'head', transparency: 0.3 }),
+      emitter({ id: 'c2', overlay: 'sphere', frame: 'head', transparency: 0.3 }),
+    ]);
+    expect(manager.addOverlay).toHaveBeenCalledWith('sphere', { headStable: true });
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(duck.activate).toHaveBeenLastCalledWith('sphere', 0.3);
+    expect(s.size).toBe(1);
+  });
+
+  it('does not recreate a surviving member on re-sync (no stutter)', () => {
+    const s = scene();
+    const first = [emitter({ id: 'c1', overlay: 'sphere', frame: 'head' })];
+    s.syncScene(first);
+    s.syncScene(first);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(made[0].member.stop).not.toHaveBeenCalled();
+  });
+
+  it('stops a member whose emitter left, keeps the overlay if others remain', () => {
+    const s = scene();
+    s.syncScene([
+      emitter({ id: 'c1', overlay: 'sphere', frame: 'head' }),
+      emitter({ id: 'c2', overlay: 'sphere', frame: 'head' }),
+    ]);
+    s.syncScene([emitter({ id: 'c2', overlay: 'sphere', frame: 'head' })]);
+    const c1 = made.find((m) => m.emitterId === 'c1');
+    expect(c1?.member.stop).toHaveBeenCalledTimes(1);
+    expect(manager.removeOverlay).not.toHaveBeenCalled();
+    expect(s.size).toBe(1);
+  });
+
+  it('tears down an overlay (members + manager + duck) when it leaves the scene', () => {
+    const s = scene();
+    s.syncScene([emitter({ id: 'c1', overlay: 'sphere', frame: 'head' })]);
+    s.syncScene([emitter({ id: 'w1' })]);
+    expect(made[0].member.stop).toHaveBeenCalledTimes(1);
+    expect(manager.removeOverlay).toHaveBeenCalledWith('sphere');
+    expect(duck.deactivate).toHaveBeenCalledWith('sphere');
+    expect(s.size).toBe(0);
+  });
+
+  it('retries member creation when the factory returns undefined', () => {
+    const s = scene();
+    factory.mockReturnValueOnce(undefined);
+    const list = [emitter({ id: 'c1', overlay: 'sphere', frame: 'head' })];
+    s.syncScene(list); // factory returns undefined → no member stored
+    s.syncScene(list); // retries
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(s.size).toBe(1);
+  });
+
+  it('clear tears down everything', () => {
+    const s = scene();
+    s.syncScene([
+      emitter({ id: 'c1', overlay: 'a', frame: 'head' }),
+      emitter({ id: 'c2', overlay: 'b', frame: 'world' }),
+    ]);
+    s.clear();
+    expect(manager.removeOverlay).toHaveBeenCalledWith('a');
+    expect(manager.removeOverlay).toHaveBeenCalledWith('b');
+    expect(s.size).toBe(0);
+  });
+});

--- a/src/audio/SpatialOverlayScene.ts
+++ b/src/audio/SpatialOverlayScene.ts
@@ -1,0 +1,135 @@
+import type { SpatialEmitter } from '../gmcp/Client/Spatial';
+
+import type { SpatialOverlayManager } from './SpatialOverlayManager';
+import type { TransparencyDuck } from './TransparencyDuck';
+
+/** A live overlay member playback the scene can stop when its emitter leaves. */
+export interface OverlayMember {
+  stop(): void;
+}
+
+/**
+ * Builds (and routes into the overlay) a playback for one overlay-bound emitter.
+ * Returns undefined if a playback cannot be created yet (e.g. the correlated
+ * Media sound — keyed by `emitter.mediaKey` — has not arrived); the scene retries
+ * on the next sync. Injected so the reconciler stays independent of the actual
+ * cacophony/Media wiring (and unit-testable).
+ */
+export type OverlayMemberFactory = (
+  emitter: SpatialEmitter,
+  overlayId: string,
+) => OverlayMember | undefined;
+
+interface OverlayBucket {
+  transparency: number;
+  members: Map<string, OverlayMember>;
+}
+
+/**
+ * Reconciles the server's overlay-bound emitters into live {@link SpatialOverlay}s
+ * (via {@link SpatialOverlayManager}), their member playbacks, and the
+ * {@link TransparencyDuck}. World (non-overlay) emitters are ignored here — they
+ * stay on the existing PannerNode/Media path.
+ *
+ * Idempotent: call {@link syncScene} with the full emitter list on every scene
+ * snapshot. Overlays/members absent from the new snapshot are torn down; new ones
+ * are created; surviving members are left playing untouched (no restart) so a
+ * scene refresh does not stutter a continuing contact tone.
+ */
+export class SpatialOverlayScene {
+  private readonly overlays = new Map<string, OverlayBucket>();
+
+  constructor(
+    private readonly manager: SpatialOverlayManager,
+    private readonly duck: TransparencyDuck,
+    private readonly memberFactory: OverlayMemberFactory,
+  ) {}
+
+  syncScene(emitters: SpatialEmitter[]): void {
+    const grouped = new Map<string, SpatialEmitter[]>();
+    for (const emitter of emitters) {
+      if (!emitter.overlay) {
+        continue;
+      }
+      const list = grouped.get(emitter.overlay);
+      if (list) {
+        list.push(emitter);
+      } else {
+        grouped.set(emitter.overlay, [emitter]);
+      }
+    }
+
+    for (const id of [...this.overlays.keys()]) {
+      if (!grouped.has(id)) {
+        this.teardownOverlay(id);
+      }
+    }
+
+    for (const [id, members] of grouped) {
+      this.reconcileOverlay(id, members);
+    }
+  }
+
+  /** Tear down every overlay (scene teardown / disconnect). */
+  clear(): void {
+    for (const id of [...this.overlays.keys()]) {
+      this.teardownOverlay(id);
+    }
+  }
+
+  /** Number of live overlays the scene is tracking. */
+  get size(): number {
+    return this.overlays.size;
+  }
+
+  private reconcileOverlay(id: string, emitters: SpatialEmitter[]): void {
+    let bucket = this.overlays.get(id);
+    if (!bucket) {
+      const headStable = emitters.some((e) => e.frame === 'head');
+      this.manager.addOverlay(id, { headStable });
+      bucket = { transparency: 1, members: new Map() };
+      this.overlays.set(id, bucket);
+    }
+
+    const present = new Set(emitters.map((e) => e.id));
+    for (const [emitterId, member] of [...bucket.members]) {
+      if (!present.has(emitterId)) {
+        member.stop();
+        bucket.members.delete(emitterId);
+      }
+    }
+
+    // Retry-safe: only create a member for an emitter not already live.
+    for (const emitter of emitters) {
+      if (bucket.members.has(emitter.id)) {
+        continue;
+      }
+      const member = this.memberFactory(emitter, id);
+      if (member) {
+        bucket.members.set(emitter.id, member);
+      }
+    }
+
+    // Most-opaque declared transparency wins (mirrors the duck's own min rule).
+    const transparency = emitters.reduce(
+      (min, e) => (e.transparency !== undefined ? Math.min(min, e.transparency) : min),
+      1,
+    );
+    bucket.transparency = transparency;
+    this.duck.activate(id, transparency);
+  }
+
+  private teardownOverlay(id: string): void {
+    const bucket = this.overlays.get(id);
+    if (!bucket) {
+      return;
+    }
+    for (const member of bucket.members.values()) {
+      member.stop();
+    }
+    bucket.members.clear();
+    this.overlays.delete(id);
+    this.manager.removeOverlay(id);
+    this.duck.deactivate(id);
+  }
+}

--- a/src/audio/TransparencyDuck.test.ts
+++ b/src/audio/TransparencyDuck.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TransparencyDuck } from './TransparencyDuck';
+
+function makeSink() {
+  return { rampGain: vi.fn() };
+}
+
+describe('TransparencyDuck', () => {
+  let sink: ReturnType<typeof makeSink>;
+
+  beforeEach(() => {
+    sink = makeSink();
+  });
+
+  it('dips the world to an overlay transparency when it activates', () => {
+    const duck = new TransparencyDuck(sink, 120);
+    duck.activate('sphere', 0.3);
+    expect(duck.worldGain).toBe(0.3);
+    expect(sink.rampGain).toHaveBeenLastCalledWith(0.3, 120);
+  });
+
+  it('the most opaque active overlay wins (min transparency)', () => {
+    const duck = new TransparencyDuck(sink);
+    duck.activate('a', 0.6);
+    duck.activate('b', 0.2);
+    expect(duck.worldGain).toBe(0.2);
+    duck.activate('c', 0.9);
+    expect(duck.worldGain).toBe(0.2);
+  });
+
+  it('restores toward unity as overlays deactivate, fully at the last', () => {
+    const duck = new TransparencyDuck(sink);
+    duck.activate('a', 0.6);
+    duck.activate('b', 0.2);
+    duck.deactivate('b');
+    expect(duck.worldGain).toBe(0.6);
+    duck.deactivate('a');
+    expect(duck.worldGain).toBe(1);
+    expect(sink.rampGain).toHaveBeenLastCalledWith(1, 120);
+  });
+
+  it('clamps transparency into [0,1] and treats non-finite as fully transparent', () => {
+    const duck = new TransparencyDuck(sink);
+    duck.activate('over', 1.7);
+    expect(duck.worldGain).toBe(1);
+    duck.activate('under', -0.5);
+    expect(duck.worldGain).toBe(0);
+    duck.deactivate('under');
+    duck.activate('nan', Number.NaN);
+    expect(duck.worldGain).toBe(1);
+  });
+
+  it('deactivate is a no-op for an unknown id (no spurious ramp)', () => {
+    const duck = new TransparencyDuck(sink);
+    duck.activate('a', 0.5);
+    sink.rampGain.mockClear();
+    duck.deactivate('ghost');
+    expect(sink.rampGain).not.toHaveBeenCalled();
+  });
+
+  it('clear restores the world and only ramps when something was active', () => {
+    const duck = new TransparencyDuck(sink);
+    duck.clear();
+    expect(sink.rampGain).not.toHaveBeenCalled();
+    duck.activate('a', 0.4);
+    sink.rampGain.mockClear();
+    duck.clear();
+    expect(duck.worldGain).toBe(1);
+    expect(sink.rampGain).toHaveBeenCalledWith(1, 120);
+  });
+});

--- a/src/audio/TransparencyDuck.ts
+++ b/src/audio/TransparencyDuck.ts
@@ -1,0 +1,74 @@
+/**
+ * Anything whose level can be ramped — a {@link SpatialOverlay} or a bus wrapper.
+ * The duck only needs to push a target gain; it does not own the world sink.
+ */
+export interface DuckSink {
+  rampGain(gain: number, rampMs?: number): void;
+}
+
+/**
+ * The transparency duck (design §10): while one or more overlays are audible, the
+ * WORLD is dipped so the overlay reads clearly, by an amount each overlay
+ * declares as its transparency.
+ *
+ * - transparency = 1 → fully transparent, world is NOT dipped under this overlay.
+ * - transparency = 0 → opaque, world is fully ducked to silence under it.
+ *
+ * With several overlays active the most opaque one wins (the world target is the
+ * MIN transparency across active overlays). When the last overlay deactivates the
+ * world returns to unity. All changes are ramped to avoid clicks.
+ *
+ * The world sink is injected (structural {@link DuckSink}) so this controller is
+ * independent of whether "the world" is the master bus, a dedicated world submix
+ * bus, or a test double.
+ */
+export class TransparencyDuck {
+  private readonly active = new Map<string, number>();
+
+  constructor(
+    private readonly worldSink: DuckSink,
+    private readonly rampMs = 120,
+  ) {}
+
+  /** Mark overlay `id` audible with its `transparency` (0..1); re-applies the duck. */
+  activate(id: string, transparency: number): void {
+    this.active.set(id, clamp01(transparency));
+    this.apply();
+  }
+
+  /** Mark overlay `id` no longer audible; re-applies the duck. No-op if absent. */
+  deactivate(id: string): void {
+    if (this.active.delete(id)) {
+      this.apply();
+    }
+  }
+
+  /** Drop all overlays (scene teardown) and restore the world to unity. */
+  clear(): void {
+    if (this.active.size === 0) {
+      return;
+    }
+    this.active.clear();
+    this.apply();
+  }
+
+  /** Current world target gain (min transparency across active overlays, else 1). */
+  get worldGain(): number {
+    let gain = 1;
+    for (const transparency of this.active.values()) {
+      gain = Math.min(gain, transparency);
+    }
+    return gain;
+  }
+
+  private apply(): void {
+    this.worldSink.rampGain(this.worldGain, this.rampMs);
+  }
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return Math.min(1, Math.max(0, value));
+}

--- a/src/audio/foaEncode.test.ts
+++ b/src/audio/foaEncode.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { ambisonicDirectionFromWorld, foaEncodeGainsACN } from './foaEncode';
+
+const close = (a: number, b: number, eps = 1e-9) => Math.abs(a - b) < eps;
+
+describe('foaEncodeGainsACN (ACN/SN3D, [W,Y,Z,X])', () => {
+  it('W is always 1 (omnidirectional component)', () => {
+    expect(foaEncodeGainsACN([1, 0, 0])[0]).toBe(1);
+    expect(foaEncodeGainsACN([0, 0, 1])[0]).toBe(1);
+  });
+
+  it('encodes a front source (ambisonic +x) onto the X channel (ACN 3)', () => {
+    const [w, y, z, x] = foaEncodeGainsACN([1, 0, 0]);
+    expect(w).toBe(1);
+    expect(close(x, 1)).toBe(true);
+    expect(close(y, 0)).toBe(true);
+    expect(close(z, 0)).toBe(true);
+  });
+
+  it('encodes a left source (ambisonic +y) onto the Y channel (ACN 1)', () => {
+    const [, y, z, x] = foaEncodeGainsACN([0, 1, 0]);
+    expect(close(y, 1)).toBe(true);
+    expect(close(x, 0)).toBe(true);
+    expect(close(z, 0)).toBe(true);
+  });
+
+  it('encodes an up source (ambisonic +z) onto the Z channel (ACN 2)', () => {
+    const [, y, z, x] = foaEncodeGainsACN([0, 0, 1]);
+    expect(close(z, 1)).toBe(true);
+    expect(close(x, 0)).toBe(true);
+    expect(close(y, 0)).toBe(true);
+  });
+
+  it('normalizes a non-unit direction (gains are direction cosines)', () => {
+    const [, y, z, x] = foaEncodeGainsACN([3, 0, 0]); // magnitude 3, all front
+    expect(close(x, 1)).toBe(true);
+    expect(close(y, 0)).toBe(true);
+    expect(close(z, 0)).toBe(true);
+  });
+
+  it('a 45° front-left direction splits between X and Y equally', () => {
+    const [, y, z, x] = foaEncodeGainsACN([1, 1, 0]);
+    const inv = 1 / Math.SQRT2;
+    expect(close(x, inv)).toBe(true);
+    expect(close(y, inv)).toBe(true);
+    expect(close(z, 0)).toBe(true);
+  });
+
+  it('a degenerate (zero) direction encodes omnidirectional only', () => {
+    const [w, y, z, x] = foaEncodeGainsACN([0, 0, 0]);
+    expect(w).toBe(1);
+    expect(y).toBe(0);
+    expect(z).toBe(0);
+    expect(x).toBe(0);
+  });
+});
+
+describe('ambisonicDirectionFromWorld (Web Audio → ambiX axis map)', () => {
+  it('Web Audio forward (−z) maps to ambisonic front (+x)', () => {
+    expect(ambisonicDirectionFromWorld([0, 0, -1])).toEqual([1, -0, 0]);
+  });
+
+  it('Web Audio right (+x) maps to ambisonic right (−left)', () => {
+    expect(ambisonicDirectionFromWorld([1, 0, 0])).toEqual([-0, -1, 0]);
+  });
+
+  it('Web Audio up (+y) maps to ambisonic up (+z)', () => {
+    expect(ambisonicDirectionFromWorld([0, 1, 0])).toEqual([-0, -0, 1]);
+  });
+
+  it('composes with the encoder: a contact dead ahead lands on +X', () => {
+    const dir = ambisonicDirectionFromWorld([0, 0, -5]); // 5 units forward
+    const [, y, z, x] = foaEncodeGainsACN(dir);
+    expect(close(x, 1)).toBe(true);
+    expect(close(y, 0)).toBe(true);
+    expect(close(z, 0)).toBe(true);
+  });
+});

--- a/src/audio/foaEncode.ts
+++ b/src/audio/foaEncode.ts
@@ -1,0 +1,58 @@
+/**
+ * First-order ambisonic (FOA) encoding gains for a mono point source.
+ *
+ * omnitone's FOARenderer (DEFAULT channel map `[0,1,2,3]`) expects **ACN channel
+ * order** `[W, Y, Z, X]` with **SN3D** normalization (ambiX) — verified against
+ * `omnitone.esm.js` (`FOARouter.ChannelMap.FUMA = [0,3,1,2]` maps FuMa→ACN, so
+ * DEFAULT is ACN). Under SN3D, a unit-amplitude planewave from a unit direction
+ * `d` encodes to first order as simply:
+ *
+ *   W = 1,  Y = d_y,  Z = d_z,  X = d_x
+ *
+ * i.e. W omnidirectional plus the direction cosines on the first-order channels.
+ * This function is the convention-INDEPENDENT core: it takes a direction already
+ * expressed in the ambisonic frame (x = front, y = left, z = up) and returns the
+ * ACN-ordered gains. The mapping FROM the server's `scaled_position()` vector
+ * INTO that ambisonic frame is a separate, integration-validated step
+ * ({@link ambisonicDirectionFromWorld}) — that axis binding must be confirmed
+ * empirically (it is jointly constrained with omnitone's rotation), so it is kept
+ * apart from this math.
+ */
+export type AcnFoaGains = [number, number, number, number]; // [W, Y, Z, X]
+
+const EPSILON = 1e-9;
+
+export function foaEncodeGainsACN(directionAmbisonic: [number, number, number]): AcnFoaGains {
+  const [x, y, z] = normalize(directionAmbisonic);
+  return [1, y, z, x];
+}
+
+/**
+ * Map a Web-Audio-frame vector (x = right, y = up, z = back / −forward) to the
+ * ambisonic frame (x = front, y = left, z = up):
+ *
+ *   front = −z_wa,  left = −x_wa,  up = y_wa
+ *
+ * This is the DEFAULT assumption for a `scaled_position()` already expressed in
+ * the client's Web Audio world frame. If the sensor sphere uses a different frame
+ * (e.g. nautical +x forward), swap this mapping — it is the single axis-convention
+ * seam, and MUST be confirmed against the live renderer (a contact at a known
+ * bearing audibly/deterministically at that bearing) before shipping.
+ */
+export function ambisonicDirectionFromWorld(
+  worldVector: [number, number, number],
+): [number, number, number] {
+  const [x, y, z] = worldVector;
+  return [-z, -x, y];
+}
+
+function normalize(v: [number, number, number]): [number, number, number] {
+  const [x, y, z] = v;
+  const len = Math.hypot(x, y, z);
+  if (len < EPSILON) {
+    // Degenerate direction (contact at the listener): encode as omnidirectional
+    // only — no directional bias.
+    return [0, 0, 0];
+  }
+  return [x / len, y / len, z / len];
+}

--- a/src/gmcp/Client/Media.mediaSession.test.ts
+++ b/src/gmcp/Client/Media.mediaSession.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAmbisonicRendererCreate, mockCreateSound } = vi.hoisted(() => ({
+  mockAmbisonicRendererCreate: vi.fn(),
+  mockCreateSound: vi.fn(),
+}));
+
+vi.mock('../../audio/AmbisonicRenderer', () => ({
+  AmbisonicRenderer: { create: mockAmbisonicRendererCreate },
+}));
+
+import { GMCPClientMedia, type GMCPMessageClientMediaPlay } from './Media';
+
+type ActionHandlers = Record<string, MediaSessionActionHandler>;
+
+function installMockSession() {
+  const handlers: ActionHandlers = {};
+  const session = {
+    metadata: null as MediaMetadata | null,
+    playbackState: 'none' as MediaSessionPlaybackState,
+    setActionHandler: vi.fn((action: string, handler: MediaSessionActionHandler | null) => {
+      if (handler) {
+        handlers[action] = handler;
+      } else {
+        delete handlers[action];
+      }
+    }),
+    setPositionState: vi.fn(),
+  };
+  Object.defineProperty(navigator, 'mediaSession', {
+    value: session,
+    configurable: true,
+    writable: true,
+  });
+  (globalThis as unknown as { MediaMetadata: unknown }).MediaMetadata = class {
+    title?: string;
+    artist?: string;
+    constructor(init: MediaMetadataInit = {}) {
+      this.title = init.title;
+      this.artist = init.artist;
+    }
+  };
+  return { session, handlers };
+}
+
+function createMockMusicSound(url: string) {
+  const listeners = new Map<string, Set<() => void>>();
+  const playback = { currentTime: 0, duration: 180 };
+  const sound = {
+    cleanup: vi.fn(),
+    duration: 180,
+    isPlaying: false,
+    key: undefined as string | undefined,
+    loop: vi.fn(),
+    mediaType: undefined as string | undefined,
+    on: vi.fn((event: string, listener: () => void) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, new Set());
+      }
+      listeners.get(event)?.add(listener);
+      return () => listeners.get(event)?.delete(listener);
+    }),
+    pause: vi.fn(() => {
+      sound.isPlaying = false;
+    }),
+    play: vi.fn(() => {
+      sound.isPlaying = true;
+      return [playback];
+    }),
+    playbacks: [playback],
+    position: [0, 0, 0],
+    priority: undefined,
+    resume: vi.fn(() => {
+      sound.isPlaying = true;
+    }),
+    routeTo: vi.fn(),
+    seek: vi.fn((t: number) => {
+      playback.currentTime = t;
+    }),
+    stereoPan: 0,
+    tag: undefined,
+    trigger(event: string) {
+      for (const listener of listeners.get(event) ?? []) {
+        listener();
+      }
+    },
+    url,
+    volume: 1,
+  };
+  return sound;
+}
+
+function createMockClient() {
+  const master = { destroy: vi.fn(), input: {}, destroyed: false };
+  return {
+    cacophony: {
+      context: { currentTime: 0, sampleRate: 48000 },
+      createSound: mockCreateSound,
+      getBus: vi.fn((name: string) => (name === 'master' ? master : undefined)),
+      listenerForwardOrientation: [0, 0, -1],
+    },
+    off: vi.fn(),
+    on: vi.fn(),
+    sendGmcp: vi.fn(),
+  };
+}
+
+async function playMusic(handler: GMCPClientMedia, overrides: Partial<GMCPMessageClientMediaPlay>) {
+  return handler.handlePlay({
+    name: 'theme.ogg',
+    type: 'music',
+    volume: 50,
+    ...overrides,
+  } as GMCPMessageClientMediaPlay);
+}
+
+describe('GMCPClientMedia ↔ Media Session', () => {
+  let handler: GMCPClientMedia;
+  let session: ReturnType<typeof installMockSession>['session'];
+  let handlers: ActionHandlers;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ({ session, handlers } = installMockSession());
+    handler = new GMCPClientMedia(createMockClient() as never);
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'mediaSession');
+    Reflect.deleteProperty(globalThis as object, 'MediaMetadata');
+  });
+
+  it('publishes now-playing metadata when a music track starts', async () => {
+    mockCreateSound.mockResolvedValue(createMockMusicSound('proxy/theme.ogg'));
+    await playMusic(handler, { name: 'cantina/band.ogg' });
+
+    expect(session.metadata?.title).toBe('band'); // filename basename, no ext
+    expect(session.playbackState).toBe('playing');
+    expect(session.setPositionState).toHaveBeenCalledWith({
+      duration: 180,
+      position: 0,
+      playbackRate: 1,
+    });
+  });
+
+  it('prefers explicit title/artist metadata from the server', async () => {
+    mockCreateSound.mockResolvedValue(createMockMusicSound('proxy/theme.ogg'));
+    await playMusic(handler, { title: 'Cantina Band', artist: 'Figrin D’an' });
+
+    expect(session.metadata?.title).toBe('Cantina Band');
+    expect(session.metadata?.artist).toBe('Figrin D’an');
+  });
+
+  it('does not touch the Media Session for non-music sounds', async () => {
+    mockCreateSound.mockResolvedValue(createMockMusicSound('chime.ogg'));
+    await handler.handlePlay({
+      name: 'chime.ogg',
+      type: 'sound',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+
+    expect(session.metadata).toBeNull();
+    expect(session.playbackState).toBe('none');
+  });
+
+  it('pauses and resumes the track from OS transport controls', async () => {
+    const sound = createMockMusicSound('proxy/theme.ogg');
+    mockCreateSound.mockResolvedValue(sound);
+    await playMusic(handler, {});
+
+    handlers.pause?.({ action: 'pause' });
+    expect(sound.pause).toHaveBeenCalledOnce();
+    expect(session.playbackState).toBe('paused');
+
+    handlers.play?.({ action: 'play' });
+    expect(sound.resume).toHaveBeenCalledOnce();
+    expect(session.playbackState).toBe('playing');
+  });
+
+  it('seeks the track from the OS scrubber', async () => {
+    const sound = createMockMusicSound('proxy/theme.ogg');
+    mockCreateSound.mockResolvedValue(sound);
+    await playMusic(handler, {});
+
+    handlers.seekto?.({ action: 'seekto', seekTime: 90 });
+    expect(sound.seek).toHaveBeenCalledWith(90);
+  });
+
+  it('clamps OS seek-forward to the track duration', async () => {
+    const sound = createMockMusicSound('proxy/theme.ogg');
+    sound.playbacks[0].currentTime = 175;
+    mockCreateSound.mockResolvedValue(sound);
+    await playMusic(handler, {});
+
+    handlers.seekforward?.({ action: 'seekforward' }); // +10 from 175 -> clamp 180
+    expect(sound.seek).toHaveBeenCalledWith(180);
+  });
+
+  it('stops the track and clears the session from the OS stop control', async () => {
+    const sound = createMockMusicSound('proxy/theme.ogg');
+    mockCreateSound.mockResolvedValue(sound);
+    await playMusic(handler, {});
+
+    handlers.stop?.({ action: 'stop' });
+    expect(sound.cleanup).toHaveBeenCalledOnce();
+    expect(session.metadata).toBeNull();
+    expect(session.playbackState).toBe('none');
+  });
+
+  it('clears the session when the track ends naturally', async () => {
+    const sound = createMockMusicSound('proxy/theme.ogg');
+    mockCreateSound.mockResolvedValue(sound);
+    await playMusic(handler, {});
+
+    sound.trigger('ended');
+    expect(session.metadata).toBeNull();
+    expect(session.playbackState).toBe('none');
+  });
+
+  it('clears the session on package shutdown (disconnect)', async () => {
+    mockCreateSound.mockResolvedValue(createMockMusicSound('proxy/theme.ogg'));
+    await playMusic(handler, {});
+
+    handler.shutdown();
+    expect(session.metadata).toBeNull();
+    expect(session.playbackState).toBe('none');
+  });
+});

--- a/src/gmcp/Client/Media.ts
+++ b/src/gmcp/Client/Media.ts
@@ -10,6 +10,7 @@ import { AmbisonicRenderer } from '../../audio/AmbisonicRenderer';
 import { EffectChain } from '../../audio/effects/EffectChain';
 import { buildEffectsSupport, MediaEffects } from '../../audio/effects/MediaEffects';
 import type { EffectSpec } from '../../audio/effects/types';
+import { MediaSessionController } from '../../audio/MediaSessionController';
 import { GMCPMessage, GMCPPackage } from '../package';
 
 const CORS_PROXY = 'https://mongoose.world:9080/?url=';
@@ -48,6 +49,12 @@ export class GMCPMessageClientMediaPlay extends GMCPMessage {
   public readonly chain?: string; // Route this sound through the named effect chain.
   public readonly send?: number; // Aux-send level into `chain` (stays dry on master).
   public readonly effects?: EffectSpec[]; // Inline per-sound effect chain (one-off).
+  // Media Session metadata (OS lock screen / transport controls). Optional —
+  // the title falls back to the media name when these are absent.
+  public readonly title?: string;
+  public readonly artist?: string;
+  public readonly album?: string;
+  public readonly artwork?: MediaImage[];
 }
 
 export class GMCPMessageClientMediaStop extends GMCPMessage {
@@ -137,6 +144,10 @@ export class GMCPClientMedia extends GMCPPackage {
   defaultUrl: string = '';
   private cleanedSounds = new WeakSet<ExtendedSound>();
   private readonly effects: MediaEffects;
+  /** OS lock screen / transport-control surface for the active music track. */
+  private readonly mediaSession = new MediaSessionController();
+  /** The music sound currently bound to the Media Session, if any. */
+  private currentMusic?: ExtendedSound;
 
   constructor(client: GMCPPackage['client']) {
     super(client);
@@ -317,6 +328,11 @@ export class GMCPClientMedia extends GMCPPackage {
   }
 
   private releaseSound(sound: ExtendedSound, key?: string): void {
+    if (sound === this.currentMusic) {
+      this.currentMusic = undefined;
+      this.mediaSession.clear();
+    }
+
     if (key !== undefined && this.sounds[key] === sound) {
       delete this.sounds[key];
     }
@@ -586,6 +602,109 @@ export class GMCPClientMedia extends GMCPPackage {
     }
 
     await this.applyEffectRouting(sound, soundKey, data);
+
+    if (data.type === 'music') {
+      this.activateMusicSession(sound, data);
+    }
+  }
+
+  /**
+   * Make `sound` the OS "now playing" track: publish its metadata to the lock
+   * screen and bind the hardware/lock-screen transport controls to it. The
+   * controls act locally on the cacophony sound — MCMP has no client→server
+   * transport verb, so a lock-screen pause pauses the user's local audio only.
+   */
+  private activateMusicSession(sound: ExtendedSound, data: GMCPMessageClientMediaPlay): void {
+    this.currentMusic = sound;
+    this.mediaSession.setNowPlaying(
+      {
+        title: this.musicTitle(data),
+        artist: data.artist,
+        album: data.album,
+        artwork: data.artwork,
+      },
+      {
+        play: () => this.resumeCurrentMusic(),
+        pause: () => this.pauseCurrentMusic(),
+        stop: () => this.stopCurrentMusic(),
+        seekTo: (time) => this.seekCurrentMusic(time),
+        seekBackward: (offset) => this.nudgeCurrentMusic(-offset),
+        seekForward: (offset) => this.nudgeCurrentMusic(offset),
+      },
+    );
+    this.mediaSession.setPlaybackState(sound.isPlaying ? 'playing' : 'paused');
+    this.updateMusicPosition();
+  }
+
+  /** Lock-screen title: explicit `title`, else the media filename sans path/ext. */
+  private musicTitle(data: GMCPMessageClientMediaPlay): string {
+    if (data.title) {
+      return data.title;
+    }
+    const base = data.name.split('/').pop() ?? data.name;
+    return base.replace(/\.[^.]+$/, '') || data.name;
+  }
+
+  private resumeCurrentMusic(): void {
+    const sound = this.currentMusic;
+    if (!sound) {
+      return;
+    }
+    sound.resume();
+    this.mediaSession.setPlaybackState('playing');
+    this.updateMusicPosition();
+  }
+
+  private pauseCurrentMusic(): void {
+    const sound = this.currentMusic;
+    if (!sound) {
+      return;
+    }
+    sound.pause();
+    this.mediaSession.setPlaybackState('paused');
+    this.updateMusicPosition();
+  }
+
+  private stopCurrentMusic(): void {
+    const sound = this.currentMusic;
+    if (sound) {
+      this.releaseSound(sound, sound.key);
+    }
+  }
+
+  private seekCurrentMusic(time: number): void {
+    const sound = this.currentMusic;
+    if (!sound) {
+      return;
+    }
+    sound.seek(time);
+    this.updateMusicPosition();
+  }
+
+  private nudgeCurrentMusic(deltaSeconds: number): void {
+    const sound = this.currentMusic;
+    if (!sound) {
+      return;
+    }
+    const current = sound.playbacks[0]?.currentTime ?? 0;
+    const duration = sound.duration;
+    let next = current + deltaSeconds;
+    if (next < 0) {
+      next = 0;
+    } else if (Number.isFinite(duration) && next > duration) {
+      next = duration;
+    }
+    this.seekCurrentMusic(next);
+  }
+
+  /** Push the current track's duration/position to the lock-screen scrubber. */
+  private updateMusicPosition(): void {
+    const sound = this.currentMusic;
+    if (!sound) {
+      return;
+    }
+    const position = sound.playbacks[0]?.currentTime ?? 0;
+    this.mediaSession.setPositionState(sound.duration, position, sound.isPlaying ? 1 : 0);
   }
 
   handleUpdate(data: GMCPMessageClientMediaUpdate) {
@@ -701,6 +820,8 @@ export class GMCPClientMedia extends GMCPPackage {
   }
 
   override shutdown() {
+    this.currentMusic = undefined;
+    this.mediaSession.clear();
     this.effects.shutdown();
     this.client.off('spatialListenerOrientation', this.handleSpatialListenerOrientation);
     this.client.off('spatialScene', this.handleSpatialScene);

--- a/src/gmcp/Client/Spatial.ts
+++ b/src/gmcp/Client/Spatial.ts
@@ -26,6 +26,15 @@ export interface SpatialEmitter {
   loops?: number;
   volume?: number;
   sourceKind?: string;
+  // P5 overlay fields (all optional → absent = the world scene, today's behavior).
+  /** Overlay id this emitter belongs to. Absent = world (PannerNode) scene. */
+  overlay?: string;
+  /** Overlay reference frame; "head" = a head-stable instrument (sensor sphere). */
+  frame?: "head" | "world";
+  /** 0..1 — how much of the world shows through under this overlay (transparency duck). */
+  transparency?: number;
+  /** Overlay stack order (higher = on top). */
+  priority?: number;
 }
 
 export interface SpatialListenerOrientation {


### PR DESCRIPTION
@
## Summary

Two related pieces of the sound work:

1. **Media Session API integration** (fully wired) — playing `music` tracks now publish title/artist/album/artwork to `navigator.mediaSession`, so they appear on the OS lock screen, notification shade, hardware media keys, and car/watch remotes. Lock-screen play/pause/stop/seek act on the user`s local cacophony sound (MCMP has no client→server transport verb). `MediaSessionController` owns no audio — it is a feature-detected presentation surface that no-ops where the API is unavailable.

2. **Spatial overlay scaffolding (P5)** (scaffolding + tests only, not yet wired into the GMCP Spatial renderer) — `SpatialOverlay`, `SpatialOverlayScene`, `SpatialOverlayManager`, `SpatialOverlayController`, first-order-ambisonic encoding (`foaEncode`), and the `TransparencyDuck` that attenuates the world bed under an active overlay. A `head`-frame overlay is a head-stable instrument (sensor sphere) whose emitters do not rotate with the listener. The `SpatialEmitter` interface gains optional `overlay`/`frame`/`transparency`/`priority` fields — all absent means the world scene, so existing emitters are unchanged.

## Testing

- 62 new unit tests across the 8 modules — all passing.
- `tsc --noEmit` clean; biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@