### PR TITLE
Improve MOO editor accessibility

### DIFF
--- a/src/components/editor/editorWindow.test.tsx
+++ b/src/components/editor/editorWindow.test.tsx
@@ -702,6 +702,114 @@ describe('EditorWindow language selection', () => {
     expect(editorMock.focus).toHaveBeenCalled();
   });
 
+  it('keeps the MOO problems region mounted with an empty state when there are no diagnostics', async () => {
+    treeSitterDiagnosticsMock.mockResolvedValueOnce([]);
+
+    render(
+      <MemoryRouter initialEntries={['/editor?reference=%231:test']}>
+        <EditorWindow />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(MockBroadcastChannel.instances[0]?.listeners.length).toBe(1));
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emit({
+        type: 'load',
+        session: {
+          contents: ['notify(player, "ok");'],
+          name: '#1:test',
+          reference: '#1:test',
+          type: 'moo-code',
+        },
+      });
+    });
+
+    const problemsRegion = await screen.findByRole('region', { name: 'MOO problems' });
+    expect(screen.getByText('No MOO problems.')).not.toBeNull();
+    expect(problemsRegion.contains(screen.getByText('No MOO problems.'))).toBe(true);
+    expect(screen.queryByRole('button', { name: /^MOO (error|warning)/ })).toBeNull();
+  });
+
+  it('keeps the same MOO problems region across the empty and non-empty boundary', async () => {
+    treeSitterDiagnosticsMock.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={['/editor?reference=%231:test']}>
+        <EditorWindow />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(MockBroadcastChannel.instances[0]?.listeners.length).toBe(1));
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emit({
+        type: 'load',
+        session: {
+          contents: ['notify(player, "ok");'],
+          name: '#1:test',
+          reference: '#1:test',
+          type: 'moo-code',
+        },
+      });
+    });
+
+    const emptyRegion = await screen.findByRole('region', { name: 'MOO problems' });
+    expect(screen.getByText('No MOO problems.')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: /^MOO (error|warning)/ })).toBeNull();
+
+    // Typing diagnostics into the same session must reuse the region (no remount).
+    const onChange = editorMock.props?.onChange as (value: string) => void;
+    act(() => {
+      onChange('unused = 1;\nwhile (1)\n  notify(player, "tick");');
+    });
+
+    const populatedRegion = await screen.findByRole('region', { name: 'MOO problems' });
+    const problemButtons = await screen.findAllByRole('button', { name: /^MOO (error|warning)/ });
+
+    expect(populatedRegion).toBe(emptyRegion);
+    expect(problemButtons.length).toBeGreaterThan(0);
+    expect(populatedRegion.contains(problemButtons[0])).toBe(true);
+
+    // And back to clean code: same region node persists with the empty state.
+    act(() => {
+      onChange('notify(player, "ok");');
+    });
+
+    const clearedRegion = await screen.findByRole('region', { name: 'MOO problems' });
+    expect(clearedRegion).toBe(emptyRegion);
+    expect(screen.getByText('No MOO problems.')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: /^MOO (error|warning)/ })).toBeNull();
+  });
+
+  it('does not add aria-live to the MOO problems region (counts stay on the statusbar)', async () => {
+    treeSitterDiagnosticsMock.mockResolvedValueOnce([]);
+
+    render(
+      <MemoryRouter initialEntries={['/editor?reference=%231:test']}>
+        <EditorWindow />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(MockBroadcastChannel.instances[0]?.listeners.length).toBe(1));
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emit({
+        type: 'load',
+        session: {
+          contents: ['unused = 1;', 'while (1)', '  notify(player, "tick");'],
+          name: '#1:test',
+          reference: '#1:test',
+          type: 'moo-code',
+        },
+      });
+    });
+
+    const problemsRegion = await screen.findByRole('region', { name: 'MOO problems' });
+    expect(problemsRegion.getAttribute('aria-live')).toBeNull();
+    expect(screen.getByRole('status').getAttribute('id')).toBe('editor-statusbar');
+  });
+
   it('filters the MOO problems list by severity without hiding filter state from assistive tech', async () => {
     treeSitterDiagnosticsMock.mockResolvedValueOnce([]);
 

--- a/src/components/editor/editorWindow.test.tsx
+++ b/src/components/editor/editorWindow.test.tsx
@@ -812,4 +812,64 @@ describe('EditorWindow language selection', () => {
     );
     expect(screen.getByRole('status').textContent).toContain('Changed');
   });
+
+  it('focuses the code editor exactly once when a document loads, without a timer', async () => {
+    render(
+      <MemoryRouter initialEntries={['/editor?reference=%231:test']}>
+        <EditorWindow />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(MockBroadcastChannel.instances[0]?.listeners.length).toBe(1));
+
+    // The editor instance mounts on render; loading a document must move focus
+    // into the code deterministically, with no fake-timer advance required.
+    expect(editorMock.focus).not.toHaveBeenCalled();
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emit({
+        type: 'load',
+        session: {
+          contents: ['notify(player, "ok");'],
+          name: '#1:test',
+          reference: '#1:test',
+          type: 'moo-code',
+        },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Unchanged'));
+    expect(editorMock.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not move focus when the user saves', async () => {
+    render(
+      <MemoryRouter initialEntries={['/editor?reference=%231:test']}>
+        <EditorWindow />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(MockBroadcastChannel.instances[0]?.listeners.length).toBe(1));
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emit({
+        type: 'load',
+        session: {
+          contents: ['notify(player, "ok");'],
+          name: '#1:test',
+          reference: '#1:test',
+          type: 'moo-code',
+        },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Unchanged'));
+    // Ignore the deterministic focus-on-open; we only care that Save adds none.
+    editorMock.focus.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(editorMock.focus).not.toHaveBeenCalled();
+    expect(screen.getByRole('status').textContent).toContain('Saved');
+  });
 });

--- a/src/components/editor/editorWindow.test.tsx
+++ b/src/components/editor/editorWindow.test.tsx
@@ -385,6 +385,36 @@ describe('EditorWindow language selection', () => {
     expect(options.accessibilitySupport).not.toBe('off');
   });
 
+  it('pages a full verb into the screen-reader element via accessibilityPageSize', async () => {
+    // accessibilityPageSize controls how many lines Monaco pages into the hidden
+    // screen-reader element. Set unconditionally to 500 so a full MOO verb is
+    // navigable. The mock has accessibilityMode: false, so this passing also
+    // proves the option is ungated.
+    render(
+      <MemoryRouter initialEntries={['/editor?reference=%231:test']}>
+        <EditorWindow />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(MockBroadcastChannel.instances[0]?.listeners.length).toBe(1));
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emit({
+        type: 'load',
+        session: {
+          contents: ['notify(player, "ok");'],
+          name: '#1:test',
+          reference: '#1:test',
+          type: 'moo-code',
+        },
+      });
+    });
+
+    await waitFor(() => expect(editorMock.props?.language).toBe(MOO_LANGUAGE_ID));
+    const options = editorMock.props?.options as Record<string, unknown>;
+    expect(options.accessibilityPageSize).toBe(500);
+  });
+
   it('enables the richer Monaco language-service UI for MOO sessions', async () => {
     render(
       <MemoryRouter initialEntries={['/editor?reference=%231:test']}>

--- a/src/components/editor/editorWindow.tsx
+++ b/src/components/editor/editorWindow.tsx
@@ -58,6 +58,11 @@ function EditorWindow() {
   const location = useLocation();
   const editorInstance = React.useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
   const monacoInstance = React.useRef<Monaco | null>(null);
+  // Set when a document is loaded; consumed exactly once to focus the editor as
+  // soon as the editor instance is ready (deterministic, no timer). Focus may be
+  // requested before the editor has mounted (load arrives first) or after (editor
+  // mounts first); whichever happens second performs the focus.
+  const pendingFocusOnReady = React.useRef<boolean>(false);
   const [clientId, setClientId] = useState<string>('');
   const [code, setCode] = useState<string>('');
   const [originalCode, setOriginalCode] = useState<string>('');
@@ -75,9 +80,27 @@ function EditorWindow() {
     type: '',
   });
 
+  // Focus the editor once, when both the editor instance is ready and a document
+  // has been loaded. Safe to call from either the load handler or the editor's
+  // mount callback; it no-ops unless a focus is pending and the instance exists,
+  // and it clears the pending flag so focus fires exactly once.
+  const focusEditorOnReady = React.useCallback(() => {
+    if (!pendingFocusOnReady.current) {
+      return;
+    }
+    const editor = editorInstance.current;
+    if (!editor) {
+      return;
+    }
+    pendingFocusOnReady.current = false;
+    editor.focus();
+  }, []);
+
   const handleEditorMount: OnMount = (editor, monaco) => {
     editorInstance.current = editor;
     monacoInstance.current = monaco;
+    // If a document already loaded before the editor mounted, focus it now.
+    focusEditorOnReady();
   };
   const handleEditorBeforeMount = (monaco: Monaco) => {
     registerMooLanguage(monaco);
@@ -86,9 +109,6 @@ function EditorWindow() {
   const accessibilityMode = prefState.editor.accessibilityMode;
   const autocompleteEnabled = prefState.editor.autocompleteEnabled;
   const editorLanguage = getEditorLanguageForSessionType(session.type);
-  const focusEditor = React.useCallback(() => {
-    editorInstance.current?.focus();
-  }, []);
   const updateMooDiagnostics = React.useCallback((markers: MonacoEditor.IMarkerData[]) => {
     setMooDiagnosticMarkers(markers);
     setMooDiagnosticCounts(getMooDiagnosticCounts(markers));
@@ -263,7 +283,11 @@ function EditorWindow() {
           setDocumentState(DocumentState.Unchanged);
           setClientId(event.data.clientId);
           setIsLoaded(true); // Add this line to set isLoaded to true when content is loaded
-          setTimeout(focusEditor, 100);
+          // Focus the code editor on open, deterministically and exactly once.
+          // If the editor instance is already mounted, this focuses now; if the
+          // editor mounts later, handleEditorMount performs the focus. No timer.
+          pendingFocusOnReady.current = true;
+          focusEditorOnReady();
           break;
         }
         case 'shutdown':
@@ -288,7 +312,7 @@ function EditorWindow() {
       channel.removeEventListener('message', handleMessage);
       channel.postMessage({ type: 'close', id });
     };
-  }, [channel, clientId, id, documentState, focusEditor]);
+  }, [channel, clientId, id, documentState, focusEditorOnReady]);
 
   const revert = () => {
     setCode(originalCode);
@@ -301,7 +325,6 @@ function EditorWindow() {
     const sessionData = { ...session, contents };
     channel.postMessage({ type: 'save', session: sessionData, id });
     setDocumentState(DocumentState.Saved);
-    focusEditor();
     event.preventDefault();
   };
 

--- a/src/components/editor/editorWindow.tsx
+++ b/src/components/editor/editorWindow.tsx
@@ -522,6 +522,11 @@ function createEditorOptions({
     // screen-reader textarea and overrides ariaLabel with an error string.
     // 'auto' is the safe floor; 'on' forces full screen-reader optimization.
     accessibilitySupport: accessibilityMode ? 'on' : 'auto',
+    // Monaco's SR-optimized default; pages a full MOO verb (~hundreds of lines)
+    // into the hidden screen-reader element instead of the ~10-line default window.
+    // Set unconditionally: at 500 there is no perf cost beyond Monaco's own SR
+    // default, and it does not depend on runtime SR detection.
+    accessibilityPageSize: 500,
     quickSuggestions: autocompleteEnabled,
   };
 

--- a/src/components/editor/editorWindow.tsx
+++ b/src/components/editor/editorWindow.tsx
@@ -379,13 +379,15 @@ function EditorWindow() {
         onMount={handleEditorMount}
         path={session.reference}
       />
-      <MooProblemsPanel
-        id={EDITOR_PROBLEMS_ID}
-        markers={mooDiagnosticProblems}
-        onProblemClick={showMooDiagnostic}
-        onQuickFixClick={applyMooQuickFix}
-        quickFixes={mooQuickFixes}
-      />
+      {editorLanguage === MOO_LANGUAGE_ID ? (
+        <MooProblemsPanel
+          id={EDITOR_PROBLEMS_ID}
+          markers={mooDiagnosticProblems}
+          onProblemClick={showMooDiagnostic}
+          onQuickFixClick={applyMooQuickFix}
+          quickFixes={mooQuickFixes}
+        />
+      ) : null}
       <EditorStatusBar
         id={EDITOR_STATUSBAR_ID}
         onDiagnosticsClick={mooDiagnosticTarget ? showFirstMooDiagnostic : undefined}
@@ -414,89 +416,91 @@ function MooProblemsPanel({
 }: MooProblemsPanelProps) {
   const [filter, setFilter] = useState<MooProblemFilter>('all');
 
-  if (markers.length === 0) {
-    return null;
-  }
-
   const counts = getMooDiagnosticCounts(markers);
   const visibleMarkers = markers.filter((marker) => mooProblemFilterIncludesMarker(filter, marker));
   const fixAllQuickFixes = quickFixes.filter(isMooFixAllQuickFix);
 
   return (
     <section aria-label="MOO problems" className="editor-problems" id={id}>
-      <div aria-label="MOO problem filters" className="editor-problems-filters" role="toolbar">
-        {mooProblemFilterOptions(markers.length, counts).map((option) => (
-          <button
-            aria-label={option.ariaLabel}
-            aria-pressed={filter === option.filter}
-            className="editor-problems-filter"
-            key={option.filter}
-            onClick={() => setFilter(option.filter)}
-            type="button"
-          >
-            {option.label}
-          </button>
-        ))}
-        {fixAllQuickFixes.map((quickFix) => (
-          <button
-            aria-label={`Apply MOO fix all: ${quickFix.title}`}
-            className="editor-problems-fix-all-button"
-            key={quickFix.title}
-            onClick={() => onQuickFixClick(quickFix)}
-            type="button"
-          >
-            Fix all
-          </button>
-        ))}
-      </div>
-      {visibleMarkers.length > 0 ? (
-        <ol className="editor-problems-list">
-          {visibleMarkers.map((marker, index) => {
-            const severity = formatMooProblemSeverity(marker);
-            const code = formatMooProblemCode(marker);
-            const target = getMooDiagnosticTarget(marker);
-            const label = `MOO ${severity.toLowerCase()} ${code} on line ${
-              target.lineNumber
-            }, column ${target.column}: ${marker.message}`;
-            const quickFix = findMooQuickFixForMarker(quickFixes, marker);
-
-            return (
-              <li className="editor-problem" key={formatMooProblemKey(marker, index)}>
-                <div className="editor-problem-row">
-                  <button
-                    aria-label={label}
-                    className="editor-problem-button"
-                    onClick={() => onProblemClick(marker)}
-                    type="button"
-                  >
-                    <span
-                      className={`editor-problem-severity editor-problem-severity-${severity.toLowerCase()}`}
-                    >
-                      {severity}
-                    </span>{' '}
-                    <span className="editor-problem-code">{code}</span>{' '}
-                    <span className="editor-problem-location">
-                      Ln {target.lineNumber}, Col {target.column}
-                    </span>{' '}
-                    <span className="editor-problem-message">{marker.message}</span>
-                  </button>
-                  {quickFix ? (
-                    <button
-                      aria-label={`Apply quick fix: ${quickFix.title}`}
-                      className="editor-problem-fix-button"
-                      onClick={() => onQuickFixClick(quickFix)}
-                      type="button"
-                    >
-                      Fix
-                    </button>
-                  ) : null}
-                </div>
-              </li>
-            );
-          })}
-        </ol>
+      {markers.length === 0 ? (
+        <p className="editor-problems-empty">{formatEmptyMooProblemsFilterMessage('all')}</p>
       ) : (
-        <p className="editor-problems-empty">{formatEmptyMooProblemsFilterMessage(filter)}</p>
+        <>
+          <div aria-label="MOO problem filters" className="editor-problems-filters" role="toolbar">
+            {mooProblemFilterOptions(markers.length, counts).map((option) => (
+              <button
+                aria-label={option.ariaLabel}
+                aria-pressed={filter === option.filter}
+                className="editor-problems-filter"
+                key={option.filter}
+                onClick={() => setFilter(option.filter)}
+                type="button"
+              >
+                {option.label}
+              </button>
+            ))}
+            {fixAllQuickFixes.map((quickFix) => (
+              <button
+                aria-label={`Apply MOO fix all: ${quickFix.title}`}
+                className="editor-problems-fix-all-button"
+                key={quickFix.title}
+                onClick={() => onQuickFixClick(quickFix)}
+                type="button"
+              >
+                Fix all
+              </button>
+            ))}
+          </div>
+          {visibleMarkers.length > 0 ? (
+            <ol className="editor-problems-list">
+              {visibleMarkers.map((marker, index) => {
+                const severity = formatMooProblemSeverity(marker);
+                const code = formatMooProblemCode(marker);
+                const target = getMooDiagnosticTarget(marker);
+                const label = `MOO ${severity.toLowerCase()} ${code} on line ${
+                  target.lineNumber
+                }, column ${target.column}: ${marker.message}`;
+                const quickFix = findMooQuickFixForMarker(quickFixes, marker);
+
+                return (
+                  <li className="editor-problem" key={formatMooProblemKey(marker, index)}>
+                    <div className="editor-problem-row">
+                      <button
+                        aria-label={label}
+                        className="editor-problem-button"
+                        onClick={() => onProblemClick(marker)}
+                        type="button"
+                      >
+                        <span
+                          className={`editor-problem-severity editor-problem-severity-${severity.toLowerCase()}`}
+                        >
+                          {severity}
+                        </span>{' '}
+                        <span className="editor-problem-code">{code}</span>{' '}
+                        <span className="editor-problem-location">
+                          Ln {target.lineNumber}, Col {target.column}
+                        </span>{' '}
+                        <span className="editor-problem-message">{marker.message}</span>
+                      </button>
+                      {quickFix ? (
+                        <button
+                          aria-label={`Apply quick fix: ${quickFix.title}`}
+                          className="editor-problem-fix-button"
+                          onClick={() => onQuickFixClick(quickFix)}
+                          type="button"
+                        >
+                          Fix
+                        </button>
+                      ) : null}
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          ) : (
+            <p className="editor-problems-empty">{formatEmptyMooProblemsFilterMessage(filter)}</p>
+          )}
+        </>
       )}
     </section>
   );

--- a/tests/visual/editor-marker-nav.spec.ts
+++ b/tests/visual/editor-marker-nav.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+
+// Piece 3 (editor a11y): PROOF that F8 / Shift+F8 navigate between diagnostic
+// markers in our Monaco editor AND that each jump is announced to assistive tech.
+//
+// We add NO keybindings here. F8 (editor.action.marker.nextInFiles) and
+// Shift+F8 (editor.action.marker.prevInFiles) ship with the standalone Monaco
+// build we load, together with their built-in `aria.status` announcement that
+// renders the gotoError peek widget. This spec drives the real editor end to end
+// and asserts the built-in behavior actually works for a blind user.
+
+const EDITOR_REFERENCE = '#1:test';
+
+// MOO source that yields exactly two parser ERRORS on different lines:
+//   L2: `frobnicate(player);`  -> unknown-builtin  (frobnicate is not a builtin)
+//   L4: `endif`                -> unexpected-close  (endif without matching if)
+// Both are synchronous parser diagnostics (no tree-sitter needed), so the
+// markers are pushed via setModelMarkers as soon as the model loads.
+const MOO_SOURCE_LINES = [
+  'notify(player, "start");',
+  'frobnicate(player);',
+  'notify(player, "middle");',
+  'endif',
+  'notify(player, "done");',
+];
+
+const FIRST_MARKER_MESSAGE = 'frobnicate is not a known ToastStunt builtin.';
+const SECOND_MARKER_MESSAGE = 'Unexpected endif without a matching if.';
+
+test.describe('Editor marker navigation (F8 / Shift+F8)', () => {
+  test('F8/Shift+F8 navigate between diagnostics and announce them', async ({ page }) => {
+    // Monaco is fetched from a CDN at runtime; give the editor room to load.
+    test.setTimeout(90_000);
+    // 1. Open the editor route directly, then deliver the document the way the
+    //    app does in production: a BroadcastChannel('editor') `load` message.
+    await page.goto(`/editor?reference=${encodeURIComponent(EDITOR_REFERENCE)}`);
+
+    // Monaco is loaded from a CDN at runtime; wait for the real editor to mount.
+    // (In this SR-optimized build the input element is `textarea.ime-text-area`.)
+    const editorTextarea = page.locator('.monaco-editor textarea').first();
+    await expect(editorTextarea).toBeVisible({ timeout: 60_000 });
+
+    // Deliver content via the same channel the parent window uses.
+    await page.evaluate(
+      ({ reference, lines }) => {
+        const channel = new BroadcastChannel('editor');
+        channel.postMessage({
+          type: 'load',
+          clientId: 'e2e-marker-nav',
+          session: {
+            contents: lines,
+            name: reference,
+            reference,
+            type: 'moo-code',
+          },
+        });
+        channel.close();
+      },
+      { reference: EDITOR_REFERENCE, lines: MOO_SOURCE_LINES },
+    );
+
+    // 2. The two parser errors must reach Monaco as markers. We prove they were
+    //    pushed by asserting the app's own problems panel lists both messages.
+    const problems = page.locator('.editor-problems');
+    await expect(problems).toBeVisible({ timeout: 30_000 });
+    await expect(
+      problems.locator('.editor-problem-message', { hasText: FIRST_MARKER_MESSAGE }),
+    ).toBeVisible();
+    await expect(
+      problems.locator('.editor-problem-message', { hasText: SECOND_MARKER_MESSAGE }),
+    ).toBeVisible();
+
+    // Focus the code surface so the editor-scoped F8 keybinding is in effect.
+    // Click the visible text region (the hidden ime-text-area cannot be clicked);
+    // Monaco routes keyboard events through its focus tracker once focused.
+    await page.locator('.monaco-editor .view-lines').click();
+    await expect(page.locator('.monaco-editor.focused')).toBeVisible();
+
+    // The gotoError peek widget Monaco opens on navigate. Its `.message` block is
+    // `role="alert" aria-live="assertive"` — the element AT reads aloud. We assert
+    // against the concrete message text per marker, not merely "a widget exists".
+    const peekMessage = page.locator('.monaco-editor .peekview-widget .message[role="alert"]');
+
+    // 3. Press F8 -> navigate to the first marker (line 2, frobnicate). The peek
+    //    appears and announces that marker's message.
+    await page.keyboard.press('F8');
+    await expect(peekMessage).toBeVisible({ timeout: 15_000 });
+    await expect(peekMessage).toContainText(FIRST_MARKER_MESSAGE);
+    await expect(page.locator('.monaco-editor .peekview-title')).toContainText('of 2');
+
+    // 4. Press F8 again -> advance to the second marker (line 4, endif). The same
+    //    announcement element now reads the next marker's message.
+    await page.keyboard.press('F8');
+    await expect(peekMessage).toContainText(SECOND_MARKER_MESSAGE);
+
+    // 5. Press Shift+F8 -> move BACK to the first marker. Announcement reverts.
+    await page.keyboard.press('Shift+F8');
+    await expect(peekMessage).toContainText(FIRST_MARKER_MESSAGE);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, 'tests/**'],
     globals: true,
-    setupFiles: ['./src/setupTests.ts']
-  }
+    setupFiles: ['./src/setupTests.ts'],
+  },
 });


### PR DESCRIPTION
## Summary
- focus the Monaco editor deterministically when an editor document loads, without timer-based focus grabs or save-time refocus
- set Monaco accessibilityPageSize to 500 so full MOO verbs are available to screen readers
- keep the MOO problems region mounted with an empty state to avoid tab-order churn
- add a Playwright proof for F8 / Shift+F8 marker navigation, while excluding Playwright specs from Vitest discovery

## Verification
- npm test
- npm test -- --run src
- npm run typecheck
- npx biome check vitest.config.ts
- git diff --check
- precommit hook on cf66c73: npm run typecheck && npm run lint:staged