### PR TITLE
Cancel superseded Node.js CI runs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
     branches: [ "master" ]
 
+# Cancel an in-progress run when a newer commit is pushed to the same branch/PR,
+# so superseded runs don't pile up. Master pushes group per-SHA so they never cancel
+# each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
 


### PR DESCRIPTION
@
## What

Adds a `concurrency` group to the Node.js CI workflow so a new push to a PR cancels that PRs in-progress run instead of leaving stale runs stacked in the checks list.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: true
```

## Why

Pushing several commits to a PR in quick succession currently spawns one `test (20.x)` run per push, and none are cancelled — they pile up looking like the same test running multiple times.

## Behavior

- **PR events** group by PR number, so a newer push cancels the superseded run.
- **Pushes to master** fall back to the commit SHA, so master runs never cancel one another (each master commit runs to completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@