### PR TITLE
[codex] Typed protocol registry cleanup

### DIFF
--- a/docs/GMCP/README.md
+++ b/docs/GMCP/README.md
@@ -33,13 +33,13 @@ server may use.
 
 ## Source of Truth
 
-The implementation source is `src/gmcp/`. The runtime registration list is
-`src/createConfiguredClient.ts`, and the dispatch path is `src/client.ts` plus
-`src/telnet.ts`.
+The implementation source is `src/gmcp/`. Default runtime registration and
+application event wiring live in `src/createConfiguredClient.ts`; telnet GMCP
+framing is parsed by `src/telnet.ts` and dispatched by `src/gmcp/session.ts`.
 
 GMCP message names are matched by splitting the incoming package string at the
-last dot. For example, `Client.Media.Play` dispatches to the `Client.Media`
-package and calls `handlePlay(data)`. Multi-word wire names are therefore
-implemented exactly as handler suffixes, such as `handleBind_all` for
-`Client.Keystrokes.Bind_all` and `handleroom_token` for
-`Comm.LiveKit.room_token`.
+last dot. For example, `Client.Media.Play` dispatches to the registered
+`Client.Media` package and then to that package's class-local message registry.
+The registry entry owns the wire suffix, direction, payload codec, default
+package-local event name, and generated outbound `sendX` method. Application
+events are wired from those package-local events outside the protocol package.

--- a/docs/GMCP/package-inventory.md
+++ b/docs/GMCP/package-inventory.md
@@ -1,7 +1,8 @@
 # Package Inventory
 
 This inventory is based on `src/createConfiguredClient.ts`, `src/gmcp/index.ts`,
-and `src/gmcp/types.ts`.
+and `src/gmcp/types.ts`. `createConfiguredClient()` is the default runtime
+registration path and wires package-local events to application events.
 
 ## Registered Packages
 
@@ -64,4 +65,3 @@ The upstream archive also contains package families that this client does not
 currently implement, including `beip`, `config`, `external.discord`,
 `gmcp.overland`, `loci.hotkey`, `loci.menu`, `MSDP`, `mudstandards.*`,
 `tilemap`, and `webview`.
-

--- a/docs/GMCP/packages/client-keystrokes.md
+++ b/docs/GMCP/packages/client-keystrokes.md
@@ -62,8 +62,8 @@ Removes bindings with the same key and exact modifier set.
 
 ### `Client.Keystrokes.Bind_all`
 
-Replaces the complete binding list. The wire suffix is `Bind_all` because the
-handler is `handleBind_all`.
+Replaces the complete binding list. The registry keeps the wire suffix as
+`Bind_all` and derives the package-local event name `bindAll`.
 
 ```json
 {
@@ -129,4 +129,3 @@ field text and waits for the user.
 The live implementation listens to `document` `keydown`, prevents default
 browser behavior when a binding matches, and removes the event listener on
 package shutdown.
-

--- a/docs/GMCP/protocol-framing.md
+++ b/docs/GMCP/protocol-framing.md
@@ -27,7 +27,7 @@ or missing payloads are normalized to `{}` before `JSON.parse`. Outbound
 messages are sent through `GMCPPackage.sendData`, which serializes package data
 with `JSON.stringify`.
 
-## Dispatch
+## Registry Dispatch
 
 Incoming package names are split at the last dot:
 
@@ -36,17 +36,24 @@ Client.Media.Play -> package Client.Media, message Play
 Room.Info -> package Room, message Info
 ```
 
-The handler method name is `handle` plus the exact message suffix. This makes
-case and punctuation matter in the implementation even though public GMCP names
-are generally treated as case-insensitive by servers and clients.
+`GmcpSession` looks up the registered package instance by package name, then
+delivers the message suffix to that package's class-local message registry.
+The registry defines the wire suffix, direction, payload codec, default
+package-local event name, and generated outbound `sendX` method.
 
 Examples:
 
-- `Core.Ping` -> `GMCPCore.handlePing`
-- `Room.AddPlayer` -> `GMCPRoom.handleAddPlayer`
-- `Client.Media.ChainStop` -> `GMCPClientMedia.handleChainStop`
-- `Client.Keystrokes.Bind_all` -> `GMCPClientKeystrokes.handleBind_all`
-- `Comm.LiveKit.room_token` -> `GMCPCommLiveKit.handleroom_token`
+- `Core.Ping` is delivered to the `Core` package's `Ping` registry entry and
+  emits the package-local `ping` event.
+- `Room.AddPlayer` is delivered to `Room` and emits `addPlayer`.
+- `Client.Keystrokes.Bind_all` is delivered to `Client.Keystrokes` and emits
+  `bindAll`.
+- `Comm.LiveKit.room_token` is delivered to `Comm.LiveKit` and emits
+  `roomToken`.
+
+Package constructors may listen to their own package-local events for protocol
+translation or local state updates. Application events and UI/service wiring
+are attached outside protocol packages, primarily in `createConfiguredClient`.
 
 ## Startup Negotiation
 
@@ -69,4 +76,3 @@ remove their support with `Core.Supports.Add` and `Core.Supports.Remove`.
 - Invalid JSON is logged and not delivered to the handler.
 - `sendGmcp` always writes a space before the payload argument, so callers
   should pass a serialized value when a body is required.
-

--- a/docs/GMCP/protocol-framing.md
+++ b/docs/GMCP/protocol-framing.md
@@ -55,6 +55,23 @@ Package constructors may listen to their own package-local events for protocol
 translation or local state updates. Application events and UI/service wiring
 are attached outside protocol packages, primarily in `createConfiguredClient`.
 
+## Service Integration Boundary
+
+Protocol packages do not emit global application events. Some packages still
+call concrete client-owned services because package-local I/O is not sufficient
+for those behaviors:
+
+- `GMCPPackage.sendData` uses the GMCP session transport to write outbound wire
+  messages.
+- `Core`, `Client.Midi`, and `Client.Haptics` inspect `Core.Supports` for
+  support advertisement.
+- `Client.Media`, `Client.Spatial`, and `IRE.Sound` drive the shared media
+  service.
+- `Client.Keystrokes` and `IRE.Composer` send ordinary text commands.
+
+Those are service integrations, not package output events. Moving them behind
+smaller service-specific dependencies is a separate service-boundary refactor.
+
 ## Startup Negotiation
 
 When GMCP becomes ready, `MudClient` sends:

--- a/docs/protocol-io-registry-workstream.md
+++ b/docs/protocol-io-registry-workstream.md
@@ -1,0 +1,370 @@
+# MCP/GMCP Typed I/O Registry Workstream
+
+## Target Architecture
+
+Protocol packages declare their wire I/O in a typed message registry on the class.
+The registry is the single source of truth for:
+
+- protocol message name;
+- direction: inbound, outbound, or duplex;
+- payload codec/envelope;
+- generated outbound command methods such as `sendOffer`;
+- package-local typed events for inbound messages.
+
+The package class remains the visible owner. The session remains protocol
+mechanics. App wiring stays in the composition root.
+
+```ts
+class GMCPClientFileTransfer extends GMCPPackage.with({
+  packageName: "Client.FileTransfer",
+  messages: [
+    inbound(FileTransferOffer),
+    inbound(FileTransferAccept),
+    duplex(FileTransferCancel),
+    outbound(FileTransferRequestResend),
+  ],
+}) {}
+
+fileTransfer.on("offer", (offer) => {
+  fileTransferManager.handleOffer(offer);
+});
+
+fileTransfer.sendRequestResend({ sender, hash });
+```
+
+For MCP:
+
+```ts
+class McpSimpleEdit extends MCPPackage.with({
+  packageName: "dns-org-mud-moo-simpleedit",
+  messages: [
+    inbound(simpleEditContent).asEvent("openSession"),
+    outbound(simpleEditSet),
+  ],
+}) {}
+
+simpleEdit.on("openSession", (session) => {
+  editors.openEditorWindow(session);
+});
+
+simpleEdit.sendSet(session);
+```
+
+## Hard Rules
+
+- Do not add `EditorSessionSaver`, `McpPackageSender`, generic protocol emitters,
+  sender bags, compatibility interfaces, or other wrappers.
+- Do not make `McpSimpleEdit` special. It stays in `DEFAULT_MCP_PACKAGES`.
+- Do not make MCP/GMCP sessions app event buses.
+- Do not put global app `emit` or app callbacks into package context.
+- Do not preserve old and new paths in parallel after a slice completes.
+- When a slice says deletion-first, delete the old surface before repairing
+  callers.
+
+## Ownership Boundaries
+
+`McpSession` / `GmcpSession` own:
+
+- connection to the lower protocol framing layer;
+- registry of package instances;
+- package lookup by constructor/name;
+- inbound dispatch to package message registries;
+- outbound wire framing.
+
+`MCPPackage` / `GMCPPackage` own:
+
+- package identity;
+- class-level typed message registry;
+- package-local typed event emitter derived from inbound/duplex registry entries;
+- generated outbound methods derived from outbound/duplex registry entries.
+
+Concrete packages own:
+
+- message envelope values used by their registry;
+- any genuinely semantic methods that are not just generated wire commands;
+- package-specific policy only when that policy is protocol translation.
+
+Composition root owns:
+
+- wiring package events to application services/stores/components;
+- passing concrete package instances to consumers that need outbound commands;
+- default package registration.
+
+## Message Envelopes
+
+An envelope is a value-level protocol message definition. It is not the payload
+interface alone.
+
+GMCP JSON message envelope:
+
+```ts
+const FileTransferOffer = gmcpJsonMessage("Offer", fileTransferOfferCodec);
+```
+
+The envelope carries:
+
+- wire suffix: `Offer`;
+- runtime codec;
+- TypeScript payload type from the codec;
+- default event name: `offer`;
+- default outbound method name: `sendOffer`.
+
+MCP multiline message envelope:
+
+```ts
+const simpleEditContent = mcpMultilineMessage("content", {
+  header: editorSessionHeader,
+  bodyKey: "content",
+  toDomain: ({ header, lines }): EditorSession => ({
+    ...header,
+    contents: lines,
+  }),
+});
+```
+
+MCP envelopes carry more mechanics:
+
+- wire suffix;
+- key/value header codec;
+- multiline body key;
+- multiline domain conversion;
+- outbound key/value and line encoders where applicable.
+
+Direction is not part of the payload envelope. Direction is assigned in the
+package registry:
+
+```ts
+messages: [
+  inbound(simpleEditContent).asEvent("openSession"),
+  outbound(simpleEditSet),
+]
+```
+
+## Type Strategy
+
+Use class factories/mixins rather than codegen.
+
+Reason: runtime codegen can add `sendOffer`, but source typing only stays
+natural if the class extends a generic constructor derived from the registry
+value in the same source file.
+
+Required type behavior:
+
+- inbound `Offer` produces `on("offer", listener: (payload: OfferPayload) => void)`;
+- outbound `Offer` produces `sendOffer(payload: OfferPayload): void`;
+- duplex `Cancel` produces both `on("cancel", ...)` and `sendCancel(...)`;
+- MCP override `asEvent("openSession")` changes only the event name, not the
+  payload type.
+
+Collision handling must be explicit:
+
+- duplicate wire names fail package construction;
+- duplicate generated event names fail package construction;
+- duplicate generated send method names fail package construction;
+- generated method cannot silently overwrite a concrete class method.
+
+## Work Slices
+
+### Slice 1: Registry Kernel, No Package Migration
+
+Goal: add the typed registry machinery behind existing packages without changing
+package behavior.
+
+Create:
+
+- `src/protocol/messages.ts` or protocol-local equivalents if the existing
+  layout makes that cleaner;
+- direction wrappers: `inbound`, `outbound`, `duplex`;
+- name derivation helpers: wire name to event name and send method name;
+- typed package-local emitter base;
+- `MCPPackage.with(...)` and/or `GMCPPackage.with(...)` factory for one protocol
+  first.
+
+Do not migrate production packages in this slice.
+
+Search gates:
+
+- no production package uses the new registry yet unless the slice explicitly
+  migrates it;
+- no `EditorSessionSaver`;
+- no `McpPackageSender`.
+
+Runtime gates:
+
+- focused unit tests for name derivation, event typing/runtime dispatch, command
+  method generation, and collision errors;
+- `npm run typecheck`;
+- Biome lint on touched files.
+
+Commit when gates pass.
+
+### Slice 2: MCP SimpleEdit Vertical Slice
+
+Goal: prove MCP multiline inbound/outbound through the registry.
+
+Actions:
+
+- define top-level `simpleEditContent` and `simpleEditSet` envelopes;
+- migrate `McpSimpleEdit` to `MCPPackage.with(...)`;
+- keep `McpSimpleEdit` in `DEFAULT_MCP_PACKAGES`;
+- add package lookup if needed so composition can obtain the default registered
+  package instance;
+- wire `simpleEdit.on("openSession", ...)` in the composition root;
+- update `EditorManager` to take concrete `McpSimpleEdit` and call
+  `sendSet(session)`;
+- delete old `context.openEditorSession`, `context.sendMcp`, and
+  `context.sendMcpMultiline` surfaces if this slice fully removes their MCP use.
+
+Search gates:
+
+- `rg -n "EditorSessionSaver|McpPackageSender|context\\.send|sendMcp|sendMcpMultiline|context\\.openEditorSession" src/mcp src/EditorManager.ts src/client.ts src/createConfiguredClient.ts`
+  has zero production hits;
+- `rg -n "McpSimpleEdit" src/mcp/packages/index.ts` still shows default
+  registration;
+- `rg -n "new EditorManager\\(this\\)|client\\.mcpSession\\.sendMultiline" src`
+  has zero production hits.
+
+Runtime gates:
+
+- `npm test -- --run src/mcp.test.ts src/EditorManager.test.ts src/client.test.ts`;
+- `npm run typecheck`;
+- Biome lint on touched files.
+
+Commit when gates pass.
+
+### Slice 3: Remaining MCP Packages
+
+Goal: remove remaining global app emit/context behavior from MCP.
+
+Actions:
+
+- migrate `McpAwnsStatus`, `McpAwnsGetSet`, and `McpVmooUserlist` to package
+  registries and package-local typed events;
+- wire their events in the composition root or current client owner;
+- update outbound get/set commands to generated methods.
+
+Search gates:
+
+- zero production hits for `context.emit`, `context.send`, `sendMcp`,
+  `sendMcpMultiline`, and `openEditorSession` under `src/mcp`;
+- no session-wide typed app event bus introduced.
+
+Runtime gates:
+
+- MCP focused tests;
+- client tests that cover emitted status/getset/userlist behavior;
+- `npm run typecheck`;
+- Biome lint on touched files.
+
+Commit when gates pass.
+
+### Slice 4: GMCP FileTransfer Vertical Slice
+
+Goal: prove GMCP JSON registry on a package with meaningful inbound and outbound
+I/O.
+
+Actions:
+
+- define GMCP JSON envelopes for `Client.FileTransfer` messages;
+- migrate `GMCPClientFileTransfer` to `GMCPPackage.with(...)`;
+- generated methods replace handwritten `sendOffer`, `sendCancel`,
+  `sendRequestResend`, etc., unless a semantic wrapper is still genuinely more
+  readable;
+- replace package-local manual emitter boilerplate with registry-derived events;
+- keep `FileTransferManager` depending on the concrete package instance.
+
+Search gates:
+
+- no `(handler as any)["handle" + ...]` path for migrated package;
+- no duplicated file-transfer event emitter boilerplate in the package;
+- no broad `MudClient` dependency added to replace removed behavior.
+
+Runtime gates:
+
+- `npm test -- --run src/gmcp/session.test.ts src/FileTransferManager.test.ts src/client.test.ts`;
+- `npm run typecheck`;
+- Biome lint on touched files.
+
+Commit when gates pass.
+
+### Slice 5: GMCP Session Dispatch Migration
+
+Goal: make GMCP dispatch table-driven from message registries.
+
+Actions:
+
+- session dispatch consults package registry metadata first;
+- fallback reflection dispatch is deleted once all registered GMCP packages in
+  scope have registries;
+- dynamic/legacy reflection is not preserved unless an explicit external
+  compatibility constraint is named.
+
+Search gates:
+
+- zero production hits for `resolveGmcpMessageHandler` if fully replaced;
+- zero production hits for `(handler as any)`;
+- no `any`-based handler lookup introduced under another name.
+
+Runtime gates:
+
+- all GMCP focused tests;
+- `npm test -- --run src/gmcp src/client.test.ts`;
+- `npm run typecheck`;
+- Biome lint on touched files.
+
+Commit when gates pass.
+
+### Slice 6: Broad Protocol Cleanup
+
+Goal: converge both protocols on the same I/O contract.
+
+Actions:
+
+- eliminate remaining protocol package dependencies on `MudClient` unless they
+  are explicitly outside the current workstream and documented;
+- move app side effects to composition wiring;
+- update protocol docs to describe registry-based I/O.
+
+Search gates:
+
+- no global app `emit` in protocol packages;
+- no broad client context in protocol packages where package-local I/O suffices;
+- no duplicate default registration path.
+
+Runtime gates:
+
+- `npm test -- --run src`;
+- `npm run typecheck`;
+- Biome lint on touched files;
+- `git diff --check`.
+
+Commit when gates pass.
+
+## Definition Of Done
+
+The workstream is complete only when:
+
+- MCP and GMCP package I/O use class-local typed registries;
+- inbound messages produce package-local typed events by default;
+- outbound/duplex messages produce typed `sendX` methods by default;
+- event and method names are derived from message names unless explicitly
+  overridden for a semantic reason;
+- `McpSimpleEdit` remains a default MCP package;
+- sessions are not app event buses;
+- package contexts do not smuggle app powers or send helpers;
+- old reflection/stringly dispatch is gone for the migrated protocol surface;
+- all listed search gates are zero-hit or documented as intentionally deferred;
+- runtime gates pass;
+- each completed slice has its own commit.
+
+## Anti-Loopholes
+
+- A new interface that only hides the old dependency is a shim and is forbidden.
+- A sender object is a renamed context send helper and is forbidden.
+- A session-level typed event bus is a centralized app event bus and is
+  forbidden for package outputs.
+- Moving `McpSimpleEdit` out of default registration is special-casing and is
+  forbidden.
+- Green tests do not complete a slice while forbidden search gates still hit.
+- Do not continue to the next slice before committing the current verified
+  slice.

--- a/src/EditorManager.test.ts
+++ b/src/EditorManager.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EditorManager } from './EditorManager';
-import type MudClient from './client';
-import type { EditorSession } from './mcp';
+import type { EditorSession, McpSimpleEdit } from './mcp';
 
 type MockBroadcastChannel = {
   close: ReturnType<typeof vi.fn>;
@@ -31,16 +30,14 @@ function dispatchEditorMessage(channel: MockBroadcastChannel, data: unknown): vo
 
 describe('EditorManager', () => {
   let editorManager: EditorManager;
-  let mockClient: MudClient;
+  let mockSimpleEdit: McpSimpleEdit;
   let mockBroadcastChannel: MockBroadcastChannel;
   let mockWindow: MockEditorWindow;
 
   beforeEach(() => {
-    mockClient = {
-      mcpSession: {
-        sendMultiline: vi.fn(),
-      },
-    } as unknown as MudClient;
+    mockSimpleEdit = {
+      sendSet: vi.fn(),
+    } as unknown as McpSimpleEdit;
 
     mockWindow = {
       focus: vi.fn(),
@@ -59,7 +56,7 @@ describe('EditorManager', () => {
       vi.fn().mockImplementation(() => mockBroadcastChannel),
     );
 
-    editorManager = new EditorManager(mockClient);
+    editorManager = new EditorManager(mockSimpleEdit);
   });
 
   afterEach(() => {
@@ -85,22 +82,19 @@ describe('EditorManager', () => {
     expect(mockWindow.focus).toHaveBeenCalledOnce();
   });
 
-  it('saves editor window content through the MCP session', () => {
+  it('saves editor window content through SimpleEdit', () => {
     editorManager.saveEditorWindow(
       createSession({
         contents: ['Updated content'],
       }),
     );
 
-    expect(mockClient.mcpSession.sendMultiline).toHaveBeenCalledWith(
-      'dns-org-mud-moo-simpleedit-set',
-      {
-        reference: 'test-ref',
-        type: 'text/plain',
-        'content*': '',
-      },
-      ['Updated content'],
-    );
+    expect(mockSimpleEdit.sendSet).toHaveBeenCalledWith({
+      reference: 'test-ref',
+      type: 'text/plain',
+      contents: ['Updated content'],
+      name: 'test.txt',
+    });
   });
 
   it('loads a session after an editor window announces readiness', () => {

--- a/src/EditorManager.ts
+++ b/src/EditorManager.ts
@@ -1,5 +1,4 @@
-import type MudClient from './client';
-import type { EditorSession } from './mcp';
+import type { EditorSession, McpSimpleEdit } from './mcp';
 
 enum EditorState {
   Pending,
@@ -16,7 +15,7 @@ export class EditorManager {
   private editors: Map<string, WindowedSession>;
   private channel: BroadcastChannel;
 
-  constructor(private client: MudClient) {
+  constructor(private simpleEdit: McpSimpleEdit) {
     this.editors = new Map();
     this.channel = new BroadcastChannel('editor');
     this.setupChannelListeners();
@@ -50,16 +49,7 @@ export class EditorManager {
   }
 
   saveEditorWindow(editorSession: EditorSession) {
-    const keyvals = {
-      reference: editorSession.reference,
-      type: editorSession.type,
-      'content*': '',
-    };
-    this.client.mcpSession.sendMultiline(
-      'dns-org-mud-moo-simpleedit-set',
-      keyvals,
-      editorSession.contents,
-    );
+    this.simpleEdit.sendSet(editorSession);
   }
 
   private setupChannelListeners() {

--- a/src/FileTransferManager.ts
+++ b/src/FileTransferManager.ts
@@ -86,7 +86,10 @@ export default class FileTransferManager extends EventEmitter {
   };
   private readonly handleLocalIceCandidate = (candidate: RTCIceCandidate): void => {
     if (this.webRTCService.recipient) {
-      this.gmcpFileTransfer.sendCandidate(this.webRTCService.recipient, candidate);
+      this.gmcpFileTransfer.sendCandidate({
+        recipient: this.webRTCService.recipient,
+        candidate: JSON.stringify(candidate),
+      });
     }
   };
 
@@ -158,13 +161,13 @@ export default class FileTransferManager extends EventEmitter {
       const offer = await this.webRTCService.createOffer();
 
       console.log(`[FileTransferManager] Sending offer for file: ${file.name}`);
-      await this.gmcpFileTransfer.sendOffer(
+      await this.gmcpFileTransfer.sendOffer({
         recipient,
-        file.name,
-        file.size,
-        JSON.stringify(offer),
-        fileHash,
-      );
+        filename: file.name,
+        filesize: file.size,
+        offerSdp: JSON.stringify(offer),
+        hash: fileHash,
+      });
 
       // Wait for connection to be established
       await this.webRTCService.waitForConnection();
@@ -580,7 +583,10 @@ export default class FileTransferManager extends EventEmitter {
         await this.startFileTransfer(savedOutgoingTransfer.file, savedOutgoingTransfer.hash);
       } else if (direction === 'receive' && savedIncomingTransfer) {
         // Notify the sender to resend the offer
-        this.gmcpFileTransfer.sendRequestResend(savedIncomingTransfer.sender, hash);
+        this.gmcpFileTransfer.sendRequestResend({
+          sender: savedIncomingTransfer.sender,
+          hash,
+        });
       }
     } catch (error) {
       console.error('Failed to recover connection:', error);
@@ -683,7 +689,7 @@ export default class FileTransferManager extends EventEmitter {
           );
       }
       this.emitCancellation(useSessionStore.getState().playerId, hash);
-      this.gmcpFileTransfer.sendCancel(recipient, hash);
+      this.gmcpFileTransfer.sendCancel({ recipient, hash });
     } else {
       console.log(`[FileTransferManager] No active transfer found for hash: ${hash}`);
     }
@@ -729,12 +735,12 @@ export default class FileTransferManager extends EventEmitter {
 
       // Send accept only if we're still in a valid state
       if (this.pendingOffers.has(hash)) {
-        await this.gmcpFileTransfer.sendAccept(
+        await this.gmcpFileTransfer.sendAccept({
           sender,
           hash,
-          offer.filename,
-          JSON.stringify(answer),
-        );
+          filename: offer.filename,
+          answerSdp: JSON.stringify(answer),
+        });
 
         // Wait for the data channel to open
         await this.waitForDataChannel(hash);
@@ -756,7 +762,7 @@ export default class FileTransferManager extends EventEmitter {
 
   rejectTransfer(sender: string, hash: string): void {
     this.pendingOffers.delete(hash);
-    this.gmcpFileTransfer.sendReject(sender, hash);
+    this.gmcpFileTransfer.sendReject({ sender, hash });
   }
 
   private getCancelRecipient(hash: string): string {

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -263,9 +263,11 @@ describe('MudClient lifecycle cleanup', () => {
     const client = new MudClient('example.test', 443);
     const handleSessionReady = vi.fn();
     client.on('sessionReady', handleSessionReady);
+    const onMock = vi.mocked(client.gmcp_char.on);
+    const nameListener = onMock.mock.calls.find(([event]) => event === "name")?.[1];
 
-    client.gmcp.markSessionReady();
-    client.gmcp.markSessionReady();
+    nameListener?.({ fullname: "Q", name: "q" });
+    nameListener?.({ fullname: "Q", name: "q" });
 
     expect(client.gmcp.sessionReady).toBe(true);
     expect(handleSessionReady).toHaveBeenCalledOnce();

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -135,11 +135,7 @@ vi.mock('./mcp', () => ({
     shutdown = vi.fn();
 
     registerPackage = vi.fn((PackageConstructor) => {
-      const mcpPackage = new PackageConstructor({
-        emit: vi.fn(),
-        openEditorSession: vi.fn(),
-        sendMcp: vi.fn(),
-      });
+      const mcpPackage = new PackageConstructor();
       this.packageHandlers[mcpPackage.packageName] = mcpPackage;
       return mcpPackage;
     });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -139,6 +139,7 @@ vi.mock('./mcp', () => ({
 }));
 
 import MudClient from './client';
+import { GMCPClientFileTransfer } from './gmcp';
 
 class MockWebSocket {
   static CONNECTING = 0;
@@ -256,6 +257,9 @@ describe('MudClient lifecycle cleanup', () => {
 
   it('preserves GMCP transport until file transfer cleanup completes', () => {
     const client = new MudClient('example.test', 443);
+    client.configureFileTransfer(
+      client.gmcp.register(GMCPClientFileTransfer as never),
+    );
     client.connect();
     const cleanupOrder: string[] = [];
     const fileTransferManager = mockFileTransferManagerInstances[0];

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -182,7 +182,7 @@ class MockCoreSupportsPackage {
 class MockAutoLoginPackage {
   packageName = 'Auth.Autologin';
   packageVersion = 1;
-  sendLogin = vi.fn();
+  sendStoredLogin = vi.fn();
 }
 
 class MockClientMediaPackage {

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -175,6 +175,7 @@ class MockCorePackage {
 class MockCoreSupportsPackage {
   packageName = 'Core.Supports';
   packageVersion = 1;
+  advertisedModules = vi.fn(() => ['Core 1', 'Core.Supports 1']);
   sendSet = vi.fn();
 }
 
@@ -187,7 +188,7 @@ class MockAutoLoginPackage {
 class MockClientMediaPackage {
   packageName = 'Client.Media';
   packageVersion = 1;
-  sendEffectsSupport = vi.fn();
+  publishEffectsSupport = vi.fn();
 }
 
 function sendSocketText(socket: MockWebSocket, text: string): void {

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -104,11 +104,6 @@ vi.mock('./gmcp', async () => {
   const actual = await vi.importActual<typeof import('./gmcp')>('./gmcp');
   return {
     ...actual,
-    GMCPChar: class {
-      packageName = 'Char';
-      on = vi.fn();
-      shutdown = vi.fn();
-    },
     GMCPClientFileTransfer: class {
       packageName = 'Client.FileTransfer';
       sendReject = vi.fn();
@@ -257,20 +252,6 @@ describe('MudClient lifecycle cleanup', () => {
 
     expect(client.gmcp.ready).toBe(true);
     expect(handleGmcpReady).toHaveBeenCalledOnce();
-  });
-
-  it('emits sessionReady only once', () => {
-    const client = new MudClient('example.test', 443);
-    const handleSessionReady = vi.fn();
-    client.on('sessionReady', handleSessionReady);
-    const onMock = vi.mocked(client.gmcp_char.on);
-    const nameListener = onMock.mock.calls.find(([event]) => event === "name")?.[1];
-
-    nameListener?.({ fullname: "Q", name: "q" });
-    nameListener?.({ fullname: "Q", name: "q" });
-
-    expect(client.gmcp.sessionReady).toBe(true);
-    expect(handleSessionReady).toHaveBeenCalledOnce();
   });
 
   it('preserves GMCP transport until file transfer cleanup completes', () => {

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -106,6 +106,7 @@ vi.mock('./gmcp', async () => {
     ...actual,
     GMCPChar: class {
       packageName = 'Char';
+      on = vi.fn();
       shutdown = vi.fn();
     },
     GMCPClientFileTransfer: class {

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,7 +11,12 @@ import { EventEmitter } from "eventemitter3";
 import stripAnsi from "strip-ansi";
 import { EditorManager } from "./EditorManager";
 import { GMCPChar, GMCPClientFileTransfer, GmcpSession } from "./gmcp";
-import { type MCPPackage, type McpPackageContext, McpSession } from "./mcp";
+import {
+  type MCPPackage,
+  type McpPackageContext,
+  type McpSimpleEdit,
+  McpSession,
+} from "./mcp";
 
 import { MediaService } from "./audio/MediaService";
 import { AutoreadMode, usePreferences } from "./stores/preferencesStore";
@@ -54,7 +59,7 @@ class MudClient extends EventEmitter {
   public gmcp_char: GMCPChar;
   public gmcp_fileTransfer: GMCPClientFileTransfer;
   public media: MediaService;
-  public editors: EditorManager;
+  public editors?: EditorManager;
   public webRTCService: WebRTCService;
   public fileTransferManager: FileTransferManager;
   private _autosay: boolean = false;
@@ -76,14 +81,12 @@ class MudClient extends EventEmitter {
     this.port = port;
     this.mcpSession = new McpSession({
       emit: (event, ...args) => this.emit(event, ...args),
-      openEditorSession: (session) => this.editors.openEditorWindow(session),
       sendLine: (line) => this.send(`${line}\r\n`),
     });
     this.gmcp = new GmcpSession(this);
     this.gmcp_char = this.gmcp.register(GMCPChar);
     this.gmcp_fileTransfer = this.gmcp.register(GMCPClientFileTransfer);
     this.media = new MediaService();
-    this.editors = new EditorManager(this);
     this.webRTCService = new WebRTCService();
     this.fileTransferManager = new FileTransferManager(
       this.webRTCService,
@@ -95,6 +98,13 @@ class MudClient extends EventEmitter {
     p: new (_: McpPackageContext) => P,
   ): P {
     return this.mcpSession.registerPackage(p);
+  }
+
+  configureEditors(simpleEdit: McpSimpleEdit): void {
+    this.editors = new EditorManager(simpleEdit);
+    simpleEdit.on("openSession", (session) => {
+      this.editors?.openEditorWindow(session);
+    });
   }
 
   public connect() {
@@ -335,7 +345,7 @@ An MCP message consists of three parts: the name of the message, the authenticat
     this.mcpSession.shutdown();
     this.gmcp.shutdown();
     this.media.shutdown();
-    this.editors.shutdown();
+    this.editors?.shutdown();
     this.close();
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import { Buffer } from "buffer";
 import { EventEmitter } from "eventemitter3";
 import stripAnsi from "strip-ansi";
 import { EditorManager } from "./EditorManager";
-import { GMCPClientFileTransfer, GmcpSession } from "./gmcp";
+import { type GMCPClientFileTransfer, GmcpSession } from "./gmcp";
 import {
   type MCPPackage,
   type McpSimpleEdit,
@@ -55,11 +55,11 @@ class MudClient extends EventEmitter {
   private telnetBuffer: string = "";
   public readonly gmcp: GmcpSession;
   public readonly mcpSession: McpSession;
-  public gmcp_fileTransfer: GMCPClientFileTransfer;
+  public gmcp_fileTransfer!: GMCPClientFileTransfer;
   public media: MediaService;
   public editors?: EditorManager;
   public webRTCService: WebRTCService;
-  public fileTransferManager: FileTransferManager;
+  public fileTransferManager!: FileTransferManager;
   private _autosay: boolean = false;
   private connectionCleanupComplete: boolean = true;
   private shutdownComplete: boolean = false;
@@ -81,9 +81,12 @@ class MudClient extends EventEmitter {
       sendLine: (line) => this.send(`${line}\r\n`),
     });
     this.gmcp = new GmcpSession(this);
-    this.gmcp_fileTransfer = this.gmcp.register(GMCPClientFileTransfer);
     this.media = new MediaService();
     this.webRTCService = new WebRTCService();
+  }
+
+  configureFileTransfer(fileTransfer: GMCPClientFileTransfer): void {
+    this.gmcp_fileTransfer = fileTransfer;
     this.fileTransferManager = new FileTransferManager(
       this.webRTCService,
       this.gmcp_fileTransfer,
@@ -254,7 +257,7 @@ class MudClient extends EventEmitter {
     this.telnetBuffer = "";
     useRoomStore.getState().reset(); // Reset room info on cleanup
     useSpatialStore.getState().reset(); // Reset spatial scene on cleanup
-    this.fileTransferManager.cleanup();
+    this.fileTransferManager?.cleanup();
     this.gmcp.reset();
     useLiveKitStore.getState().reset();
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -83,9 +83,12 @@ class MudClient extends EventEmitter {
     });
     this.gmcp = new GmcpSession(this);
     this.gmcp_char = this.gmcp.register(GMCPChar);
-    this.gmcp_char.on("name", (data) =>
-      this.emit("statustext", `Logged in as ${data.fullname}`),
-    );
+    this.gmcp_char.on("name", (data) => {
+      this.emit("statustext", `Logged in as ${data.fullname}`);
+      if (this.gmcp.markSessionReady()) {
+        this.emit("sessionReady");
+      }
+    });
     this.gmcp_char.on("vitals", (data) => this.emit("vitals", data));
     this.gmcp_char.on("statusVars", (data) =>
       this.emit("statusVars", data),
@@ -138,7 +141,9 @@ class MudClient extends EventEmitter {
       if (command === TelnetCommand.WILL && option === TelnetOption.GMCP) {
         console.log("GMCP Negotiation");
         this.telnet.sendNegotiation(TelnetCommand.DO, TelnetOption.GMCP);
-        this.gmcp.start();
+        if (this.gmcp.start()) {
+          this.emit("gmcpReady");
+        }
       } else if (
         command === TelnetCommand.DO &&
         option === TelnetOption.TERMINAL_TYPE
@@ -203,7 +208,9 @@ class MudClient extends EventEmitter {
       if (command === TelnetCommand.WILL && option === TelnetOption.GMCP) {
         console.log("GMCP Negotiation (local)");
         this.telnet.sendNegotiation(TelnetCommand.DO, TelnetOption.GMCP);
-        this.gmcp.start();
+        if (this.gmcp.start()) {
+          this.emit("gmcpReady");
+        }
       } else if (
         command === TelnetCommand.DO &&
         option === TelnetOption.TERMINAL_TYPE
@@ -238,7 +245,9 @@ class MudClient extends EventEmitter {
     resetMidiIntentionalDisconnectFlags();
     this.emit("connect");
     this.emit("connectionChange", true);
-    this.gmcp.markReady();
+    if (this.gmcp.markReady()) {
+      this.emit("gmcpReady");
+    }
   }
 
   public send(data: string) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import { Buffer } from "buffer";
 import { EventEmitter } from "eventemitter3";
 import stripAnsi from "strip-ansi";
 import { EditorManager } from "./EditorManager";
-import { GMCPChar, GMCPClientFileTransfer, GmcpSession } from "./gmcp";
+import { GMCPClientFileTransfer, GmcpSession } from "./gmcp";
 import {
   type MCPPackage,
   type McpSimpleEdit,
@@ -55,7 +55,6 @@ class MudClient extends EventEmitter {
   private telnetBuffer: string = "";
   public readonly gmcp: GmcpSession;
   public readonly mcpSession: McpSession;
-  public gmcp_char: GMCPChar;
   public gmcp_fileTransfer: GMCPClientFileTransfer;
   public media: MediaService;
   public editors?: EditorManager;
@@ -82,18 +81,6 @@ class MudClient extends EventEmitter {
       sendLine: (line) => this.send(`${line}\r\n`),
     });
     this.gmcp = new GmcpSession(this);
-    this.gmcp_char = this.gmcp.register(GMCPChar);
-    this.gmcp_char.on("name", (data) => {
-      this.emit("statustext", `Logged in as ${data.fullname}`);
-      if (this.gmcp.markSessionReady()) {
-        this.emit("sessionReady");
-      }
-    });
-    this.gmcp_char.on("vitals", (data) => this.emit("vitals", data));
-    this.gmcp_char.on("statusVars", (data) =>
-      this.emit("statusVars", data),
-    );
-    this.gmcp_char.on("status", (data) => this.emit("statusUpdate", data));
     this.gmcp_fileTransfer = this.gmcp.register(GMCPClientFileTransfer);
     this.media = new MediaService();
     this.webRTCService = new WebRTCService();

--- a/src/client.ts
+++ b/src/client.ts
@@ -83,6 +83,14 @@ class MudClient extends EventEmitter {
     });
     this.gmcp = new GmcpSession(this);
     this.gmcp_char = this.gmcp.register(GMCPChar);
+    this.gmcp_char.on("name", (data) =>
+      this.emit("statustext", `Logged in as ${data.fullname}`),
+    );
+    this.gmcp_char.on("vitals", (data) => this.emit("vitals", data));
+    this.gmcp_char.on("statusVars", (data) =>
+      this.emit("statusVars", data),
+    );
+    this.gmcp_char.on("status", (data) => this.emit("statusUpdate", data));
     this.gmcp_fileTransfer = this.gmcp.register(GMCPClientFileTransfer);
     this.media = new MediaService();
     this.webRTCService = new WebRTCService();

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,6 @@ import { EditorManager } from "./EditorManager";
 import { GMCPChar, GMCPClientFileTransfer, GmcpSession } from "./gmcp";
 import {
   type MCPPackage,
-  type McpPackageContext,
   type McpSimpleEdit,
   McpSession,
 } from "./mcp";
@@ -80,7 +79,6 @@ class MudClient extends EventEmitter {
     this.host = host;
     this.port = port;
     this.mcpSession = new McpSession({
-      emit: (event, ...args) => this.emit(event, ...args),
       sendLine: (line) => this.send(`${line}\r\n`),
     });
     this.gmcp = new GmcpSession(this);
@@ -94,9 +92,7 @@ class MudClient extends EventEmitter {
     );
   }
 
-  registerMcpPackage<P extends MCPPackage>(
-    p: new (_: McpPackageContext) => P,
-  ): P {
+  registerMcpPackage(p: new () => MCPPackage): MCPPackage {
     return this.mcpSession.registerPackage(p);
   }
 

--- a/src/components/RoomInfoDisplay.test.tsx
+++ b/src/components/RoomInfoDisplay.test.tsx
@@ -1,8 +1,8 @@
-import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "eventemitter3";
 
+import type MudClient from "../client";
 import RoomInfoDisplay from "./RoomInfoDisplay";
 import { useRoomStore } from "../stores/roomStore";
 
@@ -13,7 +13,7 @@ function createMockClient() {
     gmcp: {
       handlers: {
         "Char.Items": {
-          sendRoomRequest: vi.fn(),
+          sendRoom: vi.fn(),
         },
       },
     },
@@ -62,7 +62,7 @@ describe("RoomInfoDisplay", () => {
       roomPlayers: [{ name: "q", fullname: "Q" }],
     });
 
-    render(<RoomInfoDisplay client={client as any} />);
+    render(<RoomInfoDisplay client={client as unknown as MudClient} />);
 
     act(() => {
       client.emit("itemsList", {

--- a/src/components/RoomInfoDisplay.tsx
+++ b/src/components/RoomInfoDisplay.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useState, useMemo } from "react";
-import MudClient from "../client";
+import type React from "react";
+import { useCallback, useEffect, useState, useMemo } from "react";
+import type MudClient from "../client";
 import type { RoomPlayer } from "../gmcp/Room";
 import { useRoomStore } from "../stores/roomStore";
 import type { Item, ItemLocation } from "../gmcp/Char/Items";
@@ -37,8 +38,8 @@ const RoomInfoDisplay: React.FC<RoomInfoDisplayProps> = ({ client }) => {
   // Request the room's item list once on mount. Room info/players are now
   // subscribed from the room store above rather than fed by client events.
   useEffect(() => {
-    if (charItemsHandler?.sendRoomRequest) {
-      charItemsHandler.sendRoomRequest();
+    if (charItemsHandler) {
+      charItemsHandler.sendRoom("");
     }
   }, [charItemsHandler]);
 

--- a/src/components/SkillsDisplay.tsx
+++ b/src/components/SkillsDisplay.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import MudClient from '../client';
+import type React from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import type MudClient from '../client';
 import type { SkillGroupInfo, GMCPMessageCharSkillsList } from '../gmcp/Char/Skills';
 import './SkillsDisplay.css'; // We'll create this CSS file next
 
@@ -38,11 +39,11 @@ const SkillsDisplay: React.FC<SkillsDisplayProps> = ({ client }) => {
 
         // Fetch skills for the group if it's being expanded and not already loaded/loading
         if (newExpandedGroup === groupName && !skillsData[groupName]?.list && !skillsData[groupName]?.isLoading) {
-            if (charSkillsHandler?.sendGetRequest) {
+            if (charSkillsHandler) {
                 setSkillsData(prev => ({ ...prev, [groupName]: { group: groupName, list: [], isLoading: true } }));
-                charSkillsHandler.sendGetRequest(groupName);
+                charSkillsHandler.sendGet({ group: groupName });
             } else {
-                console.warn("Char.Skills handler or sendGetRequest method not found.");
+                console.warn("Char.Skills handler not found.");
             }
         }
     };
@@ -52,11 +53,11 @@ const SkillsDisplay: React.FC<SkillsDisplayProps> = ({ client }) => {
         client.on('skillList', handleList);
 
         // Request initial skill groups when component mounts
-        if (charSkillsHandler?.sendGetRequest) {
+        if (charSkillsHandler) {
             console.log("Requesting initial skill groups...");
-            charSkillsHandler.sendGetRequest(); // Request groups (no args)
+            charSkillsHandler.sendGet({});
         } else {
-            console.warn("Char.Skills handler or sendGetRequest method not found.");
+            console.warn("Char.Skills handler not found.");
         }
 
         return () => {

--- a/src/components/inventory.tsx
+++ b/src/components/inventory.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import type React from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type MudClient from '../client';
-import { Item, ItemLocation } from '../gmcp/Char/Items';
+import type { Item, ItemLocation } from '../gmcp/Char/Items';
 import InventoryList from './InventoryList';
 import './InventoryList.css'; // Styles for inventory tab, list, and card container
 import ItemCard from './ItemCard';
@@ -80,7 +81,7 @@ const Inventory: React.FC<InventoryProps> = ({ client }) => {
     client.on('itemRemove', handleRemove);
     client.on('itemUpdate', handleUpdate);
 
-    client.gmcp.handlers['Char.Items']?.sendInventoryRequest();
+    client.gmcp.handlers['Char.Items']?.sendInv("");
 
     return () => {
       client.off('itemsList', handleList);

--- a/src/createConfiguredClient.test.ts
+++ b/src/createConfiguredClient.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type MudClient from "./client";
+import { createConfiguredClient } from "./createConfiguredClient";
+
+vi.mock("cacophony", () => ({
+  Cacophony: class {
+    muted = false;
+    setGlobalVolume = vi.fn();
+  },
+}));
+
+describe("createConfiguredClient", () => {
+  let client: MudClient | undefined;
+
+  afterEach(() => {
+    client?.shutdown();
+    client = undefined;
+  });
+
+  it("wires Char.Name to sessionReady once", () => {
+    client = createConfiguredClient();
+    const handleSessionReady = vi.fn();
+    const handleStatusText = vi.fn();
+    client.on("sessionReady", handleSessionReady);
+    client.on("statustext", handleStatusText);
+
+    const char = client.gmcp.require("Char");
+    char.receiveRegisteredMessage("Name", { fullname: "Q", name: "q" });
+    char.receiveRegisteredMessage("Name", { fullname: "Q", name: "q" });
+
+    expect(client.gmcp.sessionReady).toBe(true);
+    expect(handleSessionReady).toHaveBeenCalledOnce();
+    expect(handleStatusText).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -58,22 +58,55 @@ export function createConfiguredClient(): MudClient {
   client.gmcp.register(GMCPAutoLogin);
   client.gmcp.register(GMCPClientHtml);
   client.gmcp.register(GMCPClientFile);
-  client.gmcp.register(GMCPCharItems);
-  client.gmcp.register(GMCPCharStatus);
-  client.gmcp.register(GMCPChar);
-  client.gmcp.register(GMCPCharOffer);
-  client.gmcp.register(GMCPCharPrompt);
-  client.gmcp.register(GMCPCharStatusAffectedBy);
-  client.gmcp.register(GMCPCharStatusConditions);
-  client.gmcp.register(GMCPCharStatusTimers);
-  client.gmcp.register(GMCPCharAfflictions);
-  client.gmcp.register(GMCPCharDefences);
-  client.gmcp.register(GMCPCharSkills);
+  const charItems = client.gmcp.register(GMCPCharItems);
+  const charStatus = client.gmcp.register(GMCPCharStatus);
+  const char = client.gmcp.register(GMCPChar);
+  const charOffer = client.gmcp.register(GMCPCharOffer);
+  const charPrompt = client.gmcp.register(GMCPCharPrompt);
+  const charStatusAffectedBy = client.gmcp.register(GMCPCharStatusAffectedBy);
+  const charStatusConditions = client.gmcp.register(GMCPCharStatusConditions);
+  const charStatusTimers = client.gmcp.register(GMCPCharStatusTimers);
+  const charAfflictions = client.gmcp.register(GMCPCharAfflictions);
+  const charDefences = client.gmcp.register(GMCPCharDefences);
+  const charSkills = client.gmcp.register(GMCPCharSkills);
   client.gmcp.register(GMCPGroup);
   client.gmcp.register(GMCPLogging);
   client.gmcp.register(GMCPRedirect);
   client.gmcp.register(GMCPRoom);
   client.gmcp.register(GMCPClientHaptics);
+
+  char.on("name", (data) => client.emit("statustext", `Logged in as ${data.fullname}`));
+  char.on("vitals", (data) => client.emit("vitals", data));
+  char.on("statusVars", (data) => client.emit("statusVars", data));
+  char.on("status", (data) => client.emit("statusUpdate", data));
+  charStatus.on("status", (data) => client.emit("status", data));
+  charOffer.on("offer", (data) => client.emit("offer", data));
+  charPrompt.on("prompt", (data) => client.emit("prompt", data));
+  charStatusAffectedBy.on("affectedBy", (data) => client.emit("statusAffectedBy", data));
+  charStatusConditions.on("conditions", (data) => client.emit("statusConditions", data));
+  charStatusTimers.on("timers", (data) => client.emit("statusTimers", data));
+  charAfflictions.on("list", (data) => client.emit("afflictionsList", data));
+  charAfflictions.on("add", (data) => client.emit("afflictionAdd", data));
+  charAfflictions.on("remove", (data) => client.emit("afflictionRemove", data));
+  charDefences.on("list", (data) => client.emit("defencesList", data));
+  charDefences.on("add", (data) => client.emit("defenceAdd", data));
+  charDefences.on("remove", (data) => client.emit("defenceRemove", data));
+  charSkills.on("groups", (data) => client.emit("skillGroups", data));
+  charSkills.on("list", (data) => client.emit("skillList", data));
+  charSkills.on("info", (data) => client.emit("skillInfo", data));
+  charItems.on("list", (data) => {
+    const items = data.items.map((item) => ({ ...item, location: data.location }));
+    client.emit("itemsList", { ...data, items });
+  });
+  charItems.on("add", (data) => {
+    client.emit("itemAdd", { ...data, item: { ...data.item, location: data.location } });
+  });
+  charItems.on("remove", (data) => {
+    client.emit("itemRemove", { ...data, item: { ...data.item, location: data.location } });
+  });
+  charItems.on("update", (data) => {
+    client.emit("itemUpdate", { ...data, item: { ...data.item, location: data.location } });
+  });
 
   // MCP packages
   for (const PackageConstructor of DEFAULT_MCP_PACKAGES) {

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -14,6 +14,7 @@ import {
   GMCPCharStatusConditions,
   GMCPCharStatusTimers,
   GMCPClientFile,
+  GMCPClientFileTransfer,
   GMCPClientHaptics,
   GMCPClientHtml,
   GMCPClientKeystrokes,
@@ -52,6 +53,8 @@ marked.setOptions({
 export function createConfiguredClient(): MudClient {
   const client = new MudClient("mongoose.moo.mud.org", 8765);
   // GMCP packages
+  const clientFileTransfer = client.gmcp.register(GMCPClientFileTransfer);
+  client.configureFileTransfer(clientFileTransfer);
   const core = client.gmcp.register(GMCPCore);
   client.gmcp.register(GMCPClientMedia);
   const clientSpatial = client.gmcp.register(GMCPClientSpatial);

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -1,4 +1,5 @@
 import MudClient from "./client";
+import { marked } from "marked";
 import {
   GMCPAutoLogin,
   GMCPChar,
@@ -37,6 +38,12 @@ import {
   McpSimpleEdit,
   McpVmooUserlist,
 } from "./mcp/index";
+import { useSpatialStore } from "./stores/spatialStore";
+
+marked.setOptions({
+  breaks: true,
+  gfm: true,
+});
 
 /**
  * Create a MudClient with all GMCP and MCP packages registered.
@@ -47,16 +54,16 @@ export function createConfiguredClient(): MudClient {
   // GMCP packages
   const core = client.gmcp.register(GMCPCore);
   client.gmcp.register(GMCPClientMedia);
-  client.gmcp.register(GMCPClientSpatial);
+  const clientSpatial = client.gmcp.register(GMCPClientSpatial);
   client.gmcp.register(GMCPClientMidi);
   client.gmcp.register(GMCPClientSpeech);
-  client.gmcp.register(GMCPClientWebPush);
+  const clientWebPush = client.gmcp.register(GMCPClientWebPush);
   client.gmcp.register(GMCPClientKeystrokes);
   client.gmcp.register(GMCPCoreSupports);
   const commChannel = client.gmcp.register(GMCPCommChannel);
   const commLiveKit = client.gmcp.register(GMCPCommLiveKit);
   client.gmcp.register(GMCPAutoLogin);
-  client.gmcp.register(GMCPClientHtml);
+  const clientHtml = client.gmcp.register(GMCPClientHtml);
   client.gmcp.register(GMCPClientFile);
   const charItems = client.gmcp.register(GMCPCharItems);
   const charStatus = client.gmcp.register(GMCPCharStatus);
@@ -73,7 +80,7 @@ export function createConfiguredClient(): MudClient {
   const logging = client.gmcp.register(GMCPLogging);
   const redirect = client.gmcp.register(GMCPRedirect);
   const room = client.gmcp.register(GMCPRoom);
-  client.gmcp.register(GMCPClientHaptics);
+  const clientHaptics = client.gmcp.register(GMCPClientHaptics);
 
   char.on("name", (data) => client.emit("statustext", `Logged in as ${data.fullname}`));
   char.on("vitals", (data) => client.emit("vitals", data));
@@ -128,6 +135,51 @@ export function createConfiguredClient(): MudClient {
     client.emit("redirectWindow", targetWindow || "main"),
   );
   room.on("wrongDir", (direction) => client.emit("roomWrongDir", direction));
+  clientHtml.on("addHtml", (data) => client.emit("html", data.data.join("\n")));
+  clientHtml.on("addMarkdown", (data) => {
+    const html = marked(data.data.join("\n"));
+    client.emit("html", typeof html === "string" ? html.trimEnd() : html);
+  });
+  clientWebPush.on("token", (data) =>
+    client.emit("webpushToken", {
+      expiresAt: typeof data.expires_at === "number" ? data.expires_at : null,
+      token: data.token || null,
+    }),
+  );
+  clientHaptics.on("actuate", (data) => client.emit("hapticsActuate", data));
+  clientHaptics.on("stop", (data) => client.emit("hapticsStop", data));
+  clientHaptics.on("status", (data) => client.emit("hapticsStatus", data));
+  clientHaptics.on("sensorSubscribe", (data) =>
+    client.emit("hapticsSensorSubscribe", data),
+  );
+  clientHaptics.on("sensorUnsubscribe", (data) =>
+    client.emit("hapticsSensorUnsubscribe", data),
+  );
+  clientSpatial.on("scene", (data) => client.emit("spatialScene", data));
+  clientSpatial.on("entityEnter", (data) =>
+    client.emit("spatialEntityEnter", data.entity),
+  );
+  clientSpatial.on("entityLeave", (data) =>
+    client.emit("spatialEntityLeave", data.entityId),
+  );
+  clientSpatial.on("entityMove", (data) =>
+    client.emit(
+      "spatialEntityMove",
+      useSpatialStore.getState().spatialEntities[data.entityId],
+    ),
+  );
+  clientSpatial.on("listenerPosition", (data) =>
+    client.emit("spatialListenerPosition", data),
+  );
+  clientSpatial.on("listenerOrientation", (data) =>
+    client.emit("spatialListenerOrientation", data),
+  );
+  clientSpatial.on("emitterStart", (data) =>
+    client.emit("spatialEmitterStart", data.emitter),
+  );
+  clientSpatial.on("emitterStop", (data) =>
+    client.emit("spatialEmitterStop", data.emitterId),
+  );
 
   // MCP packages
   for (const PackageConstructor of DEFAULT_MCP_PACKAGES) {

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -45,7 +45,7 @@ import {
 export function createConfiguredClient(): MudClient {
   const client = new MudClient("mongoose.moo.mud.org", 8765);
   // GMCP packages
-  client.gmcp.register(GMCPCore);
+  const core = client.gmcp.register(GMCPCore);
   client.gmcp.register(GMCPClientMedia);
   client.gmcp.register(GMCPClientSpatial);
   client.gmcp.register(GMCPClientMidi);
@@ -53,8 +53,8 @@ export function createConfiguredClient(): MudClient {
   client.gmcp.register(GMCPClientWebPush);
   client.gmcp.register(GMCPClientKeystrokes);
   client.gmcp.register(GMCPCoreSupports);
-  client.gmcp.register(GMCPCommChannel);
-  client.gmcp.register(GMCPCommLiveKit);
+  const commChannel = client.gmcp.register(GMCPCommChannel);
+  const commLiveKit = client.gmcp.register(GMCPCommLiveKit);
   client.gmcp.register(GMCPAutoLogin);
   client.gmcp.register(GMCPClientHtml);
   client.gmcp.register(GMCPClientFile);
@@ -69,10 +69,10 @@ export function createConfiguredClient(): MudClient {
   const charAfflictions = client.gmcp.register(GMCPCharAfflictions);
   const charDefences = client.gmcp.register(GMCPCharDefences);
   const charSkills = client.gmcp.register(GMCPCharSkills);
-  client.gmcp.register(GMCPGroup);
-  client.gmcp.register(GMCPLogging);
-  client.gmcp.register(GMCPRedirect);
-  client.gmcp.register(GMCPRoom);
+  const group = client.gmcp.register(GMCPGroup);
+  const logging = client.gmcp.register(GMCPLogging);
+  const redirect = client.gmcp.register(GMCPRedirect);
+  const room = client.gmcp.register(GMCPRoom);
   client.gmcp.register(GMCPClientHaptics);
 
   char.on("name", (data) => client.emit("statustext", `Logged in as ${data.fullname}`));
@@ -107,6 +107,27 @@ export function createConfiguredClient(): MudClient {
   charItems.on("update", (data) => {
     client.emit("itemUpdate", { ...data, item: { ...data.item, location: data.location } });
   });
+  core.on("ping", () => client.emit("corePing"));
+  core.on("goodbye", (reason) => client.emit("coreGoodbye", reason));
+  commChannel.on("text", (data) => {
+    client.emit("channelText", data);
+    if (data.channel === "say_to_you" && !document.hasFocus()) {
+      client.sendNotification(`Message from ${data.talker}`, data.text);
+    }
+  });
+  commChannel.on("players", (data) => client.emit("channelPlayers", data));
+  commChannel.on("start", (channelName) =>
+    client.emit("channelStart", channelName),
+  );
+  commChannel.on("end", (channelName) => client.emit("channelEnd", channelName));
+  commLiveKit.on("roomToken", (data) => client.emit("livekitToken", data.token));
+  commLiveKit.on("roomLeave", (data) => client.emit("livekitLeave", data.token));
+  group.on("info", (data) => client.emit("groupInfo", data));
+  logging.on("error", (data) => client.emit("gmcpError", data));
+  redirect.on("window", (targetWindow) =>
+    client.emit("redirectWindow", targetWindow || "main"),
+  );
+  room.on("wrongDir", (direction) => client.emit("roomWrongDir", direction));
 
   // MCP packages
   for (const PackageConstructor of DEFAULT_MCP_PACKAGES) {

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -30,7 +30,13 @@ import {
   GMCPRedirect,
   GMCPRoom,
 } from "./gmcp";
-import { DEFAULT_MCP_PACKAGES, McpSimpleEdit } from "./mcp/index";
+import {
+  DEFAULT_MCP_PACKAGES,
+  McpAwnsGetSet,
+  McpAwnsStatus,
+  McpSimpleEdit,
+  McpVmooUserlist,
+} from "./mcp/index";
 
 /**
  * Create a MudClient with all GMCP and MCP packages registered.
@@ -74,6 +80,17 @@ export function createConfiguredClient(): MudClient {
     const mcpPackage = client.registerMcpPackage(PackageConstructor);
     if (mcpPackage instanceof McpSimpleEdit) {
       client.configureEditors(mcpPackage);
+    }
+    if (mcpPackage instanceof McpAwnsStatus) {
+      mcpPackage.on("statustext", (text) => client.emit("statustext", text));
+    }
+    if (mcpPackage instanceof McpAwnsGetSet) {
+      mcpPackage.on("getset", ({ key, value }) =>
+        client.emit("getset", key, value),
+      );
+    }
+    if (mcpPackage instanceof McpVmooUserlist) {
+      mcpPackage.on("userlist", (players) => client.emit("userlist", players));
     }
   }
   return client;

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -30,7 +30,7 @@ import {
   GMCPRedirect,
   GMCPRoom,
 } from "./gmcp";
-import { DEFAULT_MCP_PACKAGES } from "./mcp/index";
+import { DEFAULT_MCP_PACKAGES, McpSimpleEdit } from "./mcp/index";
 
 /**
  * Create a MudClient with all GMCP and MCP packages registered.
@@ -71,7 +71,10 @@ export function createConfiguredClient(): MudClient {
 
   // MCP packages
   for (const PackageConstructor of DEFAULT_MCP_PACKAGES) {
-    client.registerMcpPackage(PackageConstructor);
+    const mcpPackage = client.registerMcpPackage(PackageConstructor);
+    if (mcpPackage instanceof McpSimpleEdit) {
+      client.configureEditors(mcpPackage);
+    }
   }
   return client;
 }

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -82,7 +82,12 @@ export function createConfiguredClient(): MudClient {
   const room = client.gmcp.register(GMCPRoom);
   const clientHaptics = client.gmcp.register(GMCPClientHaptics);
 
-  char.on("name", (data) => client.emit("statustext", `Logged in as ${data.fullname}`));
+  char.on("name", (data) => {
+    client.emit("statustext", `Logged in as ${data.fullname}`);
+    if (client.gmcp.markSessionReady()) {
+      client.emit("sessionReady");
+    }
+  });
   char.on("vitals", (data) => client.emit("vitals", data));
   char.on("statusVars", (data) => client.emit("statusVars", data));
   char.on("status", (data) => client.emit("statusUpdate", data));

--- a/src/gmcp/Auth.ts
+++ b/src/gmcp/Auth.ts
@@ -1,12 +1,16 @@
-import { inbound } from "../protocol/messages";
+import { inbound, outbound } from "../protocol/messages";
 import { gmcpJsonMessage } from "./messages";
 import { GMCPPackage } from "./package";
 
 const authToken = gmcpJsonMessage<"Token", string>("Token");
+const authLogin = gmcpJsonMessage<"Login", never, string>("Login");
 
 const GMCPAutoLoginBase = GMCPPackage.with({
     packageName: "Auth.Autologin",
-    messages: [inbound(authToken)] as const,
+    messages: [
+        inbound(authToken),
+        outbound(authLogin),
+    ] as const,
 });
 
 export class GMCPAutoLogin extends GMCPAutoLoginBase {
@@ -19,9 +23,10 @@ export class GMCPAutoLogin extends GMCPAutoLoginBase {
         localStorage.setItem("LoginRefreshToken", data);
     }
 
-    sendLogin(): void {
-        var token = localStorage.getItem("LoginRefreshToken");
-        if (token)
-            this.sendData("Login", token);
+    sendStoredLogin(): void {
+        const token = localStorage.getItem("LoginRefreshToken");
+        if (token) {
+            this.sendLogin(token);
+        }
     }
 }

--- a/src/gmcp/Auth.ts
+++ b/src/gmcp/Auth.ts
@@ -1,8 +1,19 @@
+import { inbound } from "../protocol/messages";
+import { gmcpJsonMessage } from "./messages";
 import { GMCPPackage } from "./package";
 
+const authToken = gmcpJsonMessage<"Token", string>("Token");
 
-export class GMCPAutoLogin extends GMCPPackage {
-    public packageName: string = "Auth.Autologin";
+const GMCPAutoLoginBase = GMCPPackage.with({
+    packageName: "Auth.Autologin",
+    messages: [inbound(authToken)] as const,
+});
+
+export class GMCPAutoLogin extends GMCPAutoLoginBase {
+    constructor(client: ConstructorParameters<typeof GMCPAutoLoginBase>[0]) {
+        super(client);
+        this.on("token", (data) => this.handleToken(data));
+    }
 
     handleToken(data: string): void {
         localStorage.setItem("LoginRefreshToken", data);

--- a/src/gmcp/Char.ts
+++ b/src/gmcp/Char.ts
@@ -36,27 +36,23 @@ export class GMCPChar extends GMCPCharBase {
 
   handleName(data: GmcpMessageCharName): void {
     useSessionStore.getState().setPlayer(data.name, data.fullname);
-    this.client.emit("statustext", `Logged in as ${data.fullname}`);
     this.client.gmcp.markSessionReady();
   }
   // --- Vitals ---
   handleVitals(data: Record<string, unknown>): void {
     console.log("Received Char.Vitals:", data);
     // TODO: Parse and update character vitals state (HP, MP, etc.)
-    this.client.emit("vitals", data);
   }
 
   // --- StatusVars ---
   handleStatusVars(data: { [key: string]: string }): void {
     console.log("Received Char.StatusVars:", data);
     // TODO: Store the definitions of status variables
-    this.client.emit("statusVars", data);
   }
 
   // --- Status ---
   handleStatus(data: { [key: string]: string }): void {
     console.log("Received Char.Status:", data);
     // TODO: Update character status based on received values
-    this.client.emit("statusUpdate", data);
   }
 }

--- a/src/gmcp/Char.ts
+++ b/src/gmcp/Char.ts
@@ -1,5 +1,5 @@
 import { useSessionStore } from "../stores/sessionStore";
-import { inbound } from "../protocol/messages";
+import { inbound, outbound } from "../protocol/messages";
 import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
@@ -12,6 +12,7 @@ const charName = gmcpJsonMessage<"Name", GmcpMessageCharName>("Name");
 const charVitals = gmcpJsonMessage<"Vitals", Record<string, unknown>>("Vitals");
 const charStatusVars = gmcpJsonMessage<"StatusVars", Record<string, string>>("StatusVars");
 const charStatus = gmcpJsonMessage<"Status", Record<string, string>>("Status");
+const charLogin = gmcpJsonMessage<"Login", never, { name: string; password: string }>("Login");
 
 const GMCPCharBase = GMCPPackage.with({
   packageName: "Char",
@@ -20,6 +21,7 @@ const GMCPCharBase = GMCPPackage.with({
     inbound(charVitals),
     inbound(charStatusVars),
     inbound(charStatus),
+    outbound(charLogin),
   ] as const,
 });
 
@@ -56,10 +58,5 @@ export class GMCPChar extends GMCPCharBase {
     console.log("Received Char.Status:", data);
     // TODO: Update character status based on received values
     this.client.emit("statusUpdate", data);
-  }
-
-  // --- Login ---
-  sendLogin(name: string, password: string): void {
-    this.sendData("Login", { name, password });
   }
 }

--- a/src/gmcp/Char.ts
+++ b/src/gmcp/Char.ts
@@ -1,4 +1,6 @@
 import { useSessionStore } from "../stores/sessionStore";
+import { inbound } from "../protocol/messages";
+import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
 class GmcpMessageCharName extends GMCPMessage {
@@ -6,8 +8,29 @@ class GmcpMessageCharName extends GMCPMessage {
   public fullname: string = "";
 }
 
-export class GMCPChar extends GMCPPackage {
-  public packageName: string = "Char";
+const charName = gmcpJsonMessage<"Name", GmcpMessageCharName>("Name");
+const charVitals = gmcpJsonMessage<"Vitals", Record<string, unknown>>("Vitals");
+const charStatusVars = gmcpJsonMessage<"StatusVars", Record<string, string>>("StatusVars");
+const charStatus = gmcpJsonMessage<"Status", Record<string, string>>("Status");
+
+const GMCPCharBase = GMCPPackage.with({
+  packageName: "Char",
+  messages: [
+    inbound(charName),
+    inbound(charVitals),
+    inbound(charStatusVars),
+    inbound(charStatus),
+  ] as const,
+});
+
+export class GMCPChar extends GMCPCharBase {
+  constructor(client: ConstructorParameters<typeof GMCPCharBase>[0]) {
+    super(client);
+    this.on("name", (data) => this.handleName(data));
+    this.on("vitals", (data) => this.handleVitals(data));
+    this.on("statusVars", (data) => this.handleStatusVars(data));
+    this.on("status", (data) => this.handleStatus(data));
+  }
 
   handleName(data: GmcpMessageCharName): void {
     useSessionStore.getState().setPlayer(data.name, data.fullname);
@@ -15,7 +38,7 @@ export class GMCPChar extends GMCPPackage {
     this.client.gmcp.markSessionReady();
   }
   // --- Vitals ---
-  handleVitals(data: any): void { // Use 'any' for now, define specific interface later if needed
+  handleVitals(data: Record<string, unknown>): void {
     console.log("Received Char.Vitals:", data);
     // TODO: Parse and update character vitals state (HP, MP, etc.)
     this.client.emit("vitals", data);

--- a/src/gmcp/Char.ts
+++ b/src/gmcp/Char.ts
@@ -36,7 +36,6 @@ export class GMCPChar extends GMCPCharBase {
 
   handleName(data: GmcpMessageCharName): void {
     useSessionStore.getState().setPlayer(data.name, data.fullname);
-    this.client.gmcp.markSessionReady();
   }
   // --- Vitals ---
   handleVitals(data: Record<string, unknown>): void {

--- a/src/gmcp/Char/Afflictions.ts
+++ b/src/gmcp/Char/Afflictions.ts
@@ -48,21 +48,18 @@ export class GMCPCharAfflictions extends GMCPCharAfflictionsBase {
     handleList(data: Affliction[]): void {
         console.log("Received Char.Afflictions.List:", data);
         // TODO: Replace current afflictions list with this data
-        this.client.emit("afflictionsList", data);
     }
 
     // Handler for adding a single affliction
     handleAdd(data: Affliction): void {
         console.log("Received Char.Afflictions.Add:", data);
         // TODO: Add this affliction to the list
-        this.client.emit("afflictionAdd", data);
     }
 
     // Handler for removing afflictions (by name)
     handleRemove(data: string[]): void {
         console.log("Received Char.Afflictions.Remove:", data);
         // TODO: Remove these afflictions from the list
-        this.client.emit("afflictionRemove", data);
     }
 
     // No client-side messages defined in the docs for this package

--- a/src/gmcp/Char/Afflictions.ts
+++ b/src/gmcp/Char/Afflictions.ts
@@ -1,3 +1,5 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export interface Affliction {
@@ -21,8 +23,26 @@ export class GMCPMessageCharAfflictionsRemove extends GMCPMessage {
 }
 
 
-export class GMCPCharAfflictions extends GMCPPackage {
-    public packageName: string = "Char.Afflictions";
+const afflictionsList = gmcpJsonMessage<"List", Affliction[]>("List");
+const afflictionsAdd = gmcpJsonMessage<"Add", Affliction>("Add");
+const afflictionsRemove = gmcpJsonMessage<"Remove", string[]>("Remove");
+
+const GMCPCharAfflictionsBase = GMCPPackage.with({
+    packageName: "Char.Afflictions",
+    messages: [
+        inbound(afflictionsList),
+        inbound(afflictionsAdd),
+        inbound(afflictionsRemove),
+    ] as const,
+});
+
+export class GMCPCharAfflictions extends GMCPCharAfflictionsBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharAfflictionsBase>[0]) {
+        super(client);
+        this.on("list", (data) => this.handleList(data));
+        this.on("add", (data) => this.handleAdd(data));
+        this.on("remove", (data) => this.handleRemove(data));
+    }
 
     // Handler for the full list of afflictions
     handleList(data: Affliction[]): void {

--- a/src/gmcp/Char/Defences.ts
+++ b/src/gmcp/Char/Defences.ts
@@ -45,21 +45,18 @@ export class GMCPCharDefences extends GMCPCharDefencesBase {
     handleList(data: Defence[]): void {
         console.log("Received Char.Defences.List:", data);
         // TODO: Replace current defences list with this data
-        this.client.emit("defencesList", data);
     }
 
     // Handler for adding a single defence
     handleAdd(data: Defence): void {
         console.log("Received Char.Defences.Add:", data);
         // TODO: Add this defence to the list
-        this.client.emit("defenceAdd", data);
     }
 
     // Handler for removing defences (by name)
     handleRemove(data: string[]): void {
         console.log("Received Char.Defences.Remove:", data);
         // TODO: Remove these defences from the list
-        this.client.emit("defenceRemove", data);
     }
 
     // No client-side messages defined in the docs for this package

--- a/src/gmcp/Char/Defences.ts
+++ b/src/gmcp/Char/Defences.ts
@@ -1,3 +1,5 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export interface Defence {
@@ -18,8 +20,26 @@ export class GMCPMessageCharDefencesRemove extends GMCPMessage {
     names: string[] = [];
 }
 
-export class GMCPCharDefences extends GMCPPackage {
-    public packageName: string = "Char.Defences";
+const defencesList = gmcpJsonMessage<"List", Defence[]>("List");
+const defencesAdd = gmcpJsonMessage<"Add", Defence>("Add");
+const defencesRemove = gmcpJsonMessage<"Remove", string[]>("Remove");
+
+const GMCPCharDefencesBase = GMCPPackage.with({
+    packageName: "Char.Defences",
+    messages: [
+        inbound(defencesList),
+        inbound(defencesAdd),
+        inbound(defencesRemove),
+    ] as const,
+});
+
+export class GMCPCharDefences extends GMCPCharDefencesBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharDefencesBase>[0]) {
+        super(client);
+        this.on("list", (data) => this.handleList(data));
+        this.on("add", (data) => this.handleAdd(data));
+        this.on("remove", (data) => this.handleRemove(data));
+    }
 
     // Handler for the full list of defences
     handleList(data: Defence[]): void {

--- a/src/gmcp/Char/Items.ts
+++ b/src/gmcp/Char/Items.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../protocol/messages";
+import { inbound, outbound } from "../../protocol/messages";
 import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
@@ -40,6 +40,9 @@ const itemsList = gmcpJsonMessage<"List", GMCPMessageCharItemsList>("List");
 const itemsAdd = gmcpJsonMessage<"Add", GMCPMessageCharItemsAdd>("Add");
 const itemsRemove = gmcpJsonMessage<"Remove", GMCPMessageCharItemsRemove>("Remove");
 const itemsUpdate = gmcpJsonMessage<"Update", GMCPMessageCharItemsUpdate>("Update");
+const itemsContents = gmcpJsonMessage<"Contents", never, string>("Contents");
+const itemsInv = gmcpJsonMessage<"Inv", never, string>("Inv");
+const itemsRoom = gmcpJsonMessage<"Room", never, string>("Room");
 
 const GMCPCharItemsBase = GMCPPackage.with({
   packageName: "Char.Items",
@@ -48,6 +51,9 @@ const GMCPCharItemsBase = GMCPPackage.with({
     inbound(itemsAdd),
     inbound(itemsRemove),
     inbound(itemsUpdate),
+    outbound(itemsContents),
+    outbound(itemsInv),
+    outbound(itemsRoom),
   ] as const,
 });
 
@@ -84,20 +90,5 @@ export class GMCPCharItems extends GMCPCharItemsBase {
     console.log(`Received Char.Items.Update for ${data.location}:`, data.item);
     const itemWithLocation = { ...data.item, location: data.location };
     this.client.emit("itemUpdate", { ...data, item: itemWithLocation });
-  }
-
-  // --- Client Messages ---
-
-  sendContentsRequest(itemId: string): void {
-    // Docs say number, but let's use string for consistency if IDs can be non-numeric
-    this.sendData("Contents", itemId);
-  }
-
-  sendInventoryRequest(): void {
-    this.sendData("Inv", ""); // Empty body as per docs
-  }
-
-  sendRoomRequest(): void {
-    this.sendData("Room", ""); // Empty body as per docs
   }
 }

--- a/src/gmcp/Char/Items.ts
+++ b/src/gmcp/Char/Items.ts
@@ -70,25 +70,17 @@ export class GMCPCharItems extends GMCPCharItemsBase {
 
   handleList(data: GMCPMessageCharItemsList): void {
     console.log(`Received Char.Items.List for ${data.location}:`, data.items);
-    const itemsWithLocation = data.items.map(item => ({ ...item, location: data.location }));
-    this.client.emit("itemsList", { ...data, items: itemsWithLocation });
   }
 
   handleAdd(data: GMCPMessageCharItemsAdd): void {
     console.log(`Received Char.Items.Add for ${data.location}:`, data.item);
-    const itemWithLocation = { ...data.item, location: data.location };
-    this.client.emit("itemAdd", { ...data, item: itemWithLocation });
   }
 
   handleRemove(data: GMCPMessageCharItemsRemove): void {
     console.log(`Received Char.Items.Remove for ${data.location}:`, data.item);
-    const itemWithLocationDetails = { ...data.item, location: data.location };
-    this.client.emit("itemRemove", { ...data, item: itemWithLocationDetails });
   }
 
   handleUpdate(data: GMCPMessageCharItemsUpdate): void {
     console.log(`Received Char.Items.Update for ${data.location}:`, data.item);
-    const itemWithLocation = { ...data.item, location: data.location };
-    this.client.emit("itemUpdate", { ...data, item: itemWithLocation });
   }
 }

--- a/src/gmcp/Char/Items.ts
+++ b/src/gmcp/Char/Items.ts
@@ -1,3 +1,5 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export interface Item {
@@ -34,8 +36,29 @@ export class GMCPMessageCharItemsUpdate extends GMCPMessage {
 }
 
 
-export class GMCPCharItems extends GMCPPackage {
-  public packageName: string = "Char.Items";
+const itemsList = gmcpJsonMessage<"List", GMCPMessageCharItemsList>("List");
+const itemsAdd = gmcpJsonMessage<"Add", GMCPMessageCharItemsAdd>("Add");
+const itemsRemove = gmcpJsonMessage<"Remove", GMCPMessageCharItemsRemove>("Remove");
+const itemsUpdate = gmcpJsonMessage<"Update", GMCPMessageCharItemsUpdate>("Update");
+
+const GMCPCharItemsBase = GMCPPackage.with({
+  packageName: "Char.Items",
+  messages: [
+    inbound(itemsList),
+    inbound(itemsAdd),
+    inbound(itemsRemove),
+    inbound(itemsUpdate),
+  ] as const,
+});
+
+export class GMCPCharItems extends GMCPCharItemsBase {
+  constructor(client: ConstructorParameters<typeof GMCPCharItemsBase>[0]) {
+    super(client);
+    this.on("list", (data) => this.handleList(data));
+    this.on("add", (data) => this.handleAdd(data));
+    this.on("remove", (data) => this.handleRemove(data));
+    this.on("update", (data) => this.handleUpdate(data));
+  }
 
   // --- Server Messages ---
 

--- a/src/gmcp/Char/Offer.ts
+++ b/src/gmcp/Char/Offer.ts
@@ -33,6 +33,5 @@ export class GMCPCharOffer extends GMCPCharOfferBase {
     handleOffer(data: GMCPMessageCharOffer): void {
         console.log("Received Char.Offer:", data);
         // TODO: Implement logic to handle offer data (e.g., display in UI)
-        this.client.emit("offer", data); // Example: emit an event
     }
 }

--- a/src/gmcp/Char/Offer.ts
+++ b/src/gmcp/Char/Offer.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../protocol/messages";
+import { duplex } from "../../protocol/messages";
 import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
@@ -16,11 +16,11 @@ export class GMCPMessageCharOffer extends GMCPMessage {
     total_rent: number = 0;
 }
 
-const charOffer = gmcpJsonMessage<"Offer", GMCPMessageCharOffer>("Offer");
+const charOffer = gmcpJsonMessage<"Offer", GMCPMessageCharOffer, Record<string, never>>("Offer");
 
 const GMCPCharOfferBase = GMCPPackage.with({
     packageName: "Char.Offer",
-    messages: [inbound(charOffer)] as const,
+    messages: [duplex(charOffer)] as const,
 });
 
 export class GMCPCharOffer extends GMCPCharOfferBase {
@@ -34,10 +34,5 @@ export class GMCPCharOffer extends GMCPCharOfferBase {
         console.log("Received Char.Offer:", data);
         // TODO: Implement logic to handle offer data (e.g., display in UI)
         this.client.emit("offer", data); // Example: emit an event
-    }
-
-    // Method to request offer data
-    sendOfferRequest(): void {
-        this.sendData("Offer", {}); // Send empty object as per docs
     }
 }

--- a/src/gmcp/Char/Offer.ts
+++ b/src/gmcp/Char/Offer.ts
@@ -1,3 +1,5 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 // Basic structure based on documentation
@@ -14,8 +16,18 @@ export class GMCPMessageCharOffer extends GMCPMessage {
     total_rent: number = 0;
 }
 
-export class GMCPCharOffer extends GMCPPackage {
-    public packageName: string = "Char.Offer";
+const charOffer = gmcpJsonMessage<"Offer", GMCPMessageCharOffer>("Offer");
+
+const GMCPCharOfferBase = GMCPPackage.with({
+    packageName: "Char.Offer",
+    messages: [inbound(charOffer)] as const,
+});
+
+export class GMCPCharOffer extends GMCPCharOfferBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharOfferBase>[0]) {
+        super(client);
+        this.on("offer", (data) => this.handleOffer(data));
+    }
 
     // Handler for response messages
     handleOffer(data: GMCPMessageCharOffer): void {

--- a/src/gmcp/Char/Prompt.ts
+++ b/src/gmcp/Char/Prompt.ts
@@ -24,6 +24,5 @@ export class GMCPCharPrompt extends GMCPCharPromptBase {
     handlePrompt(data: GMCPMessageCharPrompt): void {
         console.log("Received Char.Prompt:", data);
         // TODO: Implement logic to handle prompt data (e.g., update UI)
-        this.client.emit("prompt", data); // Example: emit an event
     }
 }

--- a/src/gmcp/Char/Prompt.ts
+++ b/src/gmcp/Char/Prompt.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../protocol/messages";
+import { duplex } from "../../protocol/messages";
 import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
@@ -7,11 +7,11 @@ export class GMCPMessageCharPrompt extends GMCPMessage {
     [key: string]: unknown; // Allows arbitrary prompt values
 }
 
-const charPrompt = gmcpJsonMessage<"Prompt", GMCPMessageCharPrompt>("Prompt");
+const charPrompt = gmcpJsonMessage<"Prompt", GMCPMessageCharPrompt, Record<string, never>>("Prompt");
 
 const GMCPCharPromptBase = GMCPPackage.with({
     packageName: "Char.Prompt",
-    messages: [inbound(charPrompt)] as const,
+    messages: [duplex(charPrompt)] as const,
 });
 
 export class GMCPCharPrompt extends GMCPCharPromptBase {
@@ -25,10 +25,5 @@ export class GMCPCharPrompt extends GMCPCharPromptBase {
         console.log("Received Char.Prompt:", data);
         // TODO: Implement logic to handle prompt data (e.g., update UI)
         this.client.emit("prompt", data); // Example: emit an event
-    }
-
-    // Method to request prompt data
-    sendPromptRequest(): void {
-        this.sendData("Prompt", {}); // Send empty object as per docs
     }
 }

--- a/src/gmcp/Char/Prompt.ts
+++ b/src/gmcp/Char/Prompt.ts
@@ -1,12 +1,24 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 // Data structure is not defined in the provided docs, using 'any' for now.
 export class GMCPMessageCharPrompt extends GMCPMessage {
-    [key: string]: any; // Allows any prompt values
+    [key: string]: unknown; // Allows arbitrary prompt values
 }
 
-export class GMCPCharPrompt extends GMCPPackage {
-    public packageName: string = "Char.Prompt";
+const charPrompt = gmcpJsonMessage<"Prompt", GMCPMessageCharPrompt>("Prompt");
+
+const GMCPCharPromptBase = GMCPPackage.with({
+    packageName: "Char.Prompt",
+    messages: [inbound(charPrompt)] as const,
+});
+
+export class GMCPCharPrompt extends GMCPCharPromptBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharPromptBase>[0]) {
+        super(client);
+        this.on("prompt", (data) => this.handlePrompt(data));
+    }
 
     // Handler for broadcast messages
     handlePrompt(data: GMCPMessageCharPrompt): void {

--- a/src/gmcp/Char/Skills.ts
+++ b/src/gmcp/Char/Skills.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../protocol/messages";
+import { inbound, outbound } from "../../protocol/messages";
 import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
@@ -26,6 +26,7 @@ export class GMCPMessageCharSkillsInfo extends GMCPMessage {
 const skillsGroups = gmcpJsonMessage<"Groups", SkillGroupInfo[]>("Groups");
 const skillsList = gmcpJsonMessage<"List", GMCPMessageCharSkillsList>("List");
 const skillsInfo = gmcpJsonMessage<"Info", GMCPMessageCharSkillsInfo>("Info");
+const skillsGet = gmcpJsonMessage<"Get", never, { group?: string; name?: string }>("Get");
 
 const GMCPCharSkillsBase = GMCPPackage.with({
     packageName: "Char.Skills",
@@ -33,6 +34,7 @@ const GMCPCharSkillsBase = GMCPPackage.with({
         inbound(skillsGroups),
         inbound(skillsList),
         inbound(skillsInfo),
+        outbound(skillsGet),
     ] as const,
 });
 
@@ -62,14 +64,5 @@ export class GMCPCharSkills extends GMCPCharSkillsBase {
         console.log(`Received Char.Skills.Info for ${data.group}.${data.skill}:`, data.info);
         // TODO: Store/display detailed skill info
         this.client.emit("skillInfo", data);
-    }
-
-    // --- Client Messages ---
-
-    sendGetRequest(group?: string, name?: string): void {
-        const requestData: { group?: string; name?: string } = {};
-        if (group) requestData.group = group;
-        if (name) requestData.name = name;
-        this.sendData("Get", requestData);
     }
 }

--- a/src/gmcp/Char/Skills.ts
+++ b/src/gmcp/Char/Skills.ts
@@ -51,18 +51,15 @@ export class GMCPCharSkills extends GMCPCharSkillsBase {
     handleGroups(data: SkillGroupInfo[]): void {
         console.log("Received Char.Skills.Groups:", data);
         // TODO: Update skill groups list
-        this.client.emit("skillGroups", data);
     }
 
     handleList(data: GMCPMessageCharSkillsList): void {
         console.log(`Received Char.Skills.List for ${data.group}:`, data);
         // TODO: Update skill list for the specified group
-        this.client.emit("skillList", data);
     }
 
     handleInfo(data: GMCPMessageCharSkillsInfo): void {
         console.log(`Received Char.Skills.Info for ${data.group}.${data.skill}:`, data.info);
         // TODO: Store/display detailed skill info
-        this.client.emit("skillInfo", data);
     }
 }

--- a/src/gmcp/Char/Skills.ts
+++ b/src/gmcp/Char/Skills.ts
@@ -1,3 +1,5 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export interface SkillGroupInfo {
@@ -21,8 +23,26 @@ export class GMCPMessageCharSkillsInfo extends GMCPMessage {
     info: string = "";
 }
 
-export class GMCPCharSkills extends GMCPPackage {
-    public packageName: string = "Char.Skills";
+const skillsGroups = gmcpJsonMessage<"Groups", SkillGroupInfo[]>("Groups");
+const skillsList = gmcpJsonMessage<"List", GMCPMessageCharSkillsList>("List");
+const skillsInfo = gmcpJsonMessage<"Info", GMCPMessageCharSkillsInfo>("Info");
+
+const GMCPCharSkillsBase = GMCPPackage.with({
+    packageName: "Char.Skills",
+    messages: [
+        inbound(skillsGroups),
+        inbound(skillsList),
+        inbound(skillsInfo),
+    ] as const,
+});
+
+export class GMCPCharSkills extends GMCPCharSkillsBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharSkillsBase>[0]) {
+        super(client);
+        this.on("groups", (data) => this.handleGroups(data));
+        this.on("list", (data) => this.handleList(data));
+        this.on("info", (data) => this.handleInfo(data));
+    }
 
     // --- Server Messages ---
 

--- a/src/gmcp/Char/Status.ts
+++ b/src/gmcp/Char/Status.ts
@@ -25,6 +25,5 @@ export class GMCPCharStatus extends GMCPCharStatusBase {
     handleStatus(data: GMCPMessageCharStatus): void {
         console.log("Received Char.Status:", data);
         // TODO: Implement logic to handle status data
-        this.client.emit("status", data); // Example: emit an event
     }
 }

--- a/src/gmcp/Char/Status.ts
+++ b/src/gmcp/Char/Status.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../protocol/messages";
+import { duplex } from "../../protocol/messages";
 import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
@@ -8,11 +8,11 @@ export class GMCPMessageCharStatus extends GMCPMessage {
     [key: string]: unknown;
 }
 
-const charStatus = gmcpJsonMessage<"Status", GMCPMessageCharStatus>("Status");
+const charStatus = gmcpJsonMessage<"Status", GMCPMessageCharStatus, Record<string, never>>("Status");
 
 const GMCPCharStatusBase = GMCPPackage.with({
     packageName: "Char.Status",
-    messages: [inbound(charStatus)] as const,
+    messages: [duplex(charStatus)] as const,
 });
 
 export class GMCPCharStatus extends GMCPCharStatusBase {
@@ -26,10 +26,5 @@ export class GMCPCharStatus extends GMCPCharStatusBase {
         console.log("Received Char.Status:", data);
         // TODO: Implement logic to handle status data
         this.client.emit("status", data); // Example: emit an event
-    }
-
-    // Method to request status data
-    sendStatusRequest(): void {
-        this.sendData("Status", {}); // Send empty object as per docs
     }
 }

--- a/src/gmcp/Char/Status.ts
+++ b/src/gmcp/Char/Status.ts
@@ -1,13 +1,25 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 // Data structure is not defined in the provided docs, using 'any' for now.
 // Should contain conditions, affects, timers.
 export class GMCPMessageCharStatus extends GMCPMessage {
-    [key: string]: any;
+    [key: string]: unknown;
 }
 
-export class GMCPCharStatus extends GMCPPackage {
-    public packageName: string = "Char.Status";
+const charStatus = gmcpJsonMessage<"Status", GMCPMessageCharStatus>("Status");
+
+const GMCPCharStatusBase = GMCPPackage.with({
+    packageName: "Char.Status",
+    messages: [inbound(charStatus)] as const,
+});
+
+export class GMCPCharStatus extends GMCPCharStatusBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharStatusBase>[0]) {
+        super(client);
+        this.on("status", (data) => this.handleStatus(data));
+    }
 
     // Handler for response messages
     handleStatus(data: GMCPMessageCharStatus): void {

--- a/src/gmcp/Char/Status/AffectedBy.ts
+++ b/src/gmcp/Char/Status/AffectedBy.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../../protocol/messages";
+import { duplex } from "../../../protocol/messages";
 import { gmcpJsonMessage } from "../../messages";
 import { GMCPMessage, GMCPPackage } from "../../package";
 
@@ -7,11 +7,15 @@ export class GMCPMessageCharStatusAffectedBy extends GMCPMessage {
     [key: string]: unknown; // Represents affects
 }
 
-const affectedBy = gmcpJsonMessage<"AffectedBy", GMCPMessageCharStatusAffectedBy>("AffectedBy");
+const affectedBy = gmcpJsonMessage<
+    "AffectedBy",
+    GMCPMessageCharStatusAffectedBy,
+    Record<string, never>
+>("AffectedBy");
 
 const GMCPCharStatusAffectedByBase = GMCPPackage.with({
     packageName: "Char.Status.AffectedBy",
-    messages: [inbound(affectedBy)] as const,
+    messages: [duplex(affectedBy)] as const,
 });
 
 export class GMCPCharStatusAffectedBy extends GMCPCharStatusAffectedByBase {
@@ -25,10 +29,5 @@ export class GMCPCharStatusAffectedBy extends GMCPCharStatusAffectedByBase {
         console.log("Received Char.Status.AffectedBy:", data);
         // TODO: Implement logic to handle affected by data
         this.client.emit("statusAffectedBy", data); // Example: emit an event
-    }
-
-    // Method to request affected by data
-    sendAffectedByRequest(): void {
-        this.sendData("AffectedBy", {}); // Send empty object as per docs
     }
 }

--- a/src/gmcp/Char/Status/AffectedBy.ts
+++ b/src/gmcp/Char/Status/AffectedBy.ts
@@ -28,6 +28,5 @@ export class GMCPCharStatusAffectedBy extends GMCPCharStatusAffectedByBase {
     handleAffectedBy(data: GMCPMessageCharStatusAffectedBy): void {
         console.log("Received Char.Status.AffectedBy:", data);
         // TODO: Implement logic to handle affected by data
-        this.client.emit("statusAffectedBy", data); // Example: emit an event
     }
 }

--- a/src/gmcp/Char/Status/AffectedBy.ts
+++ b/src/gmcp/Char/Status/AffectedBy.ts
@@ -1,12 +1,24 @@
+import { inbound } from "../../../protocol/messages";
+import { gmcpJsonMessage } from "../../messages";
 import { GMCPMessage, GMCPPackage } from "../../package";
 
 // Data structure is not defined in the provided docs, using 'any' for now.
 export class GMCPMessageCharStatusAffectedBy extends GMCPMessage {
-    [key: string]: any; // Represents affects
+    [key: string]: unknown; // Represents affects
 }
 
-export class GMCPCharStatusAffectedBy extends GMCPPackage {
-    public packageName: string = "Char.Status.AffectedBy";
+const affectedBy = gmcpJsonMessage<"AffectedBy", GMCPMessageCharStatusAffectedBy>("AffectedBy");
+
+const GMCPCharStatusAffectedByBase = GMCPPackage.with({
+    packageName: "Char.Status.AffectedBy",
+    messages: [inbound(affectedBy)] as const,
+});
+
+export class GMCPCharStatusAffectedBy extends GMCPCharStatusAffectedByBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharStatusAffectedByBase>[0]) {
+        super(client);
+        this.on("affectedBy", (data) => this.handleAffectedBy(data));
+    }
 
     // Handler for response messages
     handleAffectedBy(data: GMCPMessageCharStatusAffectedBy): void {

--- a/src/gmcp/Char/Status/Conditions.ts
+++ b/src/gmcp/Char/Status/Conditions.ts
@@ -1,13 +1,24 @@
+import { inbound } from "../../../protocol/messages";
+import { gmcpJsonMessage } from "../../messages";
 import { GMCPMessage, GMCPPackage } from "../../package";
 
 // Data structure is not defined in the provided docs, using 'any' for now.
 export class GMCPMessageCharStatusConditions extends GMCPMessage {
-    [key: string]: any; // Represents conditions
+    [key: string]: unknown; // Represents conditions
 }
 
-export class GMCPCharStatusConditions extends GMCPPackage {
-    // Note: Package name includes the parent structure
-    public packageName: string = "Char.Status.Conditions";
+const conditions = gmcpJsonMessage<"Conditions", GMCPMessageCharStatusConditions>("Conditions");
+
+const GMCPCharStatusConditionsBase = GMCPPackage.with({
+    packageName: "Char.Status.Conditions",
+    messages: [inbound(conditions)] as const,
+});
+
+export class GMCPCharStatusConditions extends GMCPCharStatusConditionsBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharStatusConditionsBase>[0]) {
+        super(client);
+        this.on("conditions", (data) => this.handleConditions(data));
+    }
 
     // Handler for response messages
     handleConditions(data: GMCPMessageCharStatusConditions): void {

--- a/src/gmcp/Char/Status/Conditions.ts
+++ b/src/gmcp/Char/Status/Conditions.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../../protocol/messages";
+import { duplex } from "../../../protocol/messages";
 import { gmcpJsonMessage } from "../../messages";
 import { GMCPMessage, GMCPPackage } from "../../package";
 
@@ -7,11 +7,15 @@ export class GMCPMessageCharStatusConditions extends GMCPMessage {
     [key: string]: unknown; // Represents conditions
 }
 
-const conditions = gmcpJsonMessage<"Conditions", GMCPMessageCharStatusConditions>("Conditions");
+const conditions = gmcpJsonMessage<
+    "Conditions",
+    GMCPMessageCharStatusConditions,
+    Record<string, never>
+>("Conditions");
 
 const GMCPCharStatusConditionsBase = GMCPPackage.with({
     packageName: "Char.Status.Conditions",
-    messages: [inbound(conditions)] as const,
+    messages: [duplex(conditions)] as const,
 });
 
 export class GMCPCharStatusConditions extends GMCPCharStatusConditionsBase {
@@ -25,11 +29,5 @@ export class GMCPCharStatusConditions extends GMCPCharStatusConditionsBase {
         console.log("Received Char.Status.Conditions:", data);
         // TODO: Implement logic to handle conditions data
         this.client.emit("statusConditions", data); // Example: emit an event
-    }
-
-    // Method to request conditions data
-    sendConditionsRequest(): void {
-        // The message name is just the last part
-        this.sendData("Conditions", {}); // Send empty object as per docs
     }
 }

--- a/src/gmcp/Char/Status/Conditions.ts
+++ b/src/gmcp/Char/Status/Conditions.ts
@@ -28,6 +28,5 @@ export class GMCPCharStatusConditions extends GMCPCharStatusConditionsBase {
     handleConditions(data: GMCPMessageCharStatusConditions): void {
         console.log("Received Char.Status.Conditions:", data);
         // TODO: Implement logic to handle conditions data
-        this.client.emit("statusConditions", data); // Example: emit an event
     }
 }

--- a/src/gmcp/Char/Status/Timers.ts
+++ b/src/gmcp/Char/Status/Timers.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../../../protocol/messages";
+import { duplex } from "../../../protocol/messages";
 import { gmcpJsonMessage } from "../../messages";
 import { GMCPMessage, GMCPPackage } from "../../package";
 
@@ -7,11 +7,15 @@ export class GMCPMessageCharStatusTimers extends GMCPMessage {
     [key: string]: unknown; // Represents timers
 }
 
-const timers = gmcpJsonMessage<"Timers", GMCPMessageCharStatusTimers>("Timers");
+const timers = gmcpJsonMessage<
+    "Timers",
+    GMCPMessageCharStatusTimers,
+    Record<string, never>
+>("Timers");
 
 const GMCPCharStatusTimersBase = GMCPPackage.with({
     packageName: "Char.Status.Timers",
-    messages: [inbound(timers)] as const,
+    messages: [duplex(timers)] as const,
 });
 
 export class GMCPCharStatusTimers extends GMCPCharStatusTimersBase {
@@ -25,10 +29,5 @@ export class GMCPCharStatusTimers extends GMCPCharStatusTimersBase {
         console.log("Received Char.Status.Timers:", data);
         // TODO: Implement logic to handle timers data
         this.client.emit("statusTimers", data); // Example: emit an event
-    }
-
-    // Method to request timers data
-    sendTimersRequest(): void {
-        this.sendData("Timers", {}); // Send empty object as per docs
     }
 }

--- a/src/gmcp/Char/Status/Timers.ts
+++ b/src/gmcp/Char/Status/Timers.ts
@@ -28,6 +28,5 @@ export class GMCPCharStatusTimers extends GMCPCharStatusTimersBase {
     handleTimers(data: GMCPMessageCharStatusTimers): void {
         console.log("Received Char.Status.Timers:", data);
         // TODO: Implement logic to handle timers data
-        this.client.emit("statusTimers", data); // Example: emit an event
     }
 }

--- a/src/gmcp/Char/Status/Timers.ts
+++ b/src/gmcp/Char/Status/Timers.ts
@@ -1,12 +1,24 @@
+import { inbound } from "../../../protocol/messages";
+import { gmcpJsonMessage } from "../../messages";
 import { GMCPMessage, GMCPPackage } from "../../package";
 
 // Data structure is not defined in the provided docs, using 'any' for now.
 export class GMCPMessageCharStatusTimers extends GMCPMessage {
-    [key: string]: any; // Represents timers
+    [key: string]: unknown; // Represents timers
 }
 
-export class GMCPCharStatusTimers extends GMCPPackage {
-    public packageName: string = "Char.Status.Timers";
+const timers = gmcpJsonMessage<"Timers", GMCPMessageCharStatusTimers>("Timers");
+
+const GMCPCharStatusTimersBase = GMCPPackage.with({
+    packageName: "Char.Status.Timers",
+    messages: [inbound(timers)] as const,
+});
+
+export class GMCPCharStatusTimers extends GMCPCharStatusTimersBase {
+    constructor(client: ConstructorParameters<typeof GMCPCharStatusTimersBase>[0]) {
+        super(client);
+        this.on("timers", (data) => this.handleTimers(data));
+    }
 
     // Handler for response messages
     handleTimers(data: GMCPMessageCharStatusTimers): void {

--- a/src/gmcp/Client/File.ts
+++ b/src/gmcp/Client/File.ts
@@ -1,15 +1,23 @@
 import type MudClient from "../../client";
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export class FileDownload extends GMCPMessage {
   url: string = "";
 }
 
-export class GMCPClientFile extends GMCPPackage {
-  public packageName: string = "Client.File";
+const fileDownload = gmcpJsonMessage<"Download", FileDownload>("Download");
 
+const GMCPClientFileBase = GMCPPackage.with({
+  packageName: "Client.File",
+  messages: [inbound(fileDownload)] as const,
+});
+
+export class GMCPClientFile extends GMCPClientFileBase {
   constructor(client: MudClient) {
     super(client);
+    this.on("download", (data) => this.handleDownload(data));
   }
 
   handleDownload(data: FileDownload): void {

--- a/src/gmcp/Client/FileTransfer.test.ts
+++ b/src/gmcp/Client/FileTransfer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type MudClient from '../../client';
+import type { TelnetParser } from '../../telnet';
+import { GmcpSession } from '../session';
+import { GMCPClientFileTransfer } from './FileTransfer';
+
+function createFileTransferPackage() {
+  const client = {
+    emit: vi.fn(),
+  } as unknown as MudClient;
+  const session = new GmcpSession(client);
+  (client as MudClient).gmcp = session;
+  const telnet = {
+    sendGmcp: vi.fn(),
+  } as unknown as TelnetParser;
+  session.attachTransport(telnet);
+
+  return {
+    fileTransfer: session.register(GMCPClientFileTransfer),
+    session,
+    telnet,
+  };
+}
+
+describe('GMCPClientFileTransfer', () => {
+  it('emits inbound file transfer messages through package events', () => {
+    const { fileTransfer, session } = createFileTransferPackage();
+    const offers: unknown[] = [];
+
+    fileTransfer.on('offer', (offer) => offers.push(offer));
+    session.receive(
+      'Client.FileTransfer.Offer',
+      JSON.stringify({
+        sender: 'Alice',
+        filename: 'notes.txt',
+        filesize: 12,
+        offerSdp: '{}',
+        hash: 'hash-1',
+      }),
+    );
+
+    expect(offers).toEqual([
+      {
+        sender: 'Alice',
+        filename: 'notes.txt',
+        filesize: 12,
+        offerSdp: '{}',
+        hash: 'hash-1',
+      },
+    ]);
+  });
+
+  it('generates typed outbound send methods from the message registry', () => {
+    const { fileTransfer, telnet } = createFileTransferPackage();
+
+    fileTransfer.sendOffer({
+      recipient: 'Alice',
+      filename: 'notes.txt',
+      filesize: 12,
+      offerSdp: '{}',
+      hash: 'hash-1',
+    });
+    fileTransfer.sendRequestResend({ sender: 'Alice', hash: 'hash-1' });
+
+    expect(telnet.sendGmcp).toHaveBeenCalledWith(
+      'Client.FileTransfer.Offer',
+      '{"recipient":"Alice","filename":"notes.txt","filesize":12,"offerSdp":"{}","hash":"hash-1"}',
+    );
+    expect(telnet.sendGmcp).toHaveBeenCalledWith(
+      'Client.FileTransfer.RequestResend',
+      '{"sender":"Alice","hash":"hash-1"}',
+    );
+  });
+
+  it('removes package event listeners through off', () => {
+    const { fileTransfer, session } = createFileTransferPackage();
+    const listener = vi.fn();
+
+    fileTransfer.on('cancel', listener);
+    fileTransfer.off('cancel', listener);
+    session.receive(
+      'Client.FileTransfer.Cancel',
+      JSON.stringify({ sender: 'Alice', hash: 'hash-1' }),
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/gmcp/Client/FileTransfer.ts
+++ b/src/gmcp/Client/FileTransfer.ts
@@ -102,25 +102,4 @@ const GMCPClientFileTransferBase = GMCPPackage.with({
   ] as const,
 });
 
-export class GMCPClientFileTransfer extends GMCPClientFileTransferBase {
-  handleCandidate(data: FileTransferCandidate): void {
-    this.emitRegisteredMessage(fileTransferCandidate.wireName, data);
-  }
-
-  handleOffer(data: FileTransferOffer): void {
-    console.log('[GMCPClientFileTransfer] Received offer:', data);
-    this.emitRegisteredMessage(fileTransferOffer.wireName, data);
-  }
-
-  handleAccept(data: FileTransferAccept): void {
-    this.emitRegisteredMessage(fileTransferAccept.wireName, data);
-  }
-
-  handleReject(data: FileTransferReject): void {
-    this.emitRegisteredMessage(fileTransferReject.wireName, data);
-  }
-
-  handleCancel(data: FileTransferCancel): void {
-    this.emitRegisteredMessage(fileTransferCancel.wireName, data);
-  }
-}
+export class GMCPClientFileTransfer extends GMCPClientFileTransferBase {}

--- a/src/gmcp/Client/FileTransfer.ts
+++ b/src/gmcp/Client/FileTransfer.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'eventemitter3';
+import { duplex, identityCodec, messageEnvelope, outbound } from '../../protocol/messages';
 import { GMCPMessage, GMCPPackage } from '../package';
 
 export class FileTransferOffer extends GMCPMessage {
@@ -26,117 +26,101 @@ export class FileTransferCancel extends GMCPMessage {
   hash: string = '';
 }
 
+export interface FileTransferOfferRequest {
+  recipient: string;
+  filename: string;
+  filesize: number;
+  offerSdp: string;
+  hash: string;
+}
+
+export interface FileTransferCancelRequest {
+  recipient: string;
+  hash: string;
+}
+
 export interface FileTransferCandidate {
   sender: string;
   candidate: string;
 }
 
-interface FileTransferTransportEvents {
-  accept: (data: FileTransferAccept) => void;
-  cancel: (data: FileTransferCancel) => void;
-  candidate: (data: FileTransferCandidate) => void;
-  offer: (data: FileTransferOffer) => void;
-  reject: (data: FileTransferReject) => void;
+export interface FileTransferCandidateRequest {
+  recipient: string;
+  candidate: string;
 }
 
-// The signaling interface that all signalers conform to
-export interface FileTransferSignaler {
-  handleAccept(data: FileTransferAccept): void;
-  handleCancel(data: FileTransferCancel): void;
-  handleCandidate(data: { sender: string; candidate: string }): void;
-  handleOffer(data: FileTransferOffer): void;
-  handleReject(data: FileTransferReject): void;
-  sendAccept(sender: string, hash: string, filename: string, answerSdp: string): void;
-  sendCancel(recipient: string, hash: string): void;
-  sendCandidate(recipient: string, candidate: RTCIceCandidate): void;
-  sendOffer(
-    recipient: string,
-    filename: string,
-    filesize: number,
-    offerSdp: string,
-    hash: string,
-  ): void;
-  sendReject(sender: string, hash: string): void;
-  sendRequestResend(sender: string, hash: string): void;
+export interface FileTransferRequestResend {
+  sender: string;
+  hash: string;
 }
 
-export class GMCPClientFileTransfer extends GMCPPackage implements FileTransferSignaler {
-  public packageName: string = 'Client.FileTransfer';
-  private readonly signals = new EventEmitter<FileTransferTransportEvents>();
+function gmcpJson<InboundPayload, OutboundPayload = InboundPayload>() {
+  return {
+    encode(payload: OutboundPayload): unknown {
+      return payload;
+    },
+    decode(payload: unknown): InboundPayload {
+      return payload as InboundPayload;
+    },
+  };
+}
 
-  on<EventName extends keyof FileTransferTransportEvents>(
-    event: EventName,
-    listener: FileTransferTransportEvents[EventName],
-  ): this {
-    this.signals.on(
-      event,
-      listener as EventEmitter.EventListener<FileTransferTransportEvents, EventName>,
-    );
-    return this;
-  }
+const fileTransferOffer = messageEnvelope(
+  'Offer',
+  gmcpJson<FileTransferOffer, FileTransferOfferRequest>(),
+);
+const fileTransferAccept = messageEnvelope(
+  'Accept',
+  identityCodec<FileTransferAccept>(),
+);
+const fileTransferReject = messageEnvelope(
+  'Reject',
+  identityCodec<FileTransferReject>(),
+);
+const fileTransferCancel = messageEnvelope(
+  'Cancel',
+  gmcpJson<FileTransferCancel, FileTransferCancelRequest>(),
+);
+const fileTransferCandidate = messageEnvelope(
+  'Candidate',
+  gmcpJson<FileTransferCandidate, FileTransferCandidateRequest>(),
+);
+const fileTransferRequestResend = messageEnvelope(
+  'RequestResend',
+  identityCodec<FileTransferRequestResend>(),
+);
 
-  off<EventName extends keyof FileTransferTransportEvents>(
-    event: EventName,
-    listener: FileTransferTransportEvents[EventName],
-  ): this {
-    this.signals.off(
-      event,
-      listener as EventEmitter.EventListener<FileTransferTransportEvents, EventName>,
-    );
-    return this;
-  }
+const GMCPClientFileTransferBase = GMCPPackage.with({
+  packageName: 'Client.FileTransfer',
+  messages: [
+    duplex(fileTransferOffer),
+    duplex(fileTransferAccept),
+    duplex(fileTransferReject),
+    duplex(fileTransferCancel),
+    duplex(fileTransferCandidate),
+    outbound(fileTransferRequestResend),
+  ] as const,
+});
 
-  sendCandidate(recipient: string, candidate: RTCIceCandidate): void {
-    this.sendData('Candidate', {
-      recipient,
-      candidate: JSON.stringify(candidate),
-    });
-  }
-
+export class GMCPClientFileTransfer extends GMCPClientFileTransferBase {
   handleCandidate(data: FileTransferCandidate): void {
-    this.signals.emit('candidate', data);
+    this.emitRegisteredMessage(fileTransferCandidate.wireName, data);
   }
 
   handleOffer(data: FileTransferOffer): void {
     console.log('[GMCPClientFileTransfer] Received offer:', data);
-    this.signals.emit('offer', data);
+    this.emitRegisteredMessage(fileTransferOffer.wireName, data);
   }
 
   handleAccept(data: FileTransferAccept): void {
-    this.signals.emit('accept', data);
+    this.emitRegisteredMessage(fileTransferAccept.wireName, data);
   }
 
   handleReject(data: FileTransferReject): void {
-    this.signals.emit('reject', data);
+    this.emitRegisteredMessage(fileTransferReject.wireName, data);
   }
 
   handleCancel(data: FileTransferCancel): void {
-    this.signals.emit('cancel', data);
-  }
-
-  sendOffer(
-    recipient: string,
-    filename: string,
-    filesize: number,
-    offerSdp: string,
-    hash: string,
-  ): void {
-    this.sendData('Offer', { recipient, filename, filesize, offerSdp, hash });
-  }
-
-  sendAccept(sender: string, hash: string, filename: string, answerSdp: string): void {
-    this.sendData('Accept', { sender, hash, filename, answerSdp });
-  }
-
-  sendReject(sender: string, hash: string): void {
-    this.sendData('Reject', { sender, hash });
-  }
-
-  sendCancel(recipient: string, hash: string): void {
-    this.sendData('Cancel', { recipient, hash });
-  }
-
-  sendRequestResend(sender: string, hash: string): void {
-    this.sendData('RequestResend', { sender, hash });
+    this.emitRegisteredMessage(fileTransferCancel.wireName, data);
   }
 }

--- a/src/gmcp/Client/FileTransfer.ts
+++ b/src/gmcp/Client/FileTransfer.ts
@@ -1,4 +1,5 @@
-import { duplex, identityCodec, messageEnvelope, outbound } from '../../protocol/messages';
+import { duplex, identityCodec, outbound } from '../../protocol/messages';
+import { gmcpJsonMessage } from '../messages';
 import { GMCPMessage, GMCPPackage } from '../package';
 
 export class FileTransferOffer extends GMCPMessage {
@@ -54,38 +55,36 @@ export interface FileTransferRequestResend {
   hash: string;
 }
 
-function gmcpJson<InboundPayload, OutboundPayload = InboundPayload>() {
-  return {
-    encode(payload: OutboundPayload): unknown {
-      return payload;
-    },
-    decode(payload: unknown): InboundPayload {
-      return payload as InboundPayload;
-    },
-  };
-}
-
-const fileTransferOffer = messageEnvelope(
+const fileTransferOffer = gmcpJsonMessage<
   'Offer',
-  gmcpJson<FileTransferOffer, FileTransferOfferRequest>(),
+  FileTransferOffer,
+  FileTransferOfferRequest
+>(
+  'Offer',
 );
-const fileTransferAccept = messageEnvelope(
+const fileTransferAccept = gmcpJsonMessage(
   'Accept',
   identityCodec<FileTransferAccept>(),
 );
-const fileTransferReject = messageEnvelope(
+const fileTransferReject = gmcpJsonMessage(
   'Reject',
   identityCodec<FileTransferReject>(),
 );
-const fileTransferCancel = messageEnvelope(
+const fileTransferCancel = gmcpJsonMessage<
   'Cancel',
-  gmcpJson<FileTransferCancel, FileTransferCancelRequest>(),
+  FileTransferCancel,
+  FileTransferCancelRequest
+>(
+  'Cancel',
 );
-const fileTransferCandidate = messageEnvelope(
+const fileTransferCandidate = gmcpJsonMessage<
   'Candidate',
-  gmcpJson<FileTransferCandidate, FileTransferCandidateRequest>(),
+  FileTransferCandidate,
+  FileTransferCandidateRequest
+>(
+  'Candidate',
 );
-const fileTransferRequestResend = messageEnvelope(
+const fileTransferRequestResend = gmcpJsonMessage(
   'RequestResend',
   identityCodec<FileTransferRequestResend>(),
 );

--- a/src/gmcp/Client/Haptics.test.ts
+++ b/src/gmcp/Client/Haptics.test.ts
@@ -61,7 +61,6 @@ import type {
 // Helper: create a mock client
 function createMockClient() {
   return {
-    emit: vi.fn(),
     gmcp: {
       send: vi.fn(),
       handlers: {
@@ -161,15 +160,17 @@ describe("GMCPClientHaptics", () => {
     });
   });
 
-  it("emits hapticsActuate event on client", () => {
+  it("emits actuate package event", () => {
     const data: HapticsActuateData = {
       source: "test",
       commands: [{ actuator: 0, type: "Vibrate", intensity: 0.5 }],
     };
+    const listener = vi.fn();
+    handler.on("actuate", listener);
 
-    handler.handleActuate(data);
+    handler.receiveRegisteredMessage("Actuate", data);
 
-    expect(mockClient.emit).toHaveBeenCalledWith("hapticsActuate", data);
+    expect(listener).toHaveBeenCalledWith(data);
   });
 
   // -----------------------------------------------------------------
@@ -198,15 +199,17 @@ describe("GMCPClientHaptics", () => {
     expect(mockHapticsService.stop).toHaveBeenCalledWith();
   });
 
-  it("emits hapticsStop event on client", () => {
+  it("emits stop package event", () => {
     const data: HapticsStopData = {
       source: "test",
       actuator: null,
     };
+    const listener = vi.fn();
+    handler.on("stop", listener);
 
-    handler.handleStop(data);
+    handler.receiveRegisteredMessage("Stop", data);
 
-    expect(mockClient.emit).toHaveBeenCalledWith("hapticsStop", data);
+    expect(listener).toHaveBeenCalledWith(data);
   });
 
   // -----------------------------------------------------------------
@@ -269,17 +272,19 @@ describe("GMCPClientHaptics", () => {
     expect(mockHapticsService.stop).not.toHaveBeenCalled();
   });
 
-  it("emits hapticsStatus event on client", () => {
+  it("emits status package event", () => {
     const data: HapticsStatusData = {
       enabled: true,
       maxCommandRate: 0,
       maxSensorRate: 0,
       serverVersion: 1,
     };
+    const listener = vi.fn();
+    handler.on("status", listener);
 
-    handler.handleStatus(data);
+    handler.receiveRegisteredMessage("Status", data);
 
-    expect(mockClient.emit).toHaveBeenCalledWith("hapticsStatus", data);
+    expect(listener).toHaveBeenCalledWith(data);
   });
 
   // -----------------------------------------------------------------
@@ -300,18 +305,17 @@ describe("GMCPClientHaptics", () => {
     expect(mockHapticsService.subscribeSensor).toHaveBeenCalledWith(5, 10);
   });
 
-  it("emits hapticsSensorSubscribe event on client", () => {
+  it("emits sensorSubscribe package event", () => {
     const data: HapticsSensorSubscribeData = {
       sensors: [1],
       rate: 5,
     };
+    const listener = vi.fn();
+    handler.on("sensorSubscribe", listener);
 
-    handler.handleSensorSubscribe(data);
+    handler.receiveRegisteredMessage("SensorSubscribe", data);
 
-    expect(mockClient.emit).toHaveBeenCalledWith(
-      "hapticsSensorSubscribe",
-      data
-    );
+    expect(listener).toHaveBeenCalledWith(data);
   });
 
   // -----------------------------------------------------------------
@@ -330,17 +334,16 @@ describe("GMCPClientHaptics", () => {
     expect(mockHapticsService.unsubscribeSensor).toHaveBeenCalledWith(3);
   });
 
-  it("emits hapticsSensorUnsubscribe event on client", () => {
+  it("emits sensorUnsubscribe package event", () => {
     const data: HapticsSensorUnsubscribeData = {
       sensors: [1],
     };
+    const listener = vi.fn();
+    handler.on("sensorUnsubscribe", listener);
 
-    handler.handleSensorUnsubscribe(data);
+    handler.receiveRegisteredMessage("SensorUnsubscribe", data);
 
-    expect(mockClient.emit).toHaveBeenCalledWith(
-      "hapticsSensorUnsubscribe",
-      data
-    );
+    expect(listener).toHaveBeenCalledWith(data);
   });
 
   // -----------------------------------------------------------------

--- a/src/gmcp/Client/Haptics.test.ts
+++ b/src/gmcp/Client/Haptics.test.ts
@@ -74,6 +74,17 @@ function createMockClient() {
   };
 }
 
+function serviceCallback(eventName: string): (...args: unknown[]) => void {
+  const calls = mockHapticsService.on.mock.calls as Array<
+    [string, (...args: unknown[]) => void]
+  >;
+  const call = calls.find(([event]) => event === eventName);
+  if (!call) {
+    throw new Error(`Expected haptics service listener: ${eventName}`);
+  }
+  return call[1];
+}
+
 describe("GMCPClientHaptics", () => {
   let handler: GMCPClientHaptics;
   let mockClient: ReturnType<typeof createMockClient>;
@@ -333,11 +344,11 @@ describe("GMCPClientHaptics", () => {
   });
 
   // -----------------------------------------------------------------
-  // sendCapabilities
+  // publishCapabilities
   // -----------------------------------------------------------------
 
   it("sends correct GMCP capabilities message", () => {
-    handler.sendCapabilities();
+    handler.publishCapabilities();
 
     expect(mockHapticsService.getCapabilities).toHaveBeenCalledOnce();
     expect(mockClient.gmcp.send).toHaveBeenCalledWith(
@@ -353,11 +364,11 @@ describe("GMCPClientHaptics", () => {
   });
 
   // -----------------------------------------------------------------
-  // sendStopped
+  // publishStopped
   // -----------------------------------------------------------------
 
   it("sends correct GMCP stopped message", () => {
-    handler.sendStopped("user_stop");
+    handler.publishStopped("user_stop");
 
     expect(mockClient.gmcp.send).toHaveBeenCalledWith(
       "Client.Haptics.Stopped",
@@ -366,7 +377,7 @@ describe("GMCPClientHaptics", () => {
   });
 
   it("sends correct GMCP stopped message for auto_stop", () => {
-    handler.sendStopped("auto_stop");
+    handler.publishStopped("auto_stop");
 
     expect(mockClient.gmcp.send).toHaveBeenCalledWith(
       "Client.Haptics.Stopped",
@@ -375,11 +386,11 @@ describe("GMCPClientHaptics", () => {
   });
 
   // -----------------------------------------------------------------
-  // sendSensor
+  // publishSensorReading
   // -----------------------------------------------------------------
 
   it("sends correct GMCP sensor message", () => {
-    handler.sendSensor({ sensor: 0, type: "Pressure", value: 0.75 });
+    handler.publishSensorReading({ sensor: 0, type: "Pressure", value: 0.75 });
 
     expect(mockClient.gmcp.send).toHaveBeenCalledWith(
       "Client.Haptics.Sensor",
@@ -397,9 +408,7 @@ describe("GMCPClientHaptics", () => {
     handler.advertiseHapticsSupport();
 
     const coreSupports = mockClient.gmcp.handlers["Core.Supports"];
-    expect(coreSupports.sendAdd).toHaveBeenCalledWith([
-      { name: "Client.Haptics", version: 1 },
-    ]);
+    expect(coreSupports.sendAdd).toHaveBeenCalledWith(["Client.Haptics 1"]);
   });
 
   it("does not double-advertise", () => {
@@ -486,12 +495,7 @@ describe("GMCPClientHaptics", () => {
   it("sends capabilities on capabilitieschanged when enabled and advertised", () => {
     mockPreferencesState.haptics.enabled = true;
 
-    // Get the capabilitieschanged callback that was registered
-    const onCall = mockHapticsService.on.mock.calls.find(
-      (c: any[]) => c[0] === "capabilitieschanged"
-    );
-    expect(onCall).toBeDefined();
-    const capabilitiesChangedCallback = onCall![1];
+    const capabilitiesChangedCallback = serviceCallback("capabilitieschanged");
 
     // Advertise first
     handler.advertiseHapticsSupport();
@@ -510,10 +514,7 @@ describe("GMCPClientHaptics", () => {
   it("does not send capabilities on capabilitieschanged when not advertised", () => {
     mockPreferencesState.haptics.enabled = true;
 
-    const onCall = mockHapticsService.on.mock.calls.find(
-      (c: any[]) => c[0] === "capabilitieschanged"
-    );
-    const capabilitiesChangedCallback = onCall![1];
+    const capabilitiesChangedCallback = serviceCallback("capabilitieschanged");
 
     vi.clearAllMocks();
 
@@ -528,10 +529,7 @@ describe("GMCPClientHaptics", () => {
   // -----------------------------------------------------------------
 
   it("sends Stopped to server when service emits stopped", () => {
-    const onCall = mockHapticsService.on.mock.calls.find(
-      (c: any[]) => c[0] === "stopped"
-    );
-    const stoppedCallback = onCall![1];
+    const stoppedCallback = serviceCallback("stopped");
 
     stoppedCallback("auto_stop");
 
@@ -546,10 +544,7 @@ describe("GMCPClientHaptics", () => {
   // -----------------------------------------------------------------
 
   it("sends Sensor to server when service emits sensorreading", () => {
-    const onCall = mockHapticsService.on.mock.calls.find(
-      (c: any[]) => c[0] === "sensorreading"
-    );
-    const sensorReadingCallback = onCall![1];
+    const sensorReadingCallback = serviceCallback("sensorreading");
 
     sensorReadingCallback({ sensor: 1, type: "Battery", value: 0.85 });
 

--- a/src/gmcp/Client/Haptics.ts
+++ b/src/gmcp/Client/Haptics.ts
@@ -163,7 +163,6 @@ export class GMCPClientHaptics extends GMCPClientHapticsBase {
       clockwise: cmd.clockwise,
     }));
     hapticsService.actuate(commands);
-    this.client.emit("hapticsActuate", data);
   }
 
   handleStop(data: HapticsStopData): void {
@@ -172,7 +171,6 @@ export class GMCPClientHaptics extends GMCPClientHapticsBase {
     } else {
       hapticsService.stop();
     }
-    this.client.emit("hapticsStop", data);
   }
 
   handleStatus(data: HapticsStatusData): void {
@@ -190,8 +188,6 @@ export class GMCPClientHaptics extends GMCPClientHapticsBase {
     if (!data.enabled) {
       hapticsService.stop();
     }
-
-    this.client.emit("hapticsStatus", data);
   }
 
   handleSensorSubscribe(data: HapticsSensorSubscribeData): void {
@@ -202,7 +198,6 @@ export class GMCPClientHaptics extends GMCPClientHapticsBase {
         hapticsService.unsubscribeSensor(sensorId);
       });
     }
-    this.client.emit("hapticsSensorSubscribe", data);
   }
 
   handleSensorUnsubscribe(data: HapticsSensorUnsubscribeData): void {
@@ -215,7 +210,6 @@ export class GMCPClientHaptics extends GMCPClientHapticsBase {
         hapticsService.unsubscribeSensor(sensorId);
       }
     }
-    this.client.emit("hapticsSensorUnsubscribe", data);
   }
 
   // -------------------------------------------------------------------

--- a/src/gmcp/Client/Haptics.ts
+++ b/src/gmcp/Client/Haptics.ts
@@ -1,7 +1,10 @@
+import type MudClient from "../../client";
+import { inbound, outbound } from "../../protocol/messages";
 import { GMCPPackage } from "../package";
 import { hapticsService } from "../../HapticsService";
 import { usePreferences } from "../../stores/preferencesStore";
 import type { HapticsCommand, HapticsSensorReading } from "../../haptics/types";
+import { gmcpJsonMessage } from "../messages";
 
 // ---------------------------------------------------------------------------
 // Server -> Client message types
@@ -39,12 +42,52 @@ export interface HapticsSensorUnsubscribeData {
   sensors: number[];
 }
 
+interface HapticsSensorPayload {
+  readings: HapticsSensorReading[];
+}
+
+interface HapticsStoppedPayload {
+  reason: string;
+}
+
+const hapticsActuate = gmcpJsonMessage<"Actuate", HapticsActuateData>("Actuate");
+const hapticsStop = gmcpJsonMessage<"Stop", HapticsStopData>("Stop");
+const hapticsStatus = gmcpJsonMessage<"Status", HapticsStatusData>("Status");
+const hapticsSensorSubscribe = gmcpJsonMessage<
+  "SensorSubscribe",
+  HapticsSensorSubscribeData
+>("SensorSubscribe");
+const hapticsSensorUnsubscribe = gmcpJsonMessage<
+  "SensorUnsubscribe",
+  HapticsSensorUnsubscribeData
+>("SensorUnsubscribe");
+const hapticsCapabilities = gmcpJsonMessage<
+  "Capabilities",
+  never,
+  ReturnType<typeof hapticsService.getCapabilities>
+>("Capabilities");
+const hapticsSensor = gmcpJsonMessage<"Sensor", never, HapticsSensorPayload>("Sensor");
+const hapticsStopped = gmcpJsonMessage<"Stopped", never, HapticsStoppedPayload>("Stopped");
+
+const GMCPClientHapticsBase = GMCPPackage.with({
+  packageName: "Client.Haptics",
+  messages: [
+    inbound(hapticsActuate),
+    inbound(hapticsStop),
+    inbound(hapticsStatus),
+    inbound(hapticsSensorSubscribe),
+    inbound(hapticsSensorUnsubscribe),
+    outbound(hapticsCapabilities),
+    outbound(hapticsSensor),
+    outbound(hapticsStopped),
+  ] as const,
+});
+
 // ---------------------------------------------------------------------------
 // GMCPClientHaptics
 // ---------------------------------------------------------------------------
 
-export class GMCPClientHaptics extends GMCPPackage {
-  public packageName: string = "Client.Haptics";
+export class GMCPClientHaptics extends GMCPClientHapticsBase {
   public packageVersion?: number = 1;
 
   private isAdvertised: boolean = false;
@@ -65,8 +108,13 @@ export class GMCPClientHaptics extends GMCPPackage {
     return usePreferences.getState().haptics.enabled;
   }
 
-  constructor(client: any) {
+  constructor(client: MudClient) {
     super(client);
+    this.on("actuate", (data) => this.handleActuate(data));
+    this.on("stop", (data) => this.handleStop(data));
+    this.on("status", (data) => this.handleStatus(data));
+    this.on("sensorSubscribe", (data) => this.handleSensorSubscribe(data));
+    this.on("sensorUnsubscribe", (data) => this.handleSensorUnsubscribe(data));
     this.setupServiceListeners();
   }
 
@@ -77,7 +125,7 @@ export class GMCPClientHaptics extends GMCPPackage {
   private setupServiceListeners(): void {
     const onCapabilitiesChanged = (): void => {
       if (this.enabled && this.isAdvertised) {
-        this.sendCapabilities();
+        this.publishCapabilities();
       }
     };
     hapticsService.on("capabilitieschanged", onCapabilitiesChanged);
@@ -86,7 +134,7 @@ export class GMCPClientHaptics extends GMCPPackage {
     );
 
     const onStopped = (reason: string): void => {
-      this.sendStopped(reason);
+      this.publishStopped(reason);
     };
     hapticsService.on("stopped", onStopped);
     this.serviceCleanup.push(() =>
@@ -94,7 +142,7 @@ export class GMCPClientHaptics extends GMCPPackage {
     );
 
     const onSensorReading = (reading: HapticsSensorReading): void => {
-      this.sendSensor(reading);
+      this.publishSensorReading(reading);
     };
     hapticsService.on("sensorreading", onSensorReading);
     this.serviceCleanup.push(() =>
@@ -174,17 +222,17 @@ export class GMCPClientHaptics extends GMCPPackage {
   // Client -> Server senders
   // -------------------------------------------------------------------
 
-  sendCapabilities(): void {
+  publishCapabilities(): void {
     const capabilities = hapticsService.getCapabilities();
-    this.sendData("Capabilities", capabilities);
+    this.sendCapabilities(capabilities);
   }
 
-  sendSensor(reading: HapticsSensorReading): void {
-    this.sendData("Sensor", { readings: [reading] });
+  publishSensorReading(reading: HapticsSensorReading): void {
+    this.sendSensor({ readings: [reading] });
   }
 
-  sendStopped(reason: string): void {
-    this.sendData("Stopped", { reason });
+  publishStopped(reason: string): void {
+    this.sendStopped({ reason });
   }
 
   // -------------------------------------------------------------------
@@ -195,9 +243,7 @@ export class GMCPClientHaptics extends GMCPPackage {
     if (!this.isAdvertised) {
       const coreSupports = this.client.gmcp.handlers["Core.Supports"];
       if (coreSupports) {
-        coreSupports.sendAdd([
-          { name: "Client.Haptics", version: this.packageVersion || 1 },
-        ]);
+        coreSupports.sendAdd([`Client.Haptics ${this.packageVersion || 1}`]);
         this.isAdvertised = true;
       }
     }

--- a/src/gmcp/Client/Html.ts
+++ b/src/gmcp/Client/Html.ts
@@ -1,4 +1,5 @@
-import type MudClient from "../../client";
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 import { marked } from 'marked';
 
@@ -12,18 +13,29 @@ class GMCPMessageClientHtmlAddHtml extends GMCPMessage {
     public readonly data!: string[];
 }
 
-export class GMCPClientHtml extends GMCPPackage {
-    public packageName: string = "Client.Html";
+const htmlAddHtml = gmcpJsonMessage<"Add_html", GMCPMessageClientHtmlAddHtml>("Add_html");
+const htmlAddMarkdown = gmcpJsonMessage<"Add_markdown", GMCPMessageClientHtmlAddHtml>("Add_markdown");
 
-    constructor(client: MudClient) {
+const GMCPClientHtmlBase = GMCPPackage.with({
+    packageName: "Client.Html",
+    messages: [
+        inbound(htmlAddHtml),
+        inbound(htmlAddMarkdown),
+    ] as const,
+});
+
+export class GMCPClientHtml extends GMCPClientHtmlBase {
+    constructor(client: ConstructorParameters<typeof GMCPClientHtmlBase>[0]) {
         super(client);
+        this.on("addHtml", (data) => this.handleAddHtml(data));
+        this.on("addMarkdown", (data) => this.handleAddMarkdown(data));
     }
 
-    public handleAdd_html(data: GMCPMessageClientHtmlAddHtml): void {
+    public handleAddHtml(data: GMCPMessageClientHtmlAddHtml): void {
         this.client.emit("html", data.data.join("\n"));
     }
 
-    public handleAdd_markdown(data: GMCPMessageClientHtmlAddHtml): void {
+    public handleAddMarkdown(data: GMCPMessageClientHtmlAddHtml): void {
         const markdown = data.data.join("\n");
         const html = marked(markdown);
         // marked adds trailing \n to all block elements - strip it

--- a/src/gmcp/Client/Html.ts
+++ b/src/gmcp/Client/Html.ts
@@ -1,13 +1,6 @@
 import { inbound } from "../../protocol/messages";
 import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
-import { marked } from 'marked';
-
-// Configure marked options
-marked.setOptions({
-    breaks: true,  // Convert single \n to <br> (more intuitive for chat-like content)
-    gfm: true,     // GitHub Flavored Markdown (already default)
-});
 
 class GMCPMessageClientHtmlAddHtml extends GMCPMessage {
     public readonly data!: string[];
@@ -25,20 +18,4 @@ const GMCPClientHtmlBase = GMCPPackage.with({
 });
 
 export class GMCPClientHtml extends GMCPClientHtmlBase {
-    constructor(client: ConstructorParameters<typeof GMCPClientHtmlBase>[0]) {
-        super(client);
-        this.on("addHtml", (data) => this.handleAddHtml(data));
-        this.on("addMarkdown", (data) => this.handleAddMarkdown(data));
-    }
-
-    public handleAddHtml(data: GMCPMessageClientHtmlAddHtml): void {
-        this.client.emit("html", data.data.join("\n"));
-    }
-
-    public handleAddMarkdown(data: GMCPMessageClientHtmlAddHtml): void {
-        const markdown = data.data.join("\n");
-        const html = marked(markdown);
-        // marked adds trailing \n to all block elements - strip it
-        this.client.emit("html", typeof html === 'string' ? html.trimEnd() : html);
-    }
 }

--- a/src/gmcp/Client/Keystrokes.ts
+++ b/src/gmcp/Client/Keystrokes.ts
@@ -1,6 +1,7 @@
-import type MudClient from "../../client";
+import { inbound, outbound } from "../../protocol/messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 import { useInputStore } from "../../stores/inputStore";
+import { gmcpJsonMessage } from "../messages";
 
 interface KeyBinding {
     key: string;
@@ -34,14 +35,37 @@ class GMCPMessageClientKeystrokesListBindings extends GMCPMessage {
     // No specific properties needed for this message
 }
 
-export class GMCPClientKeystrokes extends GMCPPackage {
-    public packageName: string = "Client.Keystrokes";
+const keystrokesBind = gmcpJsonMessage<"Bind", GMCPMessageClientKeystrokesBind>("Bind");
+const keystrokesUnbind = gmcpJsonMessage<"Unbind", GMCPMessageClientKeystrokesUnbind>("Unbind");
+const keystrokesBindAll = gmcpJsonMessage<"Bind_all", GMCPMessageClientKeystrokesBindAll>("Bind_all");
+const keystrokesUnbindAll = gmcpJsonMessage<"UnbindAll", GMCPMessageClientKeystrokesUnbindAll>("UnbindAll");
+const keystrokesListBindings = gmcpJsonMessage<"ListBindings", GMCPMessageClientKeystrokesListBindings>("ListBindings");
+const keystrokesBindingsList = gmcpJsonMessage<"BindingsList", never, KeyBinding[]>("BindingsList");
+
+const GMCPClientKeystrokesBase = GMCPPackage.with({
+    packageName: "Client.Keystrokes",
+    messages: [
+        inbound(keystrokesBind),
+        inbound(keystrokesUnbind),
+        inbound(keystrokesBindAll),
+        inbound(keystrokesUnbindAll),
+        inbound(keystrokesListBindings),
+        outbound(keystrokesBindingsList),
+    ] as const,
+});
+
+export class GMCPClientKeystrokes extends GMCPClientKeystrokesBase {
     private bindings: KeyBinding[] = [];
     // Store the bound handler function
     private boundKeyDownHandler: (event: KeyboardEvent) => void;
 
-    constructor(client: MudClient) {
+    constructor(client: ConstructorParameters<typeof GMCPClientKeystrokesBase>[0]) {
         super(client);
+        this.on("bind", (data) => this.handleBind(data));
+        this.on("unbind", (data) => this.handleUnbind(data));
+        this.on("bindAll", (data) => this.handleBindAll(data));
+        this.on("unbindAll", (data) => this.handleUnbindAll(data));
+        this.on("listBindings", (data) => this.handleListBindings(data));
         // Bind the handler once and store it
         this.boundKeyDownHandler = this.handleKeydown.bind(this);
         document.addEventListener('keydown', this.boundKeyDownHandler);
@@ -162,24 +186,20 @@ export class GMCPClientKeystrokes extends GMCPPackage {
         this.unbindKey(data);
     }
 
-    public handleBind_all(data: GMCPMessageClientKeystrokesBindAll): void {
+    public handleBindAll(data: GMCPMessageClientKeystrokesBindAll): void {
         this.bindings = data.bindings.map(binding => ({ ...binding }));
     }
 
-    public handleUnbindAll(data: GMCPMessageClientKeystrokesUnbindAll): void {
-        // The data parameter isn't strictly needed here, but included for consistency
-        // with how handleGmcpData calls handlers.
+    public handleUnbindAll(_data: GMCPMessageClientKeystrokesUnbindAll): void {
         console.log("Received Client.Keystrokes.UnbindAll, clearing all bindings."); // Optional logging
         this.unbindAll();
     }
 
     // Handler for the server's request to list bindings
-    public handleListBindings(data: GMCPMessageClientKeystrokesListBindings): void {
-        // data parameter is unused but kept for consistency
+    public handleListBindings(_data: GMCPMessageClientKeystrokesListBindings): void {
         console.log("Received Client.Keystrokes.ListBindings request, sending current bindings."); // Optional logging
         const bindingsArray = this.listBindings();
-        // Send the list back using the "BindingsList" message name
-        this.sendData("BindingsList", bindingsArray);
+        this.sendBindingsList(bindingsArray);
     }
 
     public listBindings(): KeyBinding[] {

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -293,7 +293,7 @@ describe('GMCPClientMedia', () => {
     });
 
     it('advertises EffectsSupport to the server', () => {
-      handler.sendEffectsSupport();
+      handler.publishEffectsSupport();
       expect(client.gmcp.send).toHaveBeenCalledWith(
         'Client.Media.EffectsSupport',
         expect.stringContaining('reverb'),

--- a/src/gmcp/Client/Media.ts
+++ b/src/gmcp/Client/Media.ts
@@ -15,6 +15,8 @@ import type {
 } from '../../audio/MediaService';
 import { buildEffectsSupport } from '../../audio/effects/MediaEffects';
 import type { EffectSpec } from '../../audio/effects/types';
+import { inbound, outbound } from '../../protocol/messages';
+import { gmcpJsonMessage } from '../messages';
 import { GMCPMessage, GMCPPackage } from '../package';
 
 export class GMCPMessageClientMediaLoad extends GMCPMessage implements ClientMediaLoadPayload {
@@ -128,11 +130,69 @@ export class GMCPMessageClientMediaListenerPosition
   public readonly position?: Position;
 }
 
-export class GMCPClientMedia extends GMCPPackage {
-  public packageName = 'Client.Media';
+const mediaChain = gmcpJsonMessage<'Chain', GMCPMessageClientMediaChain>('Chain');
+const mediaChainStop = gmcpJsonMessage<
+  'ChainStop',
+  GMCPMessageClientMediaChainStop
+>('ChainStop');
+const mediaAutomate = gmcpJsonMessage<
+  'Automate',
+  GMCPMessageClientMediaAutomate
+>('Automate');
+const mediaDefault = gmcpJsonMessage<'Default', string>('Default');
+const mediaLoad = gmcpJsonMessage<'Load', GMCPMessageClientMediaLoad>('Load');
+const mediaPlay = gmcpJsonMessage<'Play', GMCPMessageClientMediaPlay>('Play');
+const mediaUpdate = gmcpJsonMessage<'Update', GMCPMessageClientMediaUpdate>('Update');
+const mediaStop = gmcpJsonMessage<'Stop', GMCPMessageClientMediaStop>('Stop');
+const mediaListenerPosition = gmcpJsonMessage<
+  'ListenerPosition',
+  GMCPMessageClientMediaListenerPosition
+>('ListenerPosition');
+const mediaListenerOrientation = gmcpJsonMessage<
+  'ListenerOrientation',
+  GMCPMessageClientMediaListenerOrientation
+>('ListenerOrientation');
+const mediaEffectsSupport = gmcpJsonMessage<
+  'EffectsSupport',
+  never,
+  ReturnType<typeof buildEffectsSupport>
+>('EffectsSupport');
 
-  constructor(client: GMCPPackage['client']) {
+const GMCPClientMediaBase = GMCPPackage.with({
+  packageName: 'Client.Media',
+  messages: [
+    inbound(mediaChain),
+    inbound(mediaChainStop),
+    inbound(mediaAutomate),
+    inbound(mediaDefault),
+    inbound(mediaLoad),
+    inbound(mediaPlay),
+    inbound(mediaUpdate),
+    inbound(mediaStop),
+    inbound(mediaListenerPosition),
+    inbound(mediaListenerOrientation),
+    outbound(mediaEffectsSupport),
+  ] as const,
+});
+
+export class GMCPClientMedia extends GMCPClientMediaBase {
+
+  constructor(client: ConstructorParameters<typeof GMCPClientMediaBase>[0]) {
     super(client);
+    this.on('chain', (data) => this.handleChain(data));
+    this.on('chainStop', (data) => this.handleChainStop(data));
+    this.on('automate', (data) => this.handleAutomate(data));
+    this.on('default', (data) => this.handleDefault(data));
+    this.on('load', (data) => {
+      void this.handleLoad(data);
+    });
+    this.on('play', (data) => {
+      void this.handlePlay(data);
+    });
+    this.on('update', (data) => this.handleUpdate(data));
+    this.on('stop', (data) => this.handleStop(data));
+    this.on('listenerPosition', (data) => this.handleListenerPosition(data));
+    this.on('listenerOrientation', (data) => this.handleListenerOrientation(data));
     this.client.on('spatialListenerOrientation', this.handleSpatialListenerOrientation);
     this.client.on('spatialScene', this.handleSpatialScene);
   }
@@ -141,8 +201,8 @@ export class GMCPClientMedia extends GMCPPackage {
     return this.client.media.sounds;
   }
 
-  sendEffectsSupport(): void {
-    this.sendData('EffectsSupport', buildEffectsSupport());
+  publishEffectsSupport(): void {
+    this.sendEffectsSupport(buildEffectsSupport());
   }
 
   handleChain(data: GMCPMessageClientMediaChain): void {

--- a/src/gmcp/Client/Midi.ts
+++ b/src/gmcp/Client/Midi.ts
@@ -1,5 +1,7 @@
 import type { MidiMessage, MidiNote } from "../../MidiService";
 import { usePreferences } from "../../stores/preferencesStore";
+import { duplex } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export class GMCPMessageClientMidiNote extends GMCPMessage {
@@ -38,8 +40,35 @@ export class GMCPMessageClientMidiEnable extends GMCPMessage {
 
 type MidiService = typeof import("../../MidiService").midiService;
 
-export class GMCPClientMidi extends GMCPPackage {
-  public packageName: string = "Client.Midi";
+const midiNote = gmcpJsonMessage<"Note", GMCPMessageClientMidiNote>("Note");
+const midiControlChange = gmcpJsonMessage<
+  "ControlChange",
+  GMCPMessageClientMidiControlChange
+>("ControlChange");
+const midiProgramChange = gmcpJsonMessage<
+  "ProgramChange",
+  GMCPMessageClientMidiProgramChange
+>("ProgramChange");
+const midiSystemMessage = gmcpJsonMessage<
+  "SystemMessage",
+  GMCPMessageClientMidiSystemMessage
+>("SystemMessage");
+const midiRawMessage = gmcpJsonMessage<"RawMessage", GMCPMessageClientMidiRawMessage>("RawMessage");
+const midiEnable = gmcpJsonMessage<"Enable", GMCPMessageClientMidiEnable>("Enable");
+
+const GMCPClientMidiBase = GMCPPackage.with({
+  packageName: "Client.Midi",
+  messages: [
+    duplex(midiNote),
+    duplex(midiControlChange),
+    duplex(midiProgramChange),
+    duplex(midiSystemMessage),
+    duplex(midiRawMessage),
+    duplex(midiEnable),
+  ] as const,
+});
+
+export class GMCPClientMidi extends GMCPClientMidiBase {
   public packageVersion?: number = 1;
   private activeNotes: Map<string, NodeJS.Timeout> = new Map();
   private isAdvertised: boolean = false;
@@ -53,8 +82,14 @@ export class GMCPClientMidi extends GMCPPackage {
     return usePreferences.getState().midi.enabled;
   }
 
-  constructor(client: any) {
+  constructor(client: ConstructorParameters<typeof GMCPClientMidiBase>[0]) {
     super(client);
+    this.on("note", (data) => this.handleNote(data));
+    this.on("controlChange", (data) => this.handleControlChange(data));
+    this.on("programChange", (data) => this.handleProgramChange(data));
+    this.on("systemMessage", (data) => this.handleSystemMessage(data));
+    this.on("rawMessage", (data) => this.handleRawMessage(data));
+    this.on("enable", (data) => this.handleEnable(data));
   }
 
   private loadMidiService(): Promise<MidiService> {
@@ -137,7 +172,7 @@ export class GMCPClientMidi extends GMCPPackage {
         on: message.note.on,
         channel: message.note.channel,
       };
-      this.sendData("Note", noteData);
+      this.sendNote(noteData);
       gmcpMessage = `Client.Midi.Note ${JSON.stringify(noteData)}`;
     } else if (message.controlChange) {
       const ccData = {
@@ -145,21 +180,21 @@ export class GMCPClientMidi extends GMCPPackage {
         value: message.controlChange.value,
         channel: message.controlChange.channel,
       };
-      this.sendData("ControlChange", ccData);
+      this.sendControlChange(ccData);
       gmcpMessage = `Client.Midi.ControlChange ${JSON.stringify(ccData)}`;
     } else if (message.programChange) {
       const pcData = {
         program: message.programChange.program,
         channel: message.programChange.channel,
       };
-      this.sendData("ProgramChange", pcData);
+      this.sendProgramChange(pcData);
       gmcpMessage = `Client.Midi.ProgramChange ${JSON.stringify(pcData)}`;
     } else if (message.systemMessage) {
       const sysData = {
         type: message.systemMessage.type,
         data: message.systemMessage.data,
       };
-      this.sendData("SystemMessage", sysData);
+      this.sendSystemMessage(sysData);
       gmcpMessage = `Client.Midi.SystemMessage ${JSON.stringify(sysData)}`;
     } else if (message.raw) {
       const rawData = {
@@ -167,7 +202,7 @@ export class GMCPClientMidi extends GMCPPackage {
         data: Array.from(message.raw.data),
         type: message.raw.type,
       };
-      this.sendData("RawMessage", rawData);
+      this.sendRawMessage(rawData);
       gmcpMessage = `Client.Midi.RawMessage ${JSON.stringify(rawData)}`;
     }
 
@@ -177,18 +212,15 @@ export class GMCPClientMidi extends GMCPPackage {
   }
 
   private sendNoteToServer(note: MidiNote, duration?: number): void {
-    const noteData: any = {
+    const noteData: GMCPMessageClientMidiNote = {
       note: note.note,
       velocity: note.velocity,
       on: note.on,
       channel: note.channel,
+      ...(duration === undefined ? {} : { duration }),
     };
 
-    if (duration !== undefined) {
-      noteData.duration = duration;
-    }
-
-    this.sendData("Note", noteData);
+    this.sendNote(noteData);
   }
 
   handleNote(data: GMCPMessageClientMidiNote): void {
@@ -206,8 +238,9 @@ export class GMCPClientMidi extends GMCPPackage {
     };
 
     const noteKey = `${data.note}_${data.channel || 0}`;
-    if (this.activeNotes.has(noteKey)) {
-      clearTimeout(this.activeNotes.get(noteKey)!);
+    const activeNoteTimeout = this.activeNotes.get(noteKey);
+    if (activeNoteTimeout) {
+      clearTimeout(activeNoteTimeout);
       this.activeNotes.delete(noteKey);
     }
 
@@ -263,7 +296,7 @@ export class GMCPClientMidi extends GMCPPackage {
     if (!this.isAdvertised) {
       const coreSupports = this.client.gmcp.handlers["Core.Supports"];
       if (coreSupports) {
-        coreSupports.sendAdd([{ name: "Client.Midi", version: this.packageVersion || 1 }]);
+        coreSupports.sendAdd([`Client.Midi ${this.packageVersion || 1}`]);
         this.isAdvertised = true;
         console.log("Advertised MIDI support to server");
       }
@@ -283,12 +316,12 @@ export class GMCPClientMidi extends GMCPPackage {
 
   sendMidiCapability(): void {
     if (!this.enabled) {
-      this.sendData("Enable", { enabled: false });
+      this.sendEnable({ enabled: false });
       return;
     }
 
     void this.loadMidiService().then((midiService) => {
-      this.sendData("Enable", {
+      this.sendEnable({
         enabled: midiService.isSupported && midiService.isInitialized,
       });
     });

--- a/src/gmcp/Client/Spatial.test.ts
+++ b/src/gmcp/Client/Spatial.test.ts
@@ -21,7 +21,6 @@ function createMockClient() {
         cacophony.listenerPosition = position ?? [0, 0, 0];
       }),
     },
-    emit: vi.fn(),
     gmcp: {
       send: vi.fn(),
     },
@@ -37,7 +36,9 @@ describe('GMCPClientSpatial', () => {
     useSpatialStore.getState().reset();
     useSessionStore.getState().reset();
     client = createMockClient();
-    handler = new GMCPClientSpatial(client as any);
+    handler = new GMCPClientSpatial(
+      client as unknown as ConstructorParameters<typeof GMCPClientSpatial>[0],
+    );
   });
 
   it('replaces stale scene state on Scene snapshot', () => {
@@ -111,10 +112,6 @@ describe('GMCPClientSpatial', () => {
         mediaKey: 'radio-1',
       },
     });
-    expect(client.emit).toHaveBeenCalledWith(
-      'spatialScene',
-      expect.objectContaining({ roomId: 'new-room', listenerId: 'player-1' }),
-    );
   });
 
   it('adds one entity on EntityEnter', () => {
@@ -127,11 +124,6 @@ describe('GMCPClientSpatial', () => {
     });
 
     expect(useSpatialStore.getState().spatialEntities['player-2']).toEqual({
-      id: 'player-2',
-      name: 'Daiverd',
-      position: [4, 5, 6],
-    });
-    expect(client.emit).toHaveBeenCalledWith('spatialEntityEnter', {
       id: 'player-2',
       name: 'Daiverd',
       position: [4, 5, 6],
@@ -168,7 +160,6 @@ describe('GMCPClientSpatial', () => {
         binding: 'world',
       },
     });
-    expect(client.emit).toHaveBeenCalledWith('spatialEntityLeave', 'player-2');
   });
 
   it('updates stored coordinates and velocity on EntityMove', () => {
@@ -200,15 +191,6 @@ describe('GMCPClientSpatial', () => {
       forward: [1, 0, 0],
       up: [0, 0, 1],
     });
-    expect(client.emit).toHaveBeenCalledWith('spatialEntityMove', {
-      id: 'player-1',
-      name: 'Q',
-      kind: 'player',
-      position: [2, 3, 4],
-      velocity: [0.5, 0, 0],
-      forward: [1, 0, 0],
-      up: [0, 0, 1],
-    });
   });
 
   it('updates listener position and orientation messages', () => {
@@ -232,15 +214,6 @@ describe('GMCPClientSpatial', () => {
     expect(client.media.cacophony.listenerPosition).toEqual([7, 8, 9]);
     expect(client.media.cacophony.listenerForwardOrientation).toEqual([0, 1, 0]);
     expect(client.media.cacophony.listenerUpOrientation).toEqual([0, 0, 1]);
-    expect(client.emit).toHaveBeenCalledWith('spatialListenerPosition', {
-      listenerId: 'player-1',
-      position: [7, 8, 9],
-    });
-    expect(client.emit).toHaveBeenCalledWith('spatialListenerOrientation', {
-      listenerId: 'player-1',
-      forward: [0, 1, 0],
-      up: [0, 0, 1],
-    });
   });
 
   it('resets cacophony listener state to defaults when a Scene omits listener vectors', () => {

--- a/src/gmcp/Client/Spatial.ts
+++ b/src/gmcp/Client/Spatial.ts
@@ -1,5 +1,7 @@
 import { useSessionStore } from '../../stores/sessionStore';
 import { useSpatialStore } from '../../stores/spatialStore';
+import { inbound } from '../../protocol/messages';
+import { gmcpJsonMessage } from '../messages';
 import { GMCPMessage, GMCPPackage } from '../package';
 
 export type SpatialVector = [number, number, number];
@@ -91,6 +93,50 @@ export class GMCPMessageClientSpatialEmitterStop extends GMCPMessage {
   emitterId: string = '';
 }
 
+const spatialScene = gmcpJsonMessage<'Scene', GMCPMessageClientSpatialScene>('Scene');
+const spatialEntityEnter = gmcpJsonMessage<
+  'EntityEnter',
+  GMCPMessageClientSpatialEntityEnter
+>('EntityEnter');
+const spatialEntityLeave = gmcpJsonMessage<
+  'EntityLeave',
+  GMCPMessageClientSpatialEntityLeave
+>('EntityLeave');
+const spatialEntityMove = gmcpJsonMessage<
+  'EntityMove',
+  GMCPMessageClientSpatialEntityMove
+>('EntityMove');
+const spatialListenerPosition = gmcpJsonMessage<
+  'ListenerPosition',
+  GMCPMessageClientSpatialListenerPosition
+>('ListenerPosition');
+const spatialListenerOrientation = gmcpJsonMessage<
+  'ListenerOrientation',
+  GMCPMessageClientSpatialListenerOrientation
+>('ListenerOrientation');
+const spatialEmitterStart = gmcpJsonMessage<
+  'EmitterStart',
+  GMCPMessageClientSpatialEmitterStart
+>('EmitterStart');
+const spatialEmitterStop = gmcpJsonMessage<
+  'EmitterStop',
+  GMCPMessageClientSpatialEmitterStop
+>('EmitterStop');
+
+const GMCPClientSpatialBase = GMCPPackage.with({
+  packageName: 'Client.Spatial',
+  messages: [
+    inbound(spatialScene),
+    inbound(spatialEntityEnter),
+    inbound(spatialEntityLeave),
+    inbound(spatialEntityMove),
+    inbound(spatialListenerPosition),
+    inbound(spatialListenerOrientation),
+    inbound(spatialEmitterStart),
+    inbound(spatialEmitterStop),
+  ] as const,
+});
+
 function indexById<T extends { id: string }>(items: T[]): Record<string, T> {
   return items.reduce<Record<string, T>>((acc, item) => {
     acc[item.id] = item;
@@ -98,8 +144,18 @@ function indexById<T extends { id: string }>(items: T[]): Record<string, T> {
   }, {});
 }
 
-export class GMCPClientSpatial extends GMCPPackage {
-  public packageName: string = 'Client.Spatial';
+export class GMCPClientSpatial extends GMCPClientSpatialBase {
+  constructor(client: ConstructorParameters<typeof GMCPClientSpatialBase>[0]) {
+    super(client);
+    this.on('scene', (data) => this.handleScene(data));
+    this.on('entityEnter', (data) => this.handleEntityEnter(data));
+    this.on('entityLeave', (data) => this.handleEntityLeave(data));
+    this.on('entityMove', (data) => this.handleEntityMove(data));
+    this.on('listenerPosition', (data) => this.handleListenerPosition(data));
+    this.on('listenerOrientation', (data) => this.handleListenerOrientation(data));
+    this.on('emitterStart', (data) => this.handleEmitterStart(data));
+    this.on('emitterStop', (data) => this.handleEmitterStop(data));
+  }
 
   private syncCacophonyListenerPosition(position: SpatialVector | null | undefined): void {
     this.client.media.setListenerPosition(position ?? [0, 0, 0]);

--- a/src/gmcp/Client/Spatial.ts
+++ b/src/gmcp/Client/Spatial.ts
@@ -186,47 +186,36 @@ export class GMCPClientSpatial extends GMCPClientSpatialBase {
     });
     this.syncCacophonyListenerPosition(listenerPosition);
     this.syncCacophonyListenerOrientation(listenerOrientation);
-    this.client.emit('spatialScene', data);
   }
 
   handleEntityEnter(data: GMCPMessageClientSpatialEntityEnter): void {
     useSpatialStore.getState().enterEntity(data.entity);
-    this.client.emit('spatialEntityEnter', data.entity);
   }
 
   handleEntityLeave(data: GMCPMessageClientSpatialEntityLeave): void {
     useSpatialStore.getState().leaveEntity(data.entityId);
-    this.client.emit('spatialEntityLeave', data.entityId);
   }
 
   handleEntityMove(data: GMCPMessageClientSpatialEntityMove): void {
     useSpatialStore.getState().moveEntity(data);
-    this.client.emit(
-      'spatialEntityMove',
-      useSpatialStore.getState().spatialEntities[data.entityId],
-    );
   }
 
   handleListenerPosition(data: GMCPMessageClientSpatialListenerPosition): void {
     useSpatialStore.getState().setListenerPosition(data.position, data.listenerId);
     this.syncCacophonyListenerPosition(data.position);
-    this.client.emit('spatialListenerPosition', data);
   }
 
   handleListenerOrientation(data: GMCPMessageClientSpatialListenerOrientation): void {
     const orientation = { forward: data.forward, up: data.up };
     useSpatialStore.getState().setListenerOrientation(orientation, data.listenerId);
     this.syncCacophonyListenerOrientation(orientation);
-    this.client.emit('spatialListenerOrientation', data);
   }
 
   handleEmitterStart(data: GMCPMessageClientSpatialEmitterStart): void {
     useSpatialStore.getState().startEmitter(data.emitter);
-    this.client.emit('spatialEmitterStart', data.emitter);
   }
 
   handleEmitterStop(data: GMCPMessageClientSpatialEmitterStop): void {
     useSpatialStore.getState().stopEmitter(data.emitterId);
-    this.client.emit('spatialEmitterStop', data.emitterId);
   }
 }

--- a/src/gmcp/Client/Speech.ts
+++ b/src/gmcp/Client/Speech.ts
@@ -1,3 +1,5 @@
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export class GMCPMessageClientSpeechSpeak extends GMCPMessage {
@@ -7,8 +9,18 @@ export class GMCPMessageClientSpeechSpeak extends GMCPMessage {
     volume = 0.5;
 }
 
-export class GMCPClientSpeech extends GMCPPackage {
-    public packageName: string = "Client.Speech";
+const speechSpeak = gmcpJsonMessage<"Speak", GMCPMessageClientSpeechSpeak>("Speak");
+
+const GMCPClientSpeechBase = GMCPPackage.with({
+    packageName: "Client.Speech",
+    messages: [inbound(speechSpeak)] as const,
+});
+
+export class GMCPClientSpeech extends GMCPClientSpeechBase {
+    constructor(client: ConstructorParameters<typeof GMCPClientSpeechBase>[0]) {
+        super(client);
+        this.on("speak", (data) => this.handleSpeak(data));
+    }
 
     handleSpeak(data: GMCPMessageClientSpeechSpeak): void {
         const utterance = new SpeechSynthesisUtterance(data.text);

--- a/src/gmcp/Client/WebPush.test.ts
+++ b/src/gmcp/Client/WebPush.test.ts
@@ -4,12 +4,9 @@ import { GMCPClientWebPush } from "./WebPush";
 
 function createMockClient() {
   return {
-    emit: vi.fn(),
     gmcp: {
       send: vi.fn(),
     },
-    off: vi.fn(),
-    on: vi.fn(),
   };
 }
 
@@ -23,13 +20,13 @@ describe("GMCPClientWebPush", () => {
     handler = new GMCPClientWebPush(client as never);
   });
 
-  it("stores token payloads and emits token events", () => {
-    handler.handleToken({ expires_at: 12345, token: "token-a" });
+  it("stores token payloads and emits package token events", () => {
+    const listener = vi.fn();
+    handler.on("token", listener);
 
-    expect(client.emit).toHaveBeenCalledWith("webpushToken", {
-      expiresAt: 12345,
-      token: "token-a",
-    });
+    handler.receiveRegisteredMessage("Token", { expires_at: 12345, token: "token-a" });
+
+    expect(listener).toHaveBeenCalledWith({ expires_at: 12345, token: "token-a" });
   });
 
   it("returns a cached token without sending another request", async () => {
@@ -40,18 +37,10 @@ describe("GMCPClientWebPush", () => {
   });
 
   it("requests a token over GMCP when none is cached", async () => {
-    const listeners = new Map<string, (payload: { token: string | null }) => void>();
-    client.on.mockImplementation((event: string, callback: (payload: { token: string | null }) => void) => {
-      listeners.set(event, callback);
-    });
-    client.off.mockImplementation((event: string) => {
-      listeners.delete(event);
-    });
-
     const tokenPromise = handler.requestToken();
 
     expect(client.gmcp.send).toHaveBeenCalledWith("Client.WebPush.Request", "{}");
-    listeners.get("webpushToken")?.({ token: "token-b" });
+    handler.receiveRegisteredMessage("Token", { token: "token-b" });
 
     await expect(tokenPromise).resolves.toBe("token-b");
   });

--- a/src/gmcp/Client/WebPush.ts
+++ b/src/gmcp/Client/WebPush.ts
@@ -1,3 +1,5 @@
+import { inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
@@ -7,11 +9,33 @@ export class GMCPMessageClientWebPushToken extends GMCPMessage {
   expires_at?: number;
 }
 
-export class GMCPClientWebPush extends GMCPPackage {
-  public packageName: string = "Client.WebPush";
+const webPushToken = gmcpJsonMessage<"Token", GMCPMessageClientWebPushToken>("Token");
+const webPushRequest = gmcpJsonMessage<"Request", never, void>("Request", {
+  encode(): unknown {
+    return {};
+  },
+  decode(payload: unknown): never {
+    return payload as never;
+  },
+});
+
+const GMCPClientWebPushBase = GMCPPackage.with({
+  packageName: "Client.WebPush",
+  messages: [
+    inbound(webPushToken),
+    outbound(webPushRequest),
+  ] as const,
+});
+
+export class GMCPClientWebPush extends GMCPClientWebPushBase {
 
   private token: string | null = null;
   private expiresAt: number | null = null;
+
+  constructor(client: ConstructorParameters<typeof GMCPClientWebPushBase>[0]) {
+    super(client);
+    this.on("token", (data) => this.handleToken(data));
+  }
 
   handleToken(data: GMCPMessageClientWebPushToken): void {
     this.token = data.token || null;
@@ -20,10 +44,6 @@ export class GMCPClientWebPush extends GMCPPackage {
       expiresAt: this.expiresAt,
       token: this.token,
     });
-  }
-
-  sendRequest(): void {
-    this.sendData("Request", {});
   }
 
   async requestToken(): Promise<string | null> {

--- a/src/gmcp/Client/WebPush.ts
+++ b/src/gmcp/Client/WebPush.ts
@@ -40,10 +40,6 @@ export class GMCPClientWebPush extends GMCPClientWebPushBase {
   handleToken(data: GMCPMessageClientWebPushToken): void {
     this.token = data.token || null;
     this.expiresAt = typeof data.expires_at === "number" ? data.expires_at : null;
-    this.client.emit("webpushToken", {
-      expiresAt: this.expiresAt,
-      token: this.token,
-    });
   }
 
   async requestToken(): Promise<string | null> {
@@ -58,17 +54,17 @@ export class GMCPClientWebPush extends GMCPClientWebPushBase {
         resolve(null);
       }, 5_000);
 
-      const handleToken = (payload: { token: string | null }) => {
+      const handleToken = (payload: GMCPMessageClientWebPushToken) => {
         cleanup();
-        resolve(payload.token);
+        resolve(payload.token || null);
       };
 
       const cleanup = () => {
         window.clearTimeout(timeout);
-        this.client.off("webpushToken", handleToken);
+        this.off("token", handleToken);
       };
 
-      this.client.on("webpushToken", handleToken);
+      this.on("token", handleToken);
       this.sendRequest();
     });
   }

--- a/src/gmcp/Comm/Channel.ts
+++ b/src/gmcp/Comm/Channel.ts
@@ -50,31 +50,22 @@ export class GMCPCommChannel extends GMCPCommChannelBase {
 
   handleText(data: GMCPMessageCommChannelText): void {
     console.log(`Received Comm.Channel.Text on ${data.channel} from ${data.talker}: ${data.text}`);
-    this.client.emit("channelText", data); // Emit the structured data
-    if (data.channel === "say_to_you") {
-      if (!document.hasFocus()) {
-        this.client.sendNotification(`Message from ${data.talker}`, `${data.text}`);
-      }
-    }
   }
 
   // --- Players ---
   handlePlayers(data: { name: string; channels?: string[] }[]): void {
     console.log("Received Comm.Channel.Players:", data);
     // TODO: Update shared channel/player info
-    this.client.emit("channelPlayers", data);
   }
 
   // --- Start/End/Text ---
   handleStart(channelName: string): void {
     console.log(`Received Comm.Channel.Start for ${channelName}`);
     // TODO: Potentially set a flag indicating channel text is incoming
-    this.client.emit("channelStart", channelName);
   }
 
   handleEnd(channelName: string): void {
     console.log(`Received Comm.Channel.End for ${channelName}`);
     // TODO: Clear the flag set by handleStart
-    this.client.emit("channelEnd", channelName);
   }
 }

--- a/src/gmcp/Comm/Channel.ts
+++ b/src/gmcp/Comm/Channel.ts
@@ -1,3 +1,5 @@
+import { duplex, inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export class GMCPMessageCommChannelText extends GMCPMessage {
@@ -5,17 +7,45 @@ export class GMCPMessageCommChannelText extends GMCPMessage {
   public readonly talker!: string;
   public readonly text!: string;
 }
-export class GMCPCommChannel extends GMCPPackage {
-  public packageName: string = "Comm.Channel";
+
+const channelList = gmcpJsonMessage<"List", string[], void>("List");
+const channelText = gmcpJsonMessage<"Text", GMCPMessageCommChannelText>("Text");
+const channelPlayers = gmcpJsonMessage<
+  "Players",
+  { name: string; channels?: string[] }[],
+  string
+>("Players");
+const channelEnable = gmcpJsonMessage<"Enable", never, string>("Enable");
+const channelStart = gmcpJsonMessage<"Start", string>("Start");
+const channelEnd = gmcpJsonMessage<"End", string>("End");
+
+const GMCPCommChannelBase = GMCPPackage.with({
+  packageName: "Comm.Channel",
+  messages: [
+    duplex(channelList),
+    inbound(channelText),
+    duplex(channelPlayers),
+    outbound(channelEnable),
+    inbound(channelStart),
+    inbound(channelEnd),
+  ] as const,
+});
+
+export class GMCPCommChannel extends GMCPCommChannelBase {
   public channels: string[] = [];
+
+  constructor(client: ConstructorParameters<typeof GMCPCommChannelBase>[0]) {
+    super(client);
+    this.on("list", (data) => this.handleList(data));
+    this.on("text", (data) => this.handleText(data));
+    this.on("players", (data) => this.handlePlayers(data));
+    this.on("start", (data) => this.handleStart(data));
+    this.on("end", (data) => this.handleEnd(data));
+  }
 
   handleList(data: string[]): void {
     this.channels = data;
 
-  }
-
-  sendList(): void {
-    this.sendData("List");
   }
 
   handleText(data: GMCPMessageCommChannelText): void {
@@ -33,15 +63,6 @@ export class GMCPCommChannel extends GMCPPackage {
     console.log("Received Comm.Channel.Players:", data);
     // TODO: Update shared channel/player info
     this.client.emit("channelPlayers", data);
-  }
-
-  sendPlayersRequest(): void {
-    this.sendData("Players", ""); // Empty body as per docs
-  }
-
-  // --- Enable ---
-  sendEnable(channelName: string): void {
-    this.sendData("Enable", channelName);
   }
 
   // --- Start/End/Text ---

--- a/src/gmcp/Comm/LiveKit.test.ts
+++ b/src/gmcp/Comm/LiveKit.test.ts
@@ -6,7 +6,6 @@ import { GMCPCommLiveKit } from "./LiveKit";
 
 function createMockClient() {
   return {
-    emit: vi.fn(),
     gmcp: {
       send: vi.fn(),
     },
@@ -24,19 +23,24 @@ describe("GMCPCommLiveKit", () => {
     handler = new GMCPCommLiveKit(client as unknown as MudClient);
   });
 
-  it("stores and emits livekitToken when room_token arrives", () => {
-    handler.handleroom_token({ token: "token-a" });
+  it("stores and emits roomToken when room_token arrives", () => {
+    const listener = vi.fn();
+    handler.on("roomToken", listener);
+
+    handler.receiveRegisteredMessage("room_token", { token: "token-a" });
 
     expect(useLiveKitStore.getState().tokens).toEqual(["token-a"]);
-    expect(client.emit).toHaveBeenCalledWith("livekitToken", "token-a");
+    expect(listener).toHaveBeenCalledWith({ token: "token-a" });
   });
 
-  it("removes and emits livekitLeave when room_leave arrives", () => {
+  it("removes and emits roomLeave when room_leave arrives", () => {
+    const listener = vi.fn();
+    handler.on("roomLeave", listener);
     useLiveKitStore.getState().addToken("token-a");
 
-    handler.handleroom_leave({ token: "token-a" });
+    handler.receiveRegisteredMessage("room_leave", { token: "token-a" });
 
     expect(useLiveKitStore.getState().tokens).toEqual([]);
-    expect(client.emit).toHaveBeenCalledWith("livekitLeave", "token-a");
+    expect(listener).toHaveBeenCalledWith({ token: "token-a" });
   });
 });

--- a/src/gmcp/Comm/LiveKit.ts
+++ b/src/gmcp/Comm/LiveKit.ts
@@ -1,12 +1,26 @@
+import { inbound } from "../../protocol/messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 import { useLiveKitStore } from "../../stores/liveKitStore";
+import { gmcpJsonMessage } from "../messages";
 
 export class GMCPMessageCommLiveKitToken extends GMCPMessage {
     token: string = "";
 }
 
-export class GMCPCommLiveKit extends GMCPPackage {
-    public packageName: string = "Comm.LiveKit";
+const roomToken = gmcpJsonMessage<"room_token", GMCPMessageCommLiveKitToken>("room_token");
+const roomLeave = gmcpJsonMessage<"room_leave", GMCPMessageCommLiveKitToken>("room_leave");
+
+const GMCPCommLiveKitBase = GMCPPackage.with({
+    packageName: "Comm.LiveKit",
+    messages: [inbound(roomToken), inbound(roomLeave)] as const,
+});
+
+export class GMCPCommLiveKit extends GMCPCommLiveKitBase {
+    constructor(client: ConstructorParameters<typeof GMCPCommLiveKitBase>[0]) {
+        super(client);
+        this.on("roomToken", (data) => this.handleroom_token(data));
+        this.on("roomLeave", (data) => this.handleroom_leave(data));
+    }
 
     handleroom_token(data: GMCPMessageCommLiveKitToken): void {
         useLiveKitStore.getState().addToken(data.token);

--- a/src/gmcp/Comm/LiveKit.ts
+++ b/src/gmcp/Comm/LiveKit.ts
@@ -24,11 +24,9 @@ export class GMCPCommLiveKit extends GMCPCommLiveKitBase {
 
     handleroom_token(data: GMCPMessageCommLiveKitToken): void {
         useLiveKitStore.getState().addToken(data.token);
-        this.client.emit("livekitToken", data.token);
     }
 
     handleroom_leave(data: GMCPMessageCommLiveKitToken): void {
         useLiveKitStore.getState().removeToken(data.token);
-        this.client.emit("livekitLeave", data.token);
     }
 }

--- a/src/gmcp/Core.ts
+++ b/src/gmcp/Core.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../protocol/messages";
+import { duplex, inbound, outbound } from "../protocol/messages";
 import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
@@ -15,8 +15,14 @@ export class GMCPMessageCoreClient extends GMCPMessage {
 }
 
 
-const corePing = gmcpJsonMessage<"Ping", undefined>("Ping", {
-  encode(payload: undefined): unknown {
+const coreHello = gmcpJsonMessage<
+  "Hello",
+  never,
+  { client: string; version: string }
+>("Hello");
+const coreKeepAlive = gmcpJsonMessage<"KeepAlive", never, void>("KeepAlive");
+const corePing = gmcpJsonMessage<"Ping", undefined, number | undefined>("Ping", {
+  encode(payload: number | undefined): unknown {
     return payload;
   },
   decode(): undefined {
@@ -27,7 +33,12 @@ const coreGoodbye = gmcpJsonMessage<"Goodbye", string>("Goodbye");
 
 const GMCPCoreBase = GMCPPackage.with({
   packageName: "Core",
-  messages: [inbound(corePing), inbound(coreGoodbye)] as const,
+  messages: [
+    outbound(coreHello),
+    outbound(coreKeepAlive),
+    duplex(corePing),
+    inbound(coreGoodbye),
+  ] as const,
 });
 
 export class GMCPCore extends GMCPCoreBase {
@@ -35,18 +46,6 @@ export class GMCPCore extends GMCPCoreBase {
     super(client);
     this.on("ping", () => this.handlePing());
     this.on("goodbye", (reason) => this.handleGoodbye(reason));
-  }
-
-  sendHello(): void {
-    this.sendData("Hello", { client: "Mongoose Client", version: "0.1" });
-  }
-
-  sendKeepAlive(): void {
-    this.sendData("KeepAlive");
-  }
-
-  sendPing(avgPing?: number): void {
-    this.sendData("Ping", avgPing);
   }
 
   handlePing(): void {
@@ -70,26 +69,24 @@ export interface GMCPMessageCoreSupportsSet extends GMCPMessage {
 
 type AdvertisedGMCPPackage = GMCPPackage & { packageVersion: number };
 
-export class GMCPCoreSupports extends GMCPPackage {
-  packageName = "Core.Supports";
+const supportsSet = gmcpJsonMessage<"Set", never, string[]>("Set");
+const supportsAdd = gmcpJsonMessage<"Add", never, string[]>("Add");
+const supportsRemove = gmcpJsonMessage<"Remove", never, string[]>("Remove");
 
-  // Sends the initial list of supported packages
-  sendSet(): void {
-    const packages = Object.values(this.client.gmcp.handlers)
+const GMCPCoreSupportsBase = GMCPPackage.with({
+  packageName: "Core.Supports",
+  messages: [
+    outbound(supportsSet),
+    outbound(supportsAdd),
+    outbound(supportsRemove),
+  ] as const,
+});
+
+export class GMCPCoreSupports extends GMCPCoreSupportsBase {
+  advertisedModules(): string[] {
+    return Object.values(this.client.gmcp.handlers)
       .filter(isAdvertisedGMCPPackage)
       .map(p => `${p.packageName} ${p.packageVersion.toString()}`);
-    this.sendData("Set", packages);
-  }
-
-  // Adds packages to the supported list
-  sendAdd(packagesToAdd: { name: string; version: number }[]): void {
-    const packageStrings = packagesToAdd.map(p => `${p.name} ${p.version}`);
-    this.sendData("Add", packageStrings);
-  }
-
-  // Removes packages from the supported list
-  sendRemove(packagesToRemove: string[]): void {
-    this.sendData("Remove", packagesToRemove); // Version number is optional/ignored
   }
 
   // Note: Server doesn't send Core.Supports messages to the client according to IRE docs.

--- a/src/gmcp/Core.ts
+++ b/src/gmcp/Core.ts
@@ -1,3 +1,5 @@
+import { inbound } from "../protocol/messages";
+import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
 
@@ -13,8 +15,27 @@ export class GMCPMessageCoreClient extends GMCPMessage {
 }
 
 
-export class GMCPCore extends GMCPPackage {
-  public packageName: string = "Core";
+const corePing = gmcpJsonMessage<"Ping", undefined>("Ping", {
+  encode(payload: undefined): unknown {
+    return payload;
+  },
+  decode(): undefined {
+    return undefined;
+  },
+});
+const coreGoodbye = gmcpJsonMessage<"Goodbye", string>("Goodbye");
+
+const GMCPCoreBase = GMCPPackage.with({
+  packageName: "Core",
+  messages: [inbound(corePing), inbound(coreGoodbye)] as const,
+});
+
+export class GMCPCore extends GMCPCoreBase {
+  constructor(client: ConstructorParameters<typeof GMCPCoreBase>[0]) {
+    super(client);
+    this.on("ping", () => this.handlePing());
+    this.on("goodbye", (reason) => this.handleGoodbye(reason));
+  }
 
   sendHello(): void {
     this.sendData("Hello", { client: "Mongoose Client", version: "0.1" });
@@ -47,14 +68,16 @@ export interface GMCPMessageCoreSupportsSet extends GMCPMessage {
   modules: string[];
 }
 
+type AdvertisedGMCPPackage = GMCPPackage & { packageVersion: number };
+
 export class GMCPCoreSupports extends GMCPPackage {
   packageName = "Core.Supports";
 
   // Sends the initial list of supported packages
   sendSet(): void {
     const packages = Object.values(this.client.gmcp.handlers)
-      .filter((p): p is GMCPPackage => Boolean(p?.packageName && p.packageVersion && p.enabled))
-      .map(p => `${p.packageName} ${p.packageVersion!.toString()}`);
+      .filter(isAdvertisedGMCPPackage)
+      .map(p => `${p.packageName} ${p.packageVersion.toString()}`);
     this.sendData("Set", packages);
   }
 
@@ -70,4 +93,14 @@ export class GMCPCoreSupports extends GMCPPackage {
   }
 
   // Note: Server doesn't send Core.Supports messages to the client according to IRE docs.
+}
+
+function isAdvertisedGMCPPackage(
+  gmcpPackage: GMCPPackage | undefined,
+): gmcpPackage is AdvertisedGMCPPackage {
+  return Boolean(
+    gmcpPackage?.packageName &&
+      gmcpPackage.packageVersion !== undefined &&
+      gmcpPackage.enabled,
+  );
 }

--- a/src/gmcp/Core.ts
+++ b/src/gmcp/Core.ts
@@ -51,12 +51,10 @@ export class GMCPCore extends GMCPCoreBase {
   handlePing(): void {
     // Server replied to our ping, potentially update latency metrics
     console.log("Received Core.Ping response from server.");
-    this.client.emit("corePing"); // Example event
   }
 
   handleGoodbye(reason: string): void {
     console.log(`Server sent Core.Goodbye: ${reason}`);
-    this.client.emit("coreGoodbye", reason);
     // Optionally trigger disconnect logic here or let the main client handle it
   }
 }

--- a/src/gmcp/Group.ts
+++ b/src/gmcp/Group.ts
@@ -1,4 +1,4 @@
-import { inbound } from "../protocol/messages";
+import { duplex } from "../protocol/messages";
 import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
@@ -8,11 +8,11 @@ export class GMCPMessageGroupInfo extends GMCPMessage {
     [key: string]: unknown;
 }
 
-const groupInfo = gmcpJsonMessage<"Info", GMCPMessageGroupInfo>("Info");
+const groupInfo = gmcpJsonMessage<"Info", GMCPMessageGroupInfo, Record<string, never>>("Info");
 
 const GMCPGroupBase = GMCPPackage.with({
     packageName: "Group",
-    messages: [inbound(groupInfo)] as const,
+    messages: [duplex(groupInfo)] as const,
 });
 
 export class GMCPGroup extends GMCPGroupBase {
@@ -26,10 +26,5 @@ export class GMCPGroup extends GMCPGroupBase {
         console.log("Received Group.Info:", data);
         // TODO: Implement logic to handle group info data
         this.client.emit("groupInfo", data); // Example: emit an event
-    }
-
-    // Method to request group info data
-    sendInfoRequest(): void {
-        this.sendData("Info", {}); // Send empty object as per docs
     }
 }

--- a/src/gmcp/Group.ts
+++ b/src/gmcp/Group.ts
@@ -25,6 +25,5 @@ export class GMCPGroup extends GMCPGroupBase {
     handleInfo(data: GMCPMessageGroupInfo): void {
         console.log("Received Group.Info:", data);
         // TODO: Implement logic to handle group info data
-        this.client.emit("groupInfo", data); // Example: emit an event
     }
 }

--- a/src/gmcp/Group.ts
+++ b/src/gmcp/Group.ts
@@ -1,13 +1,25 @@
+import { inbound } from "../protocol/messages";
+import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
 // Data structure is not defined in the provided docs, using 'any' for now.
 // Should contain group info as seen in the GROUP command.
 export class GMCPMessageGroupInfo extends GMCPMessage {
-    [key: string]: any;
+    [key: string]: unknown;
 }
 
-export class GMCPGroup extends GMCPPackage {
-    public packageName: string = "Group"; // Assuming base package is "Group"
+const groupInfo = gmcpJsonMessage<"Info", GMCPMessageGroupInfo>("Info");
+
+const GMCPGroupBase = GMCPPackage.with({
+    packageName: "Group",
+    messages: [inbound(groupInfo)] as const,
+});
+
+export class GMCPGroup extends GMCPGroupBase {
+    constructor(client: ConstructorParameters<typeof GMCPGroupBase>[0]) {
+        super(client);
+        this.on("info", (data) => this.handleInfo(data));
+    }
 
     // Handler for response messages for Group.Info
     handleInfo(data: GMCPMessageGroupInfo): void {

--- a/src/gmcp/IRE/CombatMessage.ts
+++ b/src/gmcp/IRE/CombatMessage.ts
@@ -1,4 +1,4 @@
-import { GMCPMessage, GMCPPackage } from "../package";
+import { GMCPPackage } from "../package";
 
 // Structure based on Starmourn example: { ["skill name"] = { target="...", message="...", caster="..." } }
 // This is Lua table syntax, translating to JSON is tricky.
@@ -13,8 +13,12 @@ export interface CombatMessageData {
     caster: string;
 }
 
-export class GmcPIRECombatMessage extends GMCPPackage {
-    public packageName: string = "IRE.CombatMessage";
+const GmcPIRECombatMessageBase = GMCPPackage.with({
+    packageName: "IRE.CombatMessage",
+    messages: [] as const,
+});
+
+export class GmcPIRECombatMessage extends GmcPIRECombatMessageBase {
 
     // This handler might need adjustment depending on how the server actually sends the data.
     // It assumes the skill name is part of the GMCP message name handled dynamically.

--- a/src/gmcp/IRE/CombatMessage.ts
+++ b/src/gmcp/IRE/CombatMessage.ts
@@ -25,7 +25,6 @@ export class GmcPIRECombatMessage extends GmcPIRECombatMessageBase {
     handleSkillAttack(skillName: string, data: CombatMessageData): void {
         console.log(`Received IRE.CombatMessage for ${skillName}:`, data);
         // TODO: Process combat message (e.g., display, trigger reflexes)
-        this.client.emit("combatMessage", { skill: skillName, ...data });
     }
 
     // Override handleGmcp to dynamically handle skill names if needed

--- a/src/gmcp/IRE/Composer.ts
+++ b/src/gmcp/IRE/Composer.ts
@@ -1,3 +1,5 @@
+import { inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
 import { GMCPMessage, GMCPPackage } from "../package";
 
 export class GMCPMessageIREComposerEdit extends GMCPMessage {
@@ -9,21 +11,28 @@ export class GMCPMessageIREComposerSetBuffer extends GMCPMessage {
     buffer: string = "";
 }
 
-export class GmcPIREComposer extends GMCPPackage {
-    public packageName: string = "IRE.Composer";
+const composerEdit = gmcpJsonMessage<"Edit", GMCPMessageIREComposerEdit>("Edit");
+const composerSetBuffer = gmcpJsonMessage<"SetBuffer", never, string>("SetBuffer");
+
+const GmcPIREComposerBase = GMCPPackage.with({
+    packageName: "IRE.Composer",
+    messages: [
+        inbound(composerEdit),
+        outbound(composerSetBuffer),
+    ] as const,
+});
+
+export class GmcPIREComposer extends GmcPIREComposerBase {
+    constructor(client: ConstructorParameters<typeof GmcPIREComposerBase>[0]) {
+        super(client);
+        this.on("edit", (data) => this.handleEdit(data));
+    }
 
     // --- Server Messages ---
     handleEdit(data: GMCPMessageIREComposerEdit): void {
         console.log(`Received IRE.Composer.Edit (Title: ${data.title}):`, data.text);
         // TODO: Open an editor interface with the provided title and text
         this.client.emit("composerEdit", data);
-    }
-
-    // --- Client Messages ---
-    sendSetBuffer(text: string): void {
-        // Note: IRE docs example shows just the string, not an object.
-        // Let's follow the example.
-        this.sendData("SetBuffer", text);
     }
 
     // Helper for IRE-specific commands (***save, ***quit)

--- a/src/gmcp/IRE/Composer.ts
+++ b/src/gmcp/IRE/Composer.ts
@@ -32,7 +32,6 @@ export class GmcPIREComposer extends GmcPIREComposerBase {
     handleEdit(data: GMCPMessageIREComposerEdit): void {
         console.log(`Received IRE.Composer.Edit (Title: ${data.title}):`, data.text);
         // TODO: Open an editor interface with the provided title and text
-        this.client.emit("composerEdit", data);
     }
 
     // Helper for IRE-specific commands (***save, ***quit)

--- a/src/gmcp/IRE/Display.ts
+++ b/src/gmcp/IRE/Display.ts
@@ -1,7 +1,24 @@
-import { GMCPMessage, GMCPPackage } from "../package";
+import { inbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
+import { GMCPPackage } from "../package";
 
-export class GmcPIREDisplay extends GMCPPackage {
-    public packageName: string = "IRE.Display";
+const displayFixedFont = gmcpJsonMessage<"FixedFont", "start" | "stop">("FixedFont");
+const displayOhmap = gmcpJsonMessage<"Ohmap", "start" | "stop">("Ohmap");
+
+const GmcPIREDisplayBase = GMCPPackage.with({
+    packageName: "IRE.Display",
+    messages: [
+        inbound(displayFixedFont),
+        inbound(displayOhmap),
+    ] as const,
+});
+
+export class GmcPIREDisplay extends GmcPIREDisplayBase {
+    constructor(client: ConstructorParameters<typeof GmcPIREDisplayBase>[0]) {
+        super(client);
+        this.on("fixedFont", (data) => this.handleFixedFont(data));
+        this.on("ohmap", (data) => this.handleOhmap(data));
+    }
 
     handleFixedFont(state: "start" | "stop"): void {
         console.log(`Received IRE.Display.FixedFont: ${state}`);

--- a/src/gmcp/IRE/Display.ts
+++ b/src/gmcp/IRE/Display.ts
@@ -23,13 +23,11 @@ export class GmcPIREDisplay extends GmcPIREDisplayBase {
     handleFixedFont(state: "start" | "stop"): void {
         console.log(`Received IRE.Display.FixedFont: ${state}`);
         // TODO: Toggle fixed-width font rendering for subsequent output
-        this.client.emit("displayFixedFont", state);
     }
 
     handleOhmap(state: "start" | "stop"): void {
         console.log(`Received IRE.Display.Ohmap: ${state}`);
         // TODO: Toggle handling of overhead map data
-        this.client.emit("displayOhmap", state);
     }
 
     // No client messages defined

--- a/src/gmcp/IRE/Misc.ts
+++ b/src/gmcp/IRE/Misc.ts
@@ -1,4 +1,6 @@
-import { GMCPMessage, GMCPPackage } from "../package";
+import { inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
+import { GMCPPackage } from "../package";
 
 export interface Achievement {
     name: string;
@@ -10,8 +12,31 @@ export interface UrlInfo {
     window: string;
 }
 
-export class GmcPIREMisc extends GMCPPackage {
-    public packageName: string = "IRE.Misc";
+const miscRemindVote = gmcpJsonMessage<"RemindVote", string>("RemindVote");
+const miscAchievement = gmcpJsonMessage<"Achievement", Achievement[]>("Achievement");
+const miscURL = gmcpJsonMessage<"URL", UrlInfo[]>("URL");
+const miscTip = gmcpJsonMessage<"Tip", string>("Tip");
+const miscVoted = gmcpJsonMessage<"Voted", never, string>("Voted");
+
+const GmcPIREMiscBase = GMCPPackage.with({
+    packageName: "IRE.Misc",
+    messages: [
+        inbound(miscRemindVote),
+        inbound(miscAchievement),
+        inbound(miscURL).asEvent("url"),
+        inbound(miscTip),
+        outbound(miscVoted),
+    ] as const,
+});
+
+export class GmcPIREMisc extends GmcPIREMiscBase {
+    constructor(client: ConstructorParameters<typeof GmcPIREMiscBase>[0]) {
+        super(client);
+        this.on("remindVote", (data) => this.handleRemindVote(data));
+        this.on("achievement", (data) => this.handleAchievement(data));
+        this.on("url", (data) => this.handleURL(data));
+        this.on("tip", (data) => this.handleTip(data));
+    }
 
     // --- Server Messages ---
     handleRemindVote(url: string): void {
@@ -36,10 +61,5 @@ export class GmcPIREMisc extends GMCPPackage {
         console.log(`Received IRE.Misc.Tip: ${tip}`);
         // TODO: Display the tip to the user
         this.client.emit("miscTip", tip);
-    }
-
-    // --- Client Messages ---
-    sendVoted(): void {
-        this.sendData("Voted", ""); // Empty body as per docs
     }
 }

--- a/src/gmcp/IRE/Misc.ts
+++ b/src/gmcp/IRE/Misc.ts
@@ -42,24 +42,20 @@ export class GmcPIREMisc extends GmcPIREMiscBase {
     handleRemindVote(url: string): void {
         console.log(`Received IRE.Misc.RemindVote: ${url}`);
         // TODO: Display a reminder to vote, possibly with the URL
-        this.client.emit("miscRemindVote", url);
     }
 
     handleAchievement(achievements: Achievement[]): void {
         console.log("Received IRE.Misc.Achievement:", achievements);
         // TODO: Update achievement status
-        this.client.emit("miscAchievement", achievements);
     }
 
     handleURL(urls: UrlInfo[]): void {
         console.log("Received IRE.Misc.URL:", urls);
         // TODO: Provide clickable URLs, potentially opening in specific windows/tabs
-        this.client.emit("miscURL", urls);
     }
 
     handleTip(tip: string): void {
         console.log(`Received IRE.Misc.Tip: ${tip}`);
         // TODO: Display the tip to the user
-        this.client.emit("miscTip", tip);
     }
 }

--- a/src/gmcp/IRE/Rift.ts
+++ b/src/gmcp/IRE/Rift.ts
@@ -1,4 +1,6 @@
-import { GMCPMessage, GMCPPackage } from "../package";
+import { inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
+import { GMCPPackage } from "../package";
 
 export interface RiftItem {
     name: string;
@@ -6,8 +8,25 @@ export interface RiftItem {
     desc: string;
 }
 
-export class GmcPIRERift extends GMCPPackage {
-    public packageName: string = "IRE.Rift";
+const riftList = gmcpJsonMessage<"List", RiftItem[]>("List");
+const riftChange = gmcpJsonMessage<"Change", RiftItem>("Change");
+const riftRequest = gmcpJsonMessage<"Request", never, void>("Request");
+
+const GmcPIRERiftBase = GMCPPackage.with({
+    packageName: "IRE.Rift",
+    messages: [
+        inbound(riftList),
+        inbound(riftChange),
+        outbound(riftRequest),
+    ] as const,
+});
+
+export class GmcPIRERift extends GmcPIRERiftBase {
+    constructor(client: ConstructorParameters<typeof GmcPIRERiftBase>[0]) {
+        super(client);
+        this.on("list", (data) => this.handleList(data));
+        this.on("change", (data) => this.handleChange(data));
+    }
 
     // --- Server Messages ---
     handleList(items: RiftItem[]): void {
@@ -20,10 +39,5 @@ export class GmcPIRERift extends GMCPPackage {
         console.log("Received IRE.Rift.Change:", item);
         // TODO: Update specific item amount/info in rift display
         this.client.emit("riftChange", item);
-    }
-
-    // --- Client Messages ---
-    sendRequest(): void {
-        this.sendData("Request"); // No body needed
     }
 }

--- a/src/gmcp/IRE/Rift.ts
+++ b/src/gmcp/IRE/Rift.ts
@@ -32,12 +32,10 @@ export class GmcPIRERift extends GmcPIRERiftBase {
     handleList(items: RiftItem[]): void {
         console.log("Received IRE.Rift.List:", items);
         // TODO: Update rift item list display
-        this.client.emit("riftList", items);
     }
 
     handleChange(item: RiftItem): void {
         console.log("Received IRE.Rift.Change:", item);
         // TODO: Update specific item amount/info in rift display
-        this.client.emit("riftChange", item);
     }
 }

--- a/src/gmcp/IRE/Sound.test.ts
+++ b/src/gmcp/IRE/Sound.test.ts
@@ -4,7 +4,6 @@ import { GmcPIRESound } from './Sound';
 
 function createMockClient() {
   return {
-    emit: vi.fn(),
     media: {
       load: vi.fn(async () => {}),
       play: vi.fn(async () => {}),
@@ -37,12 +36,6 @@ describe('GmcPIRESound', () => {
       type: 'sound',
       volume: 65,
     });
-    expect(client.emit).toHaveBeenCalledWith(
-      'ireSoundPlay',
-      expect.objectContaining({
-        name: 'attack.ogg',
-      }),
-    );
   });
 
   it('routes IRE stop and preload through the shared media service', () => {

--- a/src/gmcp/IRE/Sound.ts
+++ b/src/gmcp/IRE/Sound.ts
@@ -1,3 +1,5 @@
+import { inbound } from '../../protocol/messages';
+import { gmcpJsonMessage } from '../messages';
 import { GMCPPackage } from '../package';
 
 // Interfaces based on IRE.Sound documentation keys
@@ -25,8 +27,29 @@ export interface IREPreloadPayload {
 
 // This package handles IRE-specific sound messages and translates them into the
 // shared media service payloads used by the MCMP Client.Media adapter.
-export class GmcPIRESound extends GMCPPackage {
-  public packageName: string = 'IRE.Sound';
+const soundPlay = gmcpJsonMessage<'Play', IREPlayPayload>('Play');
+const soundStop = gmcpJsonMessage<'Stop', IREStopPayload>('Stop');
+const soundStopall = gmcpJsonMessage<'Stopall', IREStopAllPayload>('Stopall');
+const soundPreload = gmcpJsonMessage<'Preload', IREPreloadPayload>('Preload');
+
+const GmcPIRESoundBase = GMCPPackage.with({
+  packageName: 'IRE.Sound',
+  messages: [
+    inbound(soundPlay),
+    inbound(soundStop),
+    inbound(soundStopall),
+    inbound(soundPreload),
+  ] as const,
+});
+
+export class GmcPIRESound extends GmcPIRESoundBase {
+  constructor(client: ConstructorParameters<typeof GmcPIRESoundBase>[0]) {
+    super(client);
+    this.on('play', (data) => this.handlePlay(data));
+    this.on('stop', (data) => this.handleStop(data));
+    this.on('stopall', (data) => this.handleStopall(data));
+    this.on('preload', (data) => this.handlePreload(data));
+  }
 
   // --- Server Messages ---
 

--- a/src/gmcp/IRE/Sound.ts
+++ b/src/gmcp/IRE/Sound.ts
@@ -67,19 +67,16 @@ export class GmcPIRESound extends GmcPIRESoundBase {
       .catch((error) => {
         console.error('IRE.Sound.Play failed:', error);
       });
-    this.client.emit('ireSoundPlay', data);
   }
 
   handleStop(data: IREStopPayload): void {
     console.log('Received IRE.Sound.Stop:', data);
     this.client.media.stop({ name: data.name });
-    this.client.emit('ireSoundStop', data);
   }
 
   handleStopall(data: IREStopAllPayload): void {
     console.log('Received IRE.Sound.Stopall:', data);
     this.client.media.stop({});
-    this.client.emit('ireSoundStopall', data);
   }
 
   handlePreload(data: IREPreloadPayload): void {
@@ -87,7 +84,6 @@ export class GmcPIRESound extends GmcPIRESoundBase {
     void this.client.media.load({ name: data.name }).catch((error) => {
       console.error('IRE.Sound.Preload failed:', error);
     });
-    this.client.emit('ireSoundPreload', data);
   }
 
   // No client messages defined

--- a/src/gmcp/IRE/Target.ts
+++ b/src/gmcp/IRE/Target.ts
@@ -33,12 +33,10 @@ export class GmcPIRETarget extends GmcPIRETargetBase {
         // Server informs client of target set via cycling (e.g., tab)
         console.log(`Received IRE.Target.Set (from server): ${targetId}`);
         // TODO: Update client-side target display/state
-        this.client.emit("targetSet", targetId);
     }
 
     handleInfo(data: TargetInfo): void {
         console.log("Received IRE.Target.Info:", data);
         // TODO: Update detailed target information display
-        this.client.emit("targetInfo", data);
     }
 }

--- a/src/gmcp/IRE/Target.ts
+++ b/src/gmcp/IRE/Target.ts
@@ -1,4 +1,6 @@
-import { GMCPMessage, GMCPPackage } from "../package";
+import { duplex, inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
+import { GMCPPackage } from "../package";
 
 export interface TargetInfo {
     id: string; // Example shows string ID
@@ -6,8 +8,25 @@ export interface TargetInfo {
     hpperc: string; // Percentage as string
 }
 
-export class GmcPIRETarget extends GMCPPackage {
-    public packageName: string = "IRE.Target";
+const targetSet = gmcpJsonMessage<"Set", string>("Set");
+const targetInfo = gmcpJsonMessage<"Info", TargetInfo>("Info");
+const targetRequestInfo = gmcpJsonMessage<"RequestInfo", never, void>("RequestInfo");
+
+const GmcPIRETargetBase = GMCPPackage.with({
+    packageName: "IRE.Target",
+    messages: [
+        duplex(targetSet),
+        inbound(targetInfo),
+        outbound(targetRequestInfo),
+    ] as const,
+});
+
+export class GmcPIRETarget extends GmcPIRETargetBase {
+    constructor(client: ConstructorParameters<typeof GmcPIRETargetBase>[0]) {
+        super(client);
+        this.on("set", (data) => this.handleSet(data));
+        this.on("info", (data) => this.handleInfo(data));
+    }
 
     // --- Server Messages ---
     handleSet(targetId: string): void {
@@ -21,20 +40,5 @@ export class GmcPIRETarget extends GMCPPackage {
         console.log("Received IRE.Target.Info:", data);
         // TODO: Update detailed target information display
         this.client.emit("targetInfo", data);
-    }
-
-    // --- Client Messages ---
-    sendSet(targetId: string): void {
-        // Client informs server of manually set target
-        this.sendData("Set", targetId);
-    }
-
-    // IRE.Target.Request is mentioned but not defined in the docs provided.
-    // Assuming it might be intended to request IRE.Target.Info.
-    sendRequestInfo(): void {
-        // This is an assumption based on the pattern.
-        // The actual message name might differ or not exist.
-        console.warn("Sending hypothetical IRE.Target.RequestInfo - verify actual message if needed.");
-        this.sendData("RequestInfo"); // Hypothetical message name
     }
 }

--- a/src/gmcp/IRE/Tasks.ts
+++ b/src/gmcp/IRE/Tasks.ts
@@ -39,20 +39,17 @@ export class GmcPIRETasks extends GmcPIRETasksBase {
     handleList(tasks: TaskItem[]): void {
         console.log("Received IRE.Tasks.List:", tasks);
         // TODO: Update tasks/quests/achievements display
-        this.client.emit("tasksList", tasks);
     }
 
     handleUpdate(task: TaskItem): void {
         // Assuming Update sends a single item like other similar packages
         console.log("Received IRE.Tasks.Update:", task);
         // TODO: Update a specific task/quest/achievement in the display
-        this.client.emit("taskUpdate", task);
     }
 
     handleCompleted(task: TaskItem): void {
         // Assuming Completed sends a single item
         console.log("Received IRE.Tasks.Completed:", task);
         // TODO: Mark a task/quest/achievement as completed
-        this.client.emit("taskCompleted", task);
     }
 }

--- a/src/gmcp/IRE/Tasks.ts
+++ b/src/gmcp/IRE/Tasks.ts
@@ -1,4 +1,6 @@
-import { GMCPMessage, GMCPPackage } from "../package";
+import { inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
+import { GMCPPackage } from "../package";
 
 export interface TaskItem {
     id: string; // Docs say numeric, example shows string
@@ -10,8 +12,28 @@ export interface TaskItem {
     group: string;
 }
 
-export class GmcPIRETasks extends GMCPPackage {
-    public packageName: string = "IRE.Tasks";
+const tasksList = gmcpJsonMessage<"List", TaskItem[]>("List");
+const tasksUpdate = gmcpJsonMessage<"Update", TaskItem>("Update");
+const tasksCompleted = gmcpJsonMessage<"Completed", TaskItem>("Completed");
+const tasksRequest = gmcpJsonMessage<"Request", never, void>("Request");
+
+const GmcPIRETasksBase = GMCPPackage.with({
+    packageName: "IRE.Tasks",
+    messages: [
+        inbound(tasksList),
+        inbound(tasksUpdate),
+        inbound(tasksCompleted),
+        outbound(tasksRequest),
+    ] as const,
+});
+
+export class GmcPIRETasks extends GmcPIRETasksBase {
+    constructor(client: ConstructorParameters<typeof GmcPIRETasksBase>[0]) {
+        super(client);
+        this.on("list", (data) => this.handleList(data));
+        this.on("update", (data) => this.handleUpdate(data));
+        this.on("completed", (data) => this.handleCompleted(data));
+    }
 
     // --- Server Messages ---
     handleList(tasks: TaskItem[]): void {
@@ -32,10 +54,5 @@ export class GmcPIRETasks extends GMCPPackage {
         console.log("Received IRE.Tasks.Completed:", task);
         // TODO: Mark a task/quest/achievement as completed
         this.client.emit("taskCompleted", task);
-    }
-
-    // --- Client Messages ---
-    sendRequest(): void {
-        this.sendData("Request"); // No body needed
     }
 }

--- a/src/gmcp/IRE/Time.ts
+++ b/src/gmcp/IRE/Time.ts
@@ -35,13 +35,11 @@ export class GmcPIRETime extends GmcPIRETimeBase {
     handleList(timeInfo: TimeInfo): void {
         console.log("Received IRE.Time.List:", timeInfo);
         // TODO: Update time/date/day-night display
-        this.client.emit("timeList", timeInfo);
     }
 
     handleUpdate(timeUpdate: Partial<TimeInfo>): void {
         // Assuming Update sends only changed values
         console.log("Received IRE.Time.Update:", timeUpdate);
         // TODO: Update specific time elements
-        this.client.emit("timeUpdate", timeUpdate);
     }
 }

--- a/src/gmcp/IRE/Time.ts
+++ b/src/gmcp/IRE/Time.ts
@@ -1,4 +1,6 @@
-import { GMCPMessage, GMCPPackage } from "../package";
+import { inbound, outbound } from "../../protocol/messages";
+import { gmcpJsonMessage } from "../messages";
+import { GMCPPackage } from "../package";
 
 export interface TimeInfo {
     day: string;
@@ -9,8 +11,25 @@ export interface TimeInfo {
     daynight: string; // Example shows "80", likely percentage or similar indicator.
 }
 
-export class GmcPIRETime extends GMCPPackage {
-    public packageName: string = "IRE.Time";
+const timeList = gmcpJsonMessage<"List", TimeInfo>("List");
+const timeUpdate = gmcpJsonMessage<"Update", Partial<TimeInfo>>("Update");
+const timeRequest = gmcpJsonMessage<"Request", never, void>("Request");
+
+const GmcPIRETimeBase = GMCPPackage.with({
+    packageName: "IRE.Time",
+    messages: [
+        inbound(timeList),
+        inbound(timeUpdate),
+        outbound(timeRequest),
+    ] as const,
+});
+
+export class GmcPIRETime extends GmcPIRETimeBase {
+    constructor(client: ConstructorParameters<typeof GmcPIRETimeBase>[0]) {
+        super(client);
+        this.on("list", (data) => this.handleList(data));
+        this.on("update", (data) => this.handleUpdate(data));
+    }
 
     // --- Server Messages ---
     handleList(timeInfo: TimeInfo): void {
@@ -24,10 +43,5 @@ export class GmcPIRETime extends GMCPPackage {
         console.log("Received IRE.Time.Update:", timeUpdate);
         // TODO: Update specific time elements
         this.client.emit("timeUpdate", timeUpdate);
-    }
-
-    // --- Client Messages ---
-    sendRequest(): void {
-        this.sendData("Request"); // No body needed
     }
 }

--- a/src/gmcp/Logging.ts
+++ b/src/gmcp/Logging.ts
@@ -1,12 +1,24 @@
+import { inbound } from "../protocol/messages";
+import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
 // Data structure is not defined in the provided docs, using 'any' for now.
 export class GMCPMessageLoggingError extends GMCPMessage {
-    [key: string]: any; // Represents error information
+    [key: string]: unknown; // Represents error information
 }
 
-export class GMCPLogging extends GMCPPackage {
-    public packageName: string = "Logging"; // Assuming base package is "Logging"
+const loggingError = gmcpJsonMessage<"Error", GMCPMessageLoggingError>("Error");
+
+const GMCPLoggingBase = GMCPPackage.with({
+    packageName: "Logging",
+    messages: [inbound(loggingError)] as const,
+});
+
+export class GMCPLogging extends GMCPLoggingBase {
+    constructor(client: ConstructorParameters<typeof GMCPLoggingBase>[0]) {
+        super(client);
+        this.on("error", (data) => this.handleError(data));
+    }
 
     // Handler for broadcast messages for Logging.Error
     handleError(data: GMCPMessageLoggingError): void {

--- a/src/gmcp/Logging.ts
+++ b/src/gmcp/Logging.ts
@@ -24,7 +24,6 @@ export class GMCPLogging extends GMCPLoggingBase {
     handleError(data: GMCPMessageLoggingError): void {
         console.error("Received Logging.Error from server:", data);
         // TODO: Implement logic to display or handle the error
-        this.client.emit("gmcpError", data); // Example: emit an event
     }
 
     // No request method as it's broadcast only

--- a/src/gmcp/Redirect.ts
+++ b/src/gmcp/Redirect.ts
@@ -1,7 +1,19 @@
-import { GMCPMessage, GMCPPackage } from "./package";
+import { inbound } from "../protocol/messages";
+import { gmcpJsonMessage } from "./messages";
+import { GMCPPackage } from "./package";
 
-export class GMCPRedirect extends GMCPPackage {
-    public packageName: string = "Redirect";
+const redirectWindow = gmcpJsonMessage<"Window", string>("Window");
+
+const GMCPRedirectBase = GMCPPackage.with({
+    packageName: "Redirect",
+    messages: [inbound(redirectWindow)] as const,
+});
+
+export class GMCPRedirect extends GMCPRedirectBase {
+    constructor(client: ConstructorParameters<typeof GMCPRedirectBase>[0]) {
+        super(client);
+        this.on("window", (windowName) => this.handleWindow(windowName));
+    }
 
     // Handler for Redirect.Window
     handleWindow(windowName: string): void {

--- a/src/gmcp/Redirect.ts
+++ b/src/gmcp/Redirect.ts
@@ -20,7 +20,6 @@ export class GMCPRedirect extends GMCPRedirectBase {
         const targetWindow = windowName || "main"; // Default to "main" if empty
         console.log(`Received Redirect.Window: ${targetWindow}`);
         // TODO: Implement logic to redirect subsequent output to the specified window/pane
-        this.client.emit("redirectWindow", targetWindow);
     }
 
     // No client messages defined in IRE docs for this package

--- a/src/gmcp/Room.ts
+++ b/src/gmcp/Room.ts
@@ -1,5 +1,7 @@
 import { useRoomStore } from "../stores/roomStore";
 import { useSessionStore } from "../stores/sessionStore";
+import { inbound } from "../protocol/messages";
+import { gmcpJsonMessage } from "./messages";
 import { GMCPMessage, GMCPPackage } from "./package";
 
 // More detailed Room.Info structure based on IRE docs
@@ -19,12 +21,37 @@ export interface RoomPlayer {
   fullname: string;
 }
 
-export class GMCPRoom extends GMCPPackage {
-  public packageName: string = "Room"; // Corrected: packageName should be instance property
+const roomInfo = gmcpJsonMessage<"Info", GMCPMessageRoomInfo>("Info");
+const roomWrongDir = gmcpJsonMessage<"WrongDir", string>("WrongDir");
+const roomPlayers = gmcpJsonMessage<"Players", RoomPlayer[]>("Players");
+const roomAddPlayer = gmcpJsonMessage<"AddPlayer", RoomPlayer>("AddPlayer");
+const roomRemovePlayer = gmcpJsonMessage<"RemovePlayer", string>("RemovePlayer");
+
+const GMCPRoomBase = GMCPPackage.with({
+  packageName: "Room",
+  messages: [
+    inbound(roomInfo),
+    inbound(roomWrongDir),
+    inbound(roomPlayers),
+    inbound(roomAddPlayer),
+    inbound(roomRemovePlayer),
+  ] as const,
+});
+
+export class GMCPRoom extends GMCPRoomBase {
   public name: string = "";
   public id: string = "";
   public exits: string[] = [];
   public people: string[] = [];
+
+  constructor(client: ConstructorParameters<typeof GMCPRoomBase>[0]) {
+    super(client);
+    this.on("info", (data) => this.handleInfo(data));
+    this.on("wrongDir", (data) => this.handleWrongDir(data));
+    this.on("players", (data) => this.handlePlayers(data));
+    this.on("addPlayer", (data) => this.handleAddPlayer(data));
+    this.on("removePlayer", (data) => this.handleRemovePlayer(data));
+  }
 
   handleInfo(data: GMCPMessageRoomInfo): void {
     this.name = data.name;

--- a/src/gmcp/Room.ts
+++ b/src/gmcp/Room.ts
@@ -66,7 +66,6 @@ export class GMCPRoom extends GMCPRoomBase {
   handleWrongDir(direction: string): void {
     console.log(`Received Room.WrongDir: ${direction}`);
     // TODO: Indicate failed movement attempt in UI?
-    this.client.emit("roomWrongDir", direction);
   }
 
   handlePlayers(players: RoomPlayer[]): void {

--- a/src/gmcp/codec.test.ts
+++ b/src/gmcp/codec.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   encodeGmcpPayload,
   parseGmcpMessageAddress,
   parseGmcpPayload,
-  resolveGmcpMessageHandler,
 } from './codec';
 
 describe('GMCP codec', () => {
@@ -24,13 +23,6 @@ describe('GMCP codec', () => {
     expect(parseGmcpPayload(undefined)).toEqual({});
     expect(parseGmcpPayload('')).toEqual({});
     expect(parseGmcpPayload('{"name":"rain"}')).toEqual({ name: 'rain' });
-  });
-
-  it('resolves handlers without exposing dynamic any at the call site', () => {
-    const handlePlay = vi.fn();
-
-    expect(resolveGmcpMessageHandler({ handlePlay }, 'Play')).toBe(handlePlay);
-    expect(resolveGmcpMessageHandler({ handlePlay: 'nope' }, 'Play')).toBeUndefined();
   });
 
   it('does not double encode already serialized payloads', () => {

--- a/src/gmcp/codec.ts
+++ b/src/gmcp/codec.ts
@@ -5,10 +5,6 @@ export interface GmcpMessageAddress {
 
 export type GmcpPayload = unknown;
 
-export type GmcpMessageHandler = (payload: GmcpPayload) => void;
-
-type HandlerContainer = Record<string, unknown>;
-
 export function parseGmcpMessageAddress(gmcpPackage: string): GmcpMessageAddress | null {
   const lastDot = gmcpPackage.lastIndexOf('.');
   if (lastDot <= 0 || lastDot === gmcpPackage.length - 1) {
@@ -27,14 +23,6 @@ export function parseGmcpPayload(gmcpMessage: string | undefined): GmcpPayload {
   }
 
   return JSON.parse(gmcpMessage) as GmcpPayload;
-}
-
-export function resolveGmcpMessageHandler(
-  handler: object,
-  messageType: string,
-): GmcpMessageHandler | undefined {
-  const candidate = (handler as HandlerContainer)[`handle${messageType}`];
-  return typeof candidate === 'function' ? (candidate as GmcpMessageHandler) : undefined;
 }
 
 export function encodeGmcpPayload(data?: unknown): string {

--- a/src/gmcp/messages.ts
+++ b/src/gmcp/messages.ts
@@ -1,0 +1,23 @@
+import {
+  messageEnvelope,
+  type ProtocolCodec,
+  type ProtocolMessageEnvelope,
+} from '../protocol/messages';
+
+export function gmcpJsonMessage<
+  Name extends string,
+  InboundPayload,
+  OutboundPayload = InboundPayload,
+>(
+  wireName: Name,
+  codec: ProtocolCodec<InboundPayload, OutboundPayload> = {
+    encode(payload: OutboundPayload): unknown {
+      return payload;
+    },
+    decode(payload: unknown): InboundPayload {
+      return payload as InboundPayload;
+    },
+  },
+): ProtocolMessageEnvelope<Name, InboundPayload, OutboundPayload> {
+  return messageEnvelope(wireName, codec);
+}

--- a/src/gmcp/package.ts
+++ b/src/gmcp/package.ts
@@ -1,7 +1,16 @@
 import type MudClient from "../client";
+import {
+    createProtocolIO,
+    type AnyDirectedProtocolMessage,
+    type ProtocolIO,
+} from "../protocol/messages";
 
 export abstract class GMCPMessage { }
 
+interface GMCPPackageConfig<Messages extends readonly AnyDirectedProtocolMessage[]> {
+    packageName: string;
+    messages: Messages;
+}
 
 export class GMCPPackage {
     public readonly packageName!: string;
@@ -10,6 +19,27 @@ export class GMCPPackage {
 
     constructor(client: MudClient) {
         this.client = client;
+    }
+
+    static with<const Messages extends readonly AnyDirectedProtocolMessage[]>(
+        config: GMCPPackageConfig<Messages>,
+    ): new (client: MudClient) => GMCPPackage & ProtocolIO<Messages> {
+        const RegisteredGMCPPackage = class extends GMCPPackage {
+            public readonly packageName = config.packageName;
+
+            constructor(client: MudClient) {
+                super(client);
+                createProtocolIO(
+                    config.messages,
+                    (wireName, payload) => this.sendData(wireName, payload),
+                    this,
+                );
+            }
+        };
+
+        return RegisteredGMCPPackage as unknown as new (
+            client: MudClient,
+        ) => GMCPPackage & ProtocolIO<Messages>;
     }
 
     get enabled(): boolean {
@@ -26,5 +56,10 @@ export class GMCPPackage {
     shutdown() {
         // Do nothing
     }
-}
 
+    protected emitRegisteredMessage(wireName: string, payload: unknown): boolean {
+        const receiver = (this as { receive?: (name: string, data: unknown) => boolean })
+            .receive;
+        return receiver?.call(this, wireName, payload) ?? false;
+    }
+}

--- a/src/gmcp/package.ts
+++ b/src/gmcp/package.ts
@@ -57,9 +57,13 @@ export class GMCPPackage {
         // Do nothing
     }
 
-    protected emitRegisteredMessage(wireName: string, payload: unknown): boolean {
+    receiveRegisteredMessage(wireName: string, payload: unknown): boolean {
         const receiver = (this as { receive?: (name: string, data: unknown) => boolean })
             .receive;
         return receiver?.call(this, wireName, payload) ?? false;
+    }
+
+    protected emitRegisteredMessage(wireName: string, payload: unknown): boolean {
+        return this.receiveRegisteredMessage(wireName, payload);
     }
 }

--- a/src/gmcp/session.test.ts
+++ b/src/gmcp/session.test.ts
@@ -37,11 +37,9 @@ class MockClientMediaPackage extends GMCPPackage {
 }
 
 function createSession() {
-  const client = {
-    emit: vi.fn(),
-  } as unknown as MudClient;
+  const client = {} as unknown as MudClient;
   const session = new GmcpSession(client);
-  return { client, session };
+  return { session };
 }
 
 describe('GmcpSession', () => {
@@ -73,14 +71,14 @@ describe('GmcpSession', () => {
   });
 
   it('runs GMCP startup packages and marks GMCP ready once', () => {
-    const { client, session } = createSession();
+    const { session } = createSession();
     const core = session.register(MockCorePackage);
     const supports = session.register(MockCoreSupportsPackage);
     const autoLogin = session.register(MockAutoLoginPackage);
     const media = session.register(MockClientMediaPackage);
 
-    session.start();
-    session.start();
+    expect(session.start()).toBe(true);
+    expect(session.start()).toBe(false);
 
     expect(core.sendHello).toHaveBeenCalledTimes(2);
     expect(supports.sendSet).toHaveBeenCalledTimes(2);
@@ -88,22 +86,18 @@ describe('GmcpSession', () => {
     expect(autoLogin.sendStoredLogin).toHaveBeenCalledTimes(2);
     expect(media.publishEffectsSupport).toHaveBeenCalledTimes(2);
     expect(session.ready).toBe(true);
-    expect(client.emit).toHaveBeenCalledWith('gmcpReady');
-    expect(client.emit).toHaveBeenCalledTimes(1);
   });
 
   it('owns session readiness and reset state', () => {
-    const { client, session } = createSession();
+    const { session } = createSession();
 
-    session.markReady();
-    session.markSessionReady();
-    session.markSessionReady();
+    expect(session.markReady()).toBe(true);
+    expect(session.markReady()).toBe(false);
+    expect(session.markSessionReady()).toBe(true);
+    expect(session.markSessionReady()).toBe(false);
 
     expect(session.ready).toBe(true);
     expect(session.sessionReady).toBe(true);
-    expect(client.emit).toHaveBeenCalledWith('gmcpReady');
-    expect(client.emit).toHaveBeenCalledWith('sessionReady');
-    expect(client.emit).toHaveBeenCalledTimes(2);
 
     session.reset();
 

--- a/src/gmcp/session.test.ts
+++ b/src/gmcp/session.test.ts
@@ -22,6 +22,7 @@ class MockCorePackage extends GMCPPackage {
 
 class MockCoreSupportsPackage extends GMCPPackage {
   packageName = 'Core.Supports';
+  advertisedModules = vi.fn(() => ['Core 1', 'Core.Supports 1']);
   sendSet = vi.fn();
 }
 
@@ -32,7 +33,7 @@ class MockAutoLoginPackage extends GMCPPackage {
 
 class MockClientMediaPackage extends GMCPPackage {
   packageName = 'Client.Media';
-  sendEffectsSupport = vi.fn();
+  publishEffectsSupport = vi.fn();
 }
 
 function createSession() {
@@ -83,8 +84,9 @@ describe('GmcpSession', () => {
 
     expect(core.sendHello).toHaveBeenCalledTimes(2);
     expect(supports.sendSet).toHaveBeenCalledTimes(2);
+    expect(supports.sendSet).toHaveBeenCalledWith(['Core 1', 'Core.Supports 1']);
     expect(autoLogin.sendLogin).toHaveBeenCalledTimes(2);
-    expect(media.sendEffectsSupport).toHaveBeenCalledTimes(2);
+    expect(media.publishEffectsSupport).toHaveBeenCalledTimes(2);
     expect(session.ready).toBe(true);
     expect(client.emit).toHaveBeenCalledWith('gmcpReady');
     expect(client.emit).toHaveBeenCalledTimes(1);

--- a/src/gmcp/session.test.ts
+++ b/src/gmcp/session.test.ts
@@ -6,11 +6,6 @@ import type { TelnetParser } from '../telnet';
 import { GMCPPackage } from './package';
 import { GmcpSession } from './session';
 
-class RecordingPackage extends GMCPPackage {
-  packageName = 'Test';
-  handleThing = vi.fn();
-}
-
 const registryThing = messageEnvelope('Thing', identityCodec<{ ok: boolean }>());
 
 const RegistryPackageBase = GMCPPackage.with({
@@ -54,15 +49,6 @@ describe('GmcpSession', () => {
   });
 
   it('registers typed packages and dispatches inbound GMCP messages', () => {
-    const { session } = createSession();
-    const handler = session.register(RecordingPackage);
-
-    session.receive('Test.Thing', '{"ok":true}');
-
-    expect(handler.handleThing).toHaveBeenCalledWith({ ok: true });
-  });
-
-  it('dispatches registered GMCP messages without reflection handlers', () => {
     const { session } = createSession();
     const handler = session.register(RegistryPackage);
     const listener = vi.fn();

--- a/src/gmcp/session.test.ts
+++ b/src/gmcp/session.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type MudClient from '../client';
+import { identityCodec, inbound, messageEnvelope } from '../protocol/messages';
 import type { TelnetParser } from '../telnet';
 import { GMCPPackage } from './package';
 import { GmcpSession } from './session';
@@ -9,6 +10,15 @@ class RecordingPackage extends GMCPPackage {
   packageName = 'Test';
   handleThing = vi.fn();
 }
+
+const registryThing = messageEnvelope('Thing', identityCodec<{ ok: boolean }>());
+
+const RegistryPackageBase = GMCPPackage.with({
+  packageName: 'Registry',
+  messages: [inbound(registryThing)] as const,
+});
+
+class RegistryPackage extends RegistryPackageBase {}
 
 class MockCorePackage extends GMCPPackage {
   packageName = 'Core';
@@ -50,6 +60,17 @@ describe('GmcpSession', () => {
     session.receive('Test.Thing', '{"ok":true}');
 
     expect(handler.handleThing).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('dispatches registered GMCP messages without reflection handlers', () => {
+    const { session } = createSession();
+    const handler = session.register(RegistryPackage);
+    const listener = vi.fn();
+    handler.on('thing', listener);
+
+    session.receive('Registry.Thing', '{"ok":true}');
+
+    expect(listener).toHaveBeenCalledWith({ ok: true });
   });
 
   it('encodes outbound messages through the attached telnet transport', () => {

--- a/src/gmcp/session.test.ts
+++ b/src/gmcp/session.test.ts
@@ -28,7 +28,7 @@ class MockCoreSupportsPackage extends GMCPPackage {
 
 class MockAutoLoginPackage extends GMCPPackage {
   packageName = 'Auth.Autologin';
-  sendLogin = vi.fn();
+  sendStoredLogin = vi.fn();
 }
 
 class MockClientMediaPackage extends GMCPPackage {
@@ -85,7 +85,7 @@ describe('GmcpSession', () => {
     expect(core.sendHello).toHaveBeenCalledTimes(2);
     expect(supports.sendSet).toHaveBeenCalledTimes(2);
     expect(supports.sendSet).toHaveBeenCalledWith(['Core 1', 'Core.Supports 1']);
-    expect(autoLogin.sendLogin).toHaveBeenCalledTimes(2);
+    expect(autoLogin.sendStoredLogin).toHaveBeenCalledTimes(2);
     expect(media.publishEffectsSupport).toHaveBeenCalledTimes(2);
     expect(session.ready).toBe(true);
     expect(client.emit).toHaveBeenCalledWith('gmcpReady');

--- a/src/gmcp/session.test.ts
+++ b/src/gmcp/session.test.ts
@@ -58,6 +58,36 @@ describe('GmcpSession', () => {
     expect(listener).toHaveBeenCalledWith({ ok: true });
   });
 
+  it('logs malformed registered GMCP messages without throwing', () => {
+    const { session } = createSession();
+    session.register(RegistryPackage);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => session.receive('Registry.Thing', '{bad')).not.toThrow();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error dispatching GMCP message for Registry.Thing:',
+      expect.any(SyntaxError),
+    );
+  });
+
+  it('logs registered GMCP listener errors without throwing', () => {
+    const { session } = createSession();
+    const handler = session.register(RegistryPackage);
+    const error = new Error('listener failed');
+    handler.on('thing', () => {
+      throw error;
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => session.receive('Registry.Thing', '{"ok":true}')).not.toThrow();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error dispatching GMCP message for Registry.Thing:',
+      error,
+    );
+  });
+
   it('encodes outbound messages through the attached telnet transport', () => {
     const { session } = createSession();
     const telnet = {

--- a/src/gmcp/session.ts
+++ b/src/gmcp/session.ts
@@ -84,8 +84,19 @@ export class GmcpSession {
       return;
     }
 
-    const payload = parseGmcpPayload(gmcpMessage);
-    if (handler.receiveRegisteredMessage(address.messageType, payload)) {
+    let handled: boolean;
+    try {
+      const payload = parseGmcpPayload(gmcpMessage);
+      handled = handler.receiveRegisteredMessage(address.messageType, payload);
+    } catch (error) {
+      console.error(
+        `Error dispatching GMCP message for ${address.packageName}.${address.messageType}:`,
+        error,
+      );
+      return;
+    }
+
+    if (handled) {
       return;
     }
 

--- a/src/gmcp/session.ts
+++ b/src/gmcp/session.ts
@@ -49,25 +49,25 @@ export class GmcpSession {
     return gmcpPackage;
   }
 
-  start(): void {
+  start(): boolean {
     this.require('Core').sendHello({ client: 'Mongoose Client', version: '0.1' });
     const coreSupports = this.require('Core.Supports');
     coreSupports.sendSet(coreSupports.advertisedModules());
     this.require('Auth.Autologin').sendStoredLogin();
     this.require('Client.Media').publishEffectsSupport();
-    this.markReady();
+    return this.markReady();
   }
 
-  markReady(): void {
-    if (this._ready) return;
+  markReady(): boolean {
+    if (this._ready) return false;
     this._ready = true;
-    this.client.emit('gmcpReady');
+    return true;
   }
 
-  markSessionReady(): void {
-    if (this._sessionReady) return;
+  markSessionReady(): boolean {
+    if (this._sessionReady) return false;
     this._sessionReady = true;
-    this.client.emit('sessionReady');
+    return true;
   }
 
   receive(gmcpPackage: string, gmcpMessage: string | undefined): void {

--- a/src/gmcp/session.ts
+++ b/src/gmcp/session.ts
@@ -4,7 +4,6 @@ import {
   encodeGmcpPayload,
   parseGmcpMessageAddress,
   parseGmcpPayload,
-  resolveGmcpMessageHandler,
 } from './codec';
 import type { GMCPPackage } from './package';
 import type { GMCPHandlerMap, KnownGMCPPackageMap, KnownGMCPPackageName } from './types';
@@ -89,20 +88,7 @@ export class GmcpSession {
       return;
     }
 
-    const messageHandler = resolveGmcpMessageHandler(handler, address.messageType);
-    if (!messageHandler) {
-      console.log('No handler on package:', address.packageName, address.messageType);
-      return;
-    }
-
-    try {
-      messageHandler.call(handler, payload);
-    } catch (error) {
-      console.error(
-        `Error dispatching GMCP message for ${address.packageName}.${address.messageType}:`,
-        error,
-      );
-    }
+    console.log('No registered GMCP message:', address.packageName, address.messageType);
   }
 
   send(packageName: string, data?: unknown): void {

--- a/src/gmcp/session.ts
+++ b/src/gmcp/session.ts
@@ -50,10 +50,11 @@ export class GmcpSession {
   }
 
   start(): void {
-    this.require('Core').sendHello();
-    this.require('Core.Supports').sendSet();
+    this.require('Core').sendHello({ client: 'Mongoose Client', version: '0.1' });
+    const coreSupports = this.require('Core.Supports');
+    coreSupports.sendSet(coreSupports.advertisedModules());
     this.require('Auth.Autologin').sendLogin();
-    this.require('Client.Media').sendEffectsSupport();
+    this.require('Client.Media').publishEffectsSupport();
     this.markReady();
   }
 

--- a/src/gmcp/session.ts
+++ b/src/gmcp/session.ts
@@ -84,6 +84,11 @@ export class GmcpSession {
       return;
     }
 
+    const payload = parseGmcpPayload(gmcpMessage);
+    if (handler.receiveRegisteredMessage(address.messageType, payload)) {
+      return;
+    }
+
     const messageHandler = resolveGmcpMessageHandler(handler, address.messageType);
     if (!messageHandler) {
       console.log('No handler on package:', address.packageName, address.messageType);
@@ -91,7 +96,7 @@ export class GmcpSession {
     }
 
     try {
-      messageHandler.call(handler, parseGmcpPayload(gmcpMessage));
+      messageHandler.call(handler, payload);
     } catch (error) {
       console.error(
         `Error dispatching GMCP message for ${address.packageName}.${address.messageType}:`,

--- a/src/gmcp/session.ts
+++ b/src/gmcp/session.ts
@@ -53,7 +53,7 @@ export class GmcpSession {
     this.require('Core').sendHello({ client: 'Mongoose Client', version: '0.1' });
     const coreSupports = this.require('Core.Supports');
     coreSupports.sendSet(coreSupports.advertisedModules());
-    this.require('Auth.Autologin').sendLogin();
+    this.require('Auth.Autologin').sendStoredLogin();
     this.require('Client.Media').publishEffectsSupport();
     this.markReady();
   }

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   MCPPackage,
+  McpAwnsGetSet,
+  McpAwnsStatus,
   McpSession,
   McpSimpleEdit,
   McpVmooUserlist,
@@ -97,7 +99,6 @@ describe('McpSession', () => {
     const sent: string[] = [];
     const session = new McpSession(
       {
-        emit: vi.fn(),
         sendLine: (line) => sent.push(line),
       },
       () => 'auth01',
@@ -116,7 +117,6 @@ describe('McpSession', () => {
   it('routes authenticated messages by longest package prefix and tracks multiline tags', () => {
     const session = new McpSession(
       {
-        emit: vi.fn(),
         sendLine: vi.fn(),
       },
       () => 'auth01',
@@ -147,7 +147,6 @@ describe('McpSession', () => {
     const opened: EditorSession[] = [];
     const session = new McpSession(
       {
-        emit: vi.fn(),
         sendLine: vi.fn(),
       },
       () => 'auth01',
@@ -188,7 +187,6 @@ describe('McpSession', () => {
     const tags = ['auth01', 'mltag1'];
     const session = new McpSession(
       {
-        emit: vi.fn(),
         sendLine: (line) => sent.push(line),
       },
       () => tags.shift() ?? 'fallback',
@@ -222,19 +220,56 @@ describe('McpSession', () => {
     ]);
   });
 
-  it('removes userlist players whose MOO object ids parse as numbers', () => {
-    const userlists: unknown[][] = [];
+  it('emits AWNS status text through the status package', () => {
+    const statusTexts: string[] = [];
     const session = new McpSession(
       {
-        emit: (_event, players) => {
-          userlists.push(players as unknown[]);
-          return true;
-        },
         sendLine: vi.fn(),
       },
       () => 'auth01',
     );
-    session.registerPackage(McpVmooUserlist);
+    const status = session.registerPackage(McpAwnsStatus);
+    status.on('statustext', (text) => statusTexts.push(text));
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    session.receiveLine('#$#dns-com-awns-status auth01 text: "Standing by"');
+
+    expect(statusTexts).toEqual(['Standing by']);
+  });
+
+  it('emits AWNS get/set acknowledgements through the getset package', () => {
+    const values: Array<{ key: string; value: string }> = [];
+    const sent: string[] = [];
+    const session = new McpSession(
+      {
+        sendLine: (line) => sent.push(line),
+      },
+      () => 'auth01',
+    );
+    const getSet = session.registerPackage(McpAwnsGetSet);
+    getSet.on('getset', (payload) => values.push(payload));
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    sent.length = 0;
+    getSet.requestGet('theme');
+    session.receiveLine('#$#dns-com-awns-getset-ack auth01 id: 1 value: dark');
+
+    expect(sent).toEqual([
+      '#$#dns-com-awns-getset-get auth01 id: 1 property: theme',
+    ]);
+    expect(values).toEqual([{ key: 'theme', value: 'dark' }]);
+  });
+
+  it('removes userlist players whose MOO object ids parse as numbers', () => {
+    const userlists: unknown[][] = [];
+    const session = new McpSession(
+      {
+        sendLine: vi.fn(),
+      },
+      () => 'auth01',
+    );
+    const userlist = session.registerPackage(McpVmooUserlist);
+    userlist.on('userlist', (players) => userlists.push(players));
 
     session.receiveLine('#$#MCP version: 2.1 to: 2.1');
     session.receiveLine('#$#dns-com-vmoo-userlist-content auth01 _data-tag: users');

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -98,7 +98,6 @@ describe('McpSession', () => {
     const session = new McpSession(
       {
         emit: vi.fn(),
-        openEditorSession: vi.fn(),
         sendLine: (line) => sent.push(line),
       },
       () => 'auth01',
@@ -118,7 +117,6 @@ describe('McpSession', () => {
     const session = new McpSession(
       {
         emit: vi.fn(),
-        openEditorSession: vi.fn(),
         sendLine: vi.fn(),
       },
       () => 'auth01',
@@ -150,12 +148,12 @@ describe('McpSession', () => {
     const session = new McpSession(
       {
         emit: vi.fn(),
-        openEditorSession: (editorSession) => opened.push(editorSession),
         sendLine: vi.fn(),
       },
       () => 'auth01',
     );
-    session.registerPackage(McpSimpleEdit);
+    const simpleEdit = session.registerPackage(McpSimpleEdit);
+    simpleEdit.on('openSession', (editorSession) => opened.push(editorSession));
 
     session.receiveLine('#$#MCP version: 2.1 to: 2.1');
     session.receiveLine(
@@ -191,7 +189,6 @@ describe('McpSession', () => {
     const session = new McpSession(
       {
         emit: vi.fn(),
-        openEditorSession: vi.fn(),
         sendLine: (line) => sent.push(line),
       },
       () => tags.shift() ?? 'fallback',
@@ -204,7 +201,13 @@ describe('McpSession', () => {
 
     session.receiveLine('#$#MCP version: 2.1 to: 2.1');
     sent.length = 0;
-    session.sendMultiline('dns-org-mud-moo-simpleedit-set', keyvals, ['line one', 'line two']);
+    const simpleEdit = session.registerPackage(McpSimpleEdit);
+    simpleEdit.sendSet({
+      reference: keyvals.reference,
+      type: keyvals.type,
+      contents: ['line one', 'line two'],
+      name: 'obj 1',
+    });
 
     expect(keyvals).toEqual({
       reference: 'obj 1',
@@ -227,7 +230,6 @@ describe('McpSession', () => {
           userlists.push(players as unknown[]);
           return true;
         },
-        openEditorSession: vi.fn(),
         sendLine: vi.fn(),
       },
       () => 'auth01',

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -7,7 +7,7 @@ export {
   parseMcpMultiline,
 } from './codec';
 export { mooListToArray, type MooListValue } from './mooList';
-export { MCPPackage, type McpPackageContext } from './package';
+export { MCPPackage } from './package';
 export { DEFAULT_MCP_PACKAGES, type McpPackageConstructor } from './packages';
 export { McpAwnsGetSet } from './packages/getSet';
 export { McpNegotiate } from './packages/negotiate';

--- a/src/mcp/package.ts
+++ b/src/mcp/package.ts
@@ -1,9 +1,28 @@
-import type { EditorSession, McpMessage, McpOutboundData } from './types';
+import {
+  createProtocolIO,
+  type AnyDirectedProtocolMessage,
+  type ProtocolIO,
+} from '../protocol/messages';
+import type {
+  McpMessage,
+  McpOutboundData,
+  McpOutboundKeyvals,
+} from './types';
 
 export interface McpPackageContext {
   emit(event: string, ...args: unknown[]): boolean;
-  openEditorSession(session: EditorSession): void;
-  sendMcp(command: string, data?: McpOutboundData): void;
+}
+
+export interface McpMultilineOutboundPayload {
+  kind: 'mcp-multiline';
+  keyvals: McpOutboundKeyvals;
+  lineKey: string;
+  lines: string[];
+}
+
+interface McpPackageConfig<Messages extends readonly AnyDirectedProtocolMessage[]> {
+  packageName: string;
+  messages: Messages;
 }
 
 export class MCPPackage {
@@ -12,9 +31,50 @@ export class MCPPackage {
   public readonly maxVersion?: number = 1.0;
   public readonly packageVersion?: number = 0.0;
   protected readonly context: McpPackageContext;
+  private sendMessage?: (command: string, data?: McpOutboundData) => void;
+  private sendMultilineMessage?: (
+    command: string,
+    keyvals: McpOutboundKeyvals,
+    lineKey: string,
+    lines: string[],
+  ) => void;
 
   constructor(context: McpPackageContext) {
     this.context = context;
+  }
+
+  static with<const Messages extends readonly AnyDirectedProtocolMessage[]>(
+    config: McpPackageConfig<Messages>,
+  ): new (context: McpPackageContext) => MCPPackage & ProtocolIO<Messages> {
+    const RegisteredMCPPackage = class extends MCPPackage {
+      public readonly packageName = config.packageName;
+
+      constructor(context: McpPackageContext) {
+        super(context);
+        createProtocolIO(
+          config.messages,
+          (wireName, payload) => this.sendRegisteredMessage(wireName, payload),
+          this,
+        );
+      }
+    };
+
+    return RegisteredMCPPackage as unknown as new (
+      context: McpPackageContext,
+    ) => MCPPackage & ProtocolIO<Messages>;
+  }
+
+  attachProtocolTransport(
+    sendMessage: (command: string, data?: McpOutboundData) => void,
+    sendMultilineMessage: (
+      command: string,
+      keyvals: McpOutboundKeyvals,
+      lineKey: string,
+      lines: string[],
+    ) => void,
+  ): void {
+    this.sendMessage = sendMessage;
+    this.sendMultilineMessage = sendMultilineMessage;
   }
 
   handle(_message: McpMessage): void {
@@ -34,9 +94,58 @@ export class MCPPackage {
   }
 
   send(command: string, data?: McpOutboundData): void {
+    if (!this.sendMessage) {
+      throw new Error(`MCP package ${this.packageName} is not registered`);
+    }
+
     const messageName = command.startsWith(this.packageName)
       ? command
       : `${this.packageName}-${command}`;
-    this.context.sendMcp(messageName, data);
+    this.sendMessage(messageName, data);
   }
+
+  protected emitRegisteredMessage(wireName: string, payload: unknown): boolean {
+    const receiver = (this as { receive?: (name: string, data: unknown) => boolean })
+      .receive;
+    return receiver?.call(this, wireName, payload) ?? false;
+  }
+
+  private sendRegisteredMessage(wireName: string, payload: unknown): void {
+    if (isMcpMultilineOutboundPayload(payload)) {
+      this.sendMultiline(wireName, payload);
+      return;
+    }
+
+    this.send(wireName, payload as McpOutboundData);
+  }
+
+  private sendMultiline(
+    command: string,
+    payload: McpMultilineOutboundPayload,
+  ): void {
+    if (!this.sendMultilineMessage) {
+      throw new Error(`MCP package ${this.packageName} is not registered`);
+    }
+
+    const messageName = command.startsWith(this.packageName)
+      ? command
+      : `${this.packageName}-${command}`;
+    this.sendMultilineMessage(
+      messageName,
+      payload.keyvals,
+      payload.lineKey,
+      payload.lines,
+    );
+  }
+}
+
+function isMcpMultilineOutboundPayload(
+  payload: unknown,
+): payload is McpMultilineOutboundPayload {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    'kind' in payload &&
+    payload.kind === 'mcp-multiline'
+  );
 }

--- a/src/mcp/package.ts
+++ b/src/mcp/package.ts
@@ -9,10 +9,6 @@ import type {
   McpOutboundKeyvals,
 } from './types';
 
-export interface McpPackageContext {
-  emit(event: string, ...args: unknown[]): boolean;
-}
-
 export interface McpMultilineOutboundPayload {
   kind: 'mcp-multiline';
   keyvals: McpOutboundKeyvals;
@@ -30,7 +26,6 @@ export class MCPPackage {
   public readonly minVersion?: number = 1.0;
   public readonly maxVersion?: number = 1.0;
   public readonly packageVersion?: number = 0.0;
-  protected readonly context: McpPackageContext;
   private sendMessage?: (command: string, data?: McpOutboundData) => void;
   private sendMultilineMessage?: (
     command: string,
@@ -39,18 +34,14 @@ export class MCPPackage {
     lines: string[],
   ) => void;
 
-  constructor(context: McpPackageContext) {
-    this.context = context;
-  }
-
   static with<const Messages extends readonly AnyDirectedProtocolMessage[]>(
     config: McpPackageConfig<Messages>,
-  ): new (context: McpPackageContext) => MCPPackage & ProtocolIO<Messages> {
+  ): new () => MCPPackage & ProtocolIO<Messages> {
     const RegisteredMCPPackage = class extends MCPPackage {
       public readonly packageName = config.packageName;
 
-      constructor(context: McpPackageContext) {
-        super(context);
+      constructor() {
+        super();
         createProtocolIO(
           config.messages,
           (wireName, payload) => this.sendRegisteredMessage(wireName, payload),
@@ -59,9 +50,8 @@ export class MCPPackage {
       }
     };
 
-    return RegisteredMCPPackage as unknown as new (
-      context: McpPackageContext,
-    ) => MCPPackage & ProtocolIO<Messages>;
+    return RegisteredMCPPackage as unknown as new () => MCPPackage &
+      ProtocolIO<Messages>;
   }
 
   attachProtocolTransport(

--- a/src/mcp/packages/getSet.ts
+++ b/src/mcp/packages/getSet.ts
@@ -32,14 +32,14 @@ export class McpAwnsGetSet extends MCPPackage {
   sendGet(property: string): void {
     const id = (this.id++).toString();
     this.cache.set(id, property);
-    this.context.sendMcp('dns-com-awns-getset-get', {
+    this.send('get', {
       id,
       property,
     });
   }
 
   sendSet(property: string, value: string): void {
-    this.context.sendMcp('dns-com-awns-getset-set', {
+    this.send('set', {
       id: this.id++,
       property,
       value,
@@ -47,7 +47,7 @@ export class McpAwnsGetSet extends MCPPackage {
   }
 
   sendDrop(property: string): void {
-    this.context.sendMcp('dns-com-awns-getset-drop', {
+    this.send('drop', {
       id: this.id++,
       property,
     });

--- a/src/mcp/packages/getSet.ts
+++ b/src/mcp/packages/getSet.ts
@@ -1,9 +1,43 @@
 import { LRUCache } from 'lru-cache';
+import {
+  identityCodec,
+  inbound,
+  messageEnvelope,
+  outbound,
+} from '../../protocol/messages';
 import { MCPPackage } from '../package';
 import type { McpMessage } from '../types';
 
-export class McpAwnsGetSet extends MCPPackage {
-  public packageName = 'dns-com-awns-getset';
+interface GetSetAck {
+  key: string;
+  value: string;
+}
+
+interface GetSetGetRequest {
+  id: string;
+  property: string;
+}
+
+interface GetSetSetRequest extends GetSetGetRequest {
+  value: string;
+}
+
+const getSetAck = messageEnvelope('ack', identityCodec<GetSetAck>());
+const getSetGet = messageEnvelope('get', identityCodec<GetSetGetRequest>());
+const getSetSet = messageEnvelope('set', identityCodec<GetSetSetRequest>());
+const getSetDrop = messageEnvelope('drop', identityCodec<GetSetGetRequest>());
+
+const McpAwnsGetSetBase = MCPPackage.with({
+  packageName: 'dns-com-awns-getset',
+  messages: [
+    inbound(getSetAck).asEvent('getset'),
+    outbound(getSetGet),
+    outbound(getSetSet),
+    outbound(getSetDrop),
+  ] as const,
+});
+
+export class McpAwnsGetSet extends McpAwnsGetSetBase {
   private id = 1;
   private cache = new LRUCache<string, string>({ max: 10 });
 
@@ -20,7 +54,7 @@ export class McpAwnsGetSet extends MCPPackage {
         const value = message.keyvals.value;
         console.log(`Got ${key} = ${value}`);
         this.LocalCache[key] = value;
-        this.context.emit('getset', key, value);
+        this.emitRegisteredMessage(getSetAck.wireName, { key, value });
         break;
       }
 
@@ -29,26 +63,26 @@ export class McpAwnsGetSet extends MCPPackage {
     }
   }
 
-  sendGet(property: string): void {
+  requestGet(property: string): void {
     const id = (this.id++).toString();
     this.cache.set(id, property);
-    this.send('get', {
+    this.sendGet({
       id,
       property,
     });
   }
 
-  sendSet(property: string, value: string): void {
-    this.send('set', {
-      id: this.id++,
+  setProperty(property: string, value: string): void {
+    this.sendSet({
+      id: (this.id++).toString(),
       property,
       value,
     });
   }
 
-  sendDrop(property: string): void {
-    this.send('drop', {
-      id: this.id++,
+  dropProperty(property: string): void {
+    this.sendDrop({
+      id: (this.id++).toString(),
       property,
     });
   }

--- a/src/mcp/packages/index.ts
+++ b/src/mcp/packages/index.ts
@@ -1,4 +1,4 @@
-import type { MCPPackage, McpPackageContext } from "../package";
+import type { MCPPackage } from "../package";
 import { McpAwnsGetSet } from "./getSet";
 import { McpNegotiate } from "./negotiate";
 import { McpAwnsPing } from "./ping";
@@ -6,7 +6,7 @@ import { McpSimpleEdit } from "./simpleEdit";
 import { McpAwnsStatus } from "./status";
 import { McpVmooUserlist } from "./userlist";
 
-export type McpPackageConstructor = new (_: McpPackageContext) => MCPPackage;
+export type McpPackageConstructor = new () => MCPPackage;
 
 export const DEFAULT_MCP_PACKAGES = [
   McpNegotiate,

--- a/src/mcp/packages/simpleEdit.ts
+++ b/src/mcp/packages/simpleEdit.ts
@@ -1,9 +1,47 @@
-import { MCPPackage } from '../package';
+import {
+  identityCodec,
+  inbound,
+  messageEnvelope,
+  outbound,
+} from '../../protocol/messages';
+import {
+  MCPPackage,
+  type McpMultilineOutboundPayload,
+} from '../package';
 import type { EditorSession, McpMessage } from '../types';
 
-export class McpSimpleEdit extends MCPPackage {
-  public packageName = 'dns-org-mud-moo-simpleedit';
+const simpleEditContent = messageEnvelope(
+  'content',
+  identityCodec<EditorSession>(),
+);
 
+const simpleEditSet = messageEnvelope('set', {
+  encode(session: EditorSession): McpMultilineOutboundPayload {
+    return {
+      kind: 'mcp-multiline',
+      keyvals: {
+        reference: session.reference,
+        type: session.type,
+        'content*': '',
+      },
+      lineKey: 'content',
+      lines: session.contents,
+    };
+  },
+  decode(payload: unknown): EditorSession {
+    return payload as EditorSession;
+  },
+});
+
+const McpSimpleEditBase = MCPPackage.with({
+  packageName: 'dns-org-mud-moo-simpleedit',
+  messages: [
+    inbound(simpleEditContent).asEvent('openSession'),
+    outbound(simpleEditSet),
+  ] as const,
+});
+
+export class McpSimpleEdit extends McpSimpleEditBase {
   private sessionsByTag = new Map<string, EditorSession>();
 
   handle(message: McpMessage): void {
@@ -42,7 +80,7 @@ export class McpSimpleEdit extends MCPPackage {
       return;
     }
 
-    this.context.openEditorSession(session);
+    this.emitRegisteredMessage(simpleEditContent.wireName, session);
     this.sessionsByTag.delete(closure.name);
   }
 }

--- a/src/mcp/packages/status.ts
+++ b/src/mcp/packages/status.ts
@@ -1,10 +1,20 @@
+import {
+  identityCodec,
+  inbound,
+  messageEnvelope,
+} from '../../protocol/messages';
 import { MCPPackage } from '../package';
 import type { McpMessage } from '../types';
 
-export class McpAwnsStatus extends MCPPackage {
-  public packageName = 'dns-com-awns-status';
+const statusText = messageEnvelope('statusText', identityCodec<string>());
 
+const McpAwnsStatusBase = MCPPackage.with({
+  packageName: 'dns-com-awns-status',
+  messages: [inbound(statusText).asEvent('statustext')] as const,
+});
+
+export class McpAwnsStatus extends McpAwnsStatusBase {
   handle(message: McpMessage): void {
-    this.context.emit('statustext', message.keyvals.text);
+    this.emitRegisteredMessage(statusText.wireName, message.keyvals.text);
   }
 }

--- a/src/mcp/packages/userlist.ts
+++ b/src/mcp/packages/userlist.ts
@@ -1,3 +1,8 @@
+import {
+  identityCodec,
+  inbound,
+  messageEnvelope,
+} from '../../protocol/messages';
 import { mooListToArray, type MooListValue } from '../mooList';
 import { MCPPackage } from '../package';
 import type { McpMessage } from '../types';
@@ -10,8 +15,14 @@ export interface UserlistPlayer {
   idle: boolean;
 }
 
-export class McpVmooUserlist extends MCPPackage {
-  public packageName = 'dns-com-vmoo-userlist';
+const userlist = messageEnvelope('userlist', identityCodec<UserlistPlayer[]>());
+
+const McpVmooUserlistBase = MCPPackage.with({
+  packageName: 'dns-com-vmoo-userlist',
+  messages: [inbound(userlist)] as const,
+});
+
+export class McpVmooUserlist extends McpVmooUserlistBase {
   public maxVersion = 1.1;
   public player: string | undefined;
   public fields: string[] = ['Object', 'Name', 'Icon'];
@@ -116,7 +127,7 @@ export class McpVmooUserlist extends MCPPackage {
 
   private update(): void {
     this.players.sort((left, right) => sortScore(right) - sortScore(left));
-    this.context.emit('userlist', this.players);
+    this.emitRegisteredMessage(userlist.wireName, this.players);
 
     function sortScore(player: UserlistPlayer): number {
       return player.Icon - (player.idle ? 10 : 0) - (player.away ? 20 : 0);

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -4,11 +4,10 @@ import {
   encodeMcpMultilineLine,
   parseMcpLine,
 } from "./codec";
-import type { MCPPackage, McpPackageContext } from "./package";
+import type { MCPPackage } from "./package";
 import type { MCPKeyvals, McpMessage, McpOutboundData, McpOutboundKeyvals } from "./types";
 
 export interface McpSessionHost {
-  emit(event: string, ...args: unknown[]): boolean;
   sendLine(line: string): void;
 }
 
@@ -16,16 +15,11 @@ export class McpSession {
   private authKey: string | null = null;
   private readonly handlers: Record<string, MCPPackage> = {};
   private readonly multilines: Record<string, MCPPackage> = {};
-  private readonly packageContext: McpPackageContext;
 
   constructor(
     private readonly host: McpSessionHost,
     private readonly tagGenerator: () => string = generateTag,
-  ) {
-    this.packageContext = {
-      emit: (event, ...args) => this.host.emit(event, ...args),
-    };
-  }
+  ) {}
 
   get packageHandlers(): Record<string, MCPPackage> {
     return this.handlers;
@@ -35,10 +29,8 @@ export class McpSession {
     return this.multilines;
   }
 
-  registerPackage<P extends MCPPackage>(
-    PackageConstructor: new (_: McpPackageContext) => P,
-  ): P {
-    const mcpPackage = new PackageConstructor(this.packageContext);
+  registerPackage<P extends MCPPackage>(PackageConstructor: new () => P): P {
+    const mcpPackage = new PackageConstructor();
     mcpPackage.attachProtocolTransport(
       (command, data) => this.sendMessage(command, data),
       (command, keyvals, lineKey, lines) =>

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -5,16 +5,10 @@ import {
   parseMcpLine,
 } from "./codec";
 import type { MCPPackage, McpPackageContext } from "./package";
-import type {
-  EditorSession,
-  MCPKeyvals,
-  McpMessage,
-  McpOutboundData,
-} from "./types";
+import type { MCPKeyvals, McpMessage, McpOutboundData, McpOutboundKeyvals } from "./types";
 
 export interface McpSessionHost {
   emit(event: string, ...args: unknown[]): boolean;
-  openEditorSession(session: EditorSession): void;
   sendLine(line: string): void;
 }
 
@@ -30,8 +24,6 @@ export class McpSession {
   ) {
     this.packageContext = {
       emit: (event, ...args) => this.host.emit(event, ...args),
-      openEditorSession: (session) => this.host.openEditorSession(session),
-      sendMcp: (command, data) => this.sendMessage(command, data),
     };
   }
 
@@ -47,6 +39,11 @@ export class McpSession {
     PackageConstructor: new (_: McpPackageContext) => P,
   ): P {
     const mcpPackage = new PackageConstructor(this.packageContext);
+    mcpPackage.attachProtocolTransport(
+      (command, data) => this.sendMessage(command, data),
+      (command, keyvals, lineKey, lines) =>
+        this.sendMultiline(command, keyvals, lineKey, lines),
+    );
     this.handlers[mcpPackage.packageName] = mcpPackage;
     return mcpPackage;
   }
@@ -91,7 +88,8 @@ export class McpSession {
 
   sendMultiline(
     messageName: string,
-    keyvals: MCPKeyvals,
+    keyvals: McpOutboundKeyvals,
+    lineKey: string,
     lines: string[],
   ): void {
     const multilineTag = this.tagGenerator();
@@ -100,7 +98,7 @@ export class McpSession {
       "_data-tag": multilineTag,
     });
     for (const line of lines) {
-      this.sendMultilineLine(multilineTag, "content", line);
+      this.sendMultilineLine(multilineTag, lineKey, line);
     }
     this.closeMultiline(multilineTag);
   }

--- a/src/protocol/messages.test.ts
+++ b/src/protocol/messages.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createProtocolIO,
+  defaultEventName,
+  duplex,
+  identityCodec,
+  inbound,
+  messageEnvelope,
+  outbound,
+  sendMethodName,
+} from './messages';
+
+interface OfferPayload {
+  sender: string;
+  filename: string;
+}
+
+interface RequestResendPayload {
+  sender: string;
+  hash: string;
+}
+
+describe('protocol message registry', () => {
+  it('derives canonical event and send method names from wire names', () => {
+    expect(defaultEventName('Offer')).toBe('offer');
+    expect(defaultEventName('RequestResend')).toBe('requestResend');
+    expect(defaultEventName('room_token')).toBe('roomToken');
+    expect(sendMethodName('Offer')).toBe('sendOffer');
+    expect(sendMethodName('request_resend')).toBe('sendRequestResend');
+  });
+
+  it('emits inbound messages through package-local typed events', () => {
+    const Offer = messageEnvelope('Offer', identityCodec<OfferPayload>());
+    const io = createProtocolIO([inbound(Offer)] as const, vi.fn());
+    const listener = vi.fn();
+
+    io.on('offer', listener);
+    expect(io.receive('Offer', { sender: 'Q', filename: 'notes.txt' })).toBe(
+      true,
+    );
+
+    expect(listener).toHaveBeenCalledWith({
+      sender: 'Q',
+      filename: 'notes.txt',
+    });
+  });
+
+  it('uses explicit event aliases without changing payload typing', () => {
+    const Content = messageEnvelope(
+      'content',
+      identityCodec<{ tag: string; contents: string[] }>(),
+    );
+    const io = createProtocolIO(
+      [inbound(Content).asEvent('openSession')] as const,
+      vi.fn(),
+    );
+    const listener = vi.fn();
+
+    io.on('openSession', listener);
+    io.receive('content', { tag: '17', contents: ['line one'] });
+
+    expect(listener).toHaveBeenCalledWith({
+      tag: '17',
+      contents: ['line one'],
+    });
+  });
+
+  it('generates outbound methods from outbound and duplex messages', () => {
+    const Offer = messageEnvelope('Offer', identityCodec<OfferPayload>());
+    const RequestResend = messageEnvelope(
+      'RequestResend',
+      identityCodec<RequestResendPayload>(),
+    );
+    const send = vi.fn();
+    const io = createProtocolIO(
+      [duplex(Offer), outbound(RequestResend)] as const,
+      send,
+    );
+
+    io.sendOffer({ sender: 'Q', filename: 'notes.txt' });
+    io.sendRequestResend({ sender: 'Q', hash: 'abc123' });
+
+    expect(send).toHaveBeenCalledWith('Offer', {
+      sender: 'Q',
+      filename: 'notes.txt',
+    });
+    expect(send).toHaveBeenCalledWith('RequestResend', {
+      sender: 'Q',
+      hash: 'abc123',
+    });
+  });
+
+  it('returns an unsubscribe function from package-local events', () => {
+    const Offer = messageEnvelope('Offer', identityCodec<OfferPayload>());
+    const io = createProtocolIO([inbound(Offer)] as const, vi.fn());
+    const listener = vi.fn();
+    const unsubscribe = io.on('offer', listener);
+
+    unsubscribe();
+    io.receive('Offer', { sender: 'Q', filename: 'notes.txt' });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate wire names, event names, and send methods', () => {
+    const Offer = messageEnvelope('Offer', identityCodec<OfferPayload>());
+    const DuplicateOffer = messageEnvelope(
+      'Offer',
+      identityCodec<OfferPayload>(),
+    );
+    const Open = messageEnvelope('Open', identityCodec<OfferPayload>());
+    const open = messageEnvelope('open', identityCodec<OfferPayload>());
+    const request_resend = messageEnvelope(
+      'request_resend',
+      identityCodec<RequestResendPayload>(),
+    );
+    const RequestResend = messageEnvelope(
+      'RequestResend',
+      identityCodec<RequestResendPayload>(),
+    );
+
+    expect(() =>
+      createProtocolIO([inbound(Offer), inbound(DuplicateOffer)] as const, vi.fn()),
+    ).toThrow(/Duplicate protocol wire name: Offer/);
+    expect(() =>
+      createProtocolIO([inbound(Open), inbound(open)] as const, vi.fn()),
+    ).toThrow(/Duplicate protocol event name: open/);
+    expect(() =>
+      createProtocolIO(
+        [outbound(request_resend), outbound(RequestResend)] as const,
+        vi.fn(),
+      ),
+    ).toThrow(/Duplicate protocol send method: sendRequestResend/);
+  });
+
+  it('does not overwrite concrete methods with generated send methods', () => {
+    const Offer = messageEnvelope('Offer', identityCodec<OfferPayload>());
+    const target = {
+      sendOffer() {
+        throw new Error('concrete method');
+      },
+    };
+
+    expect(() =>
+      createProtocolIO([outbound(Offer)] as const, vi.fn(), target),
+    ).toThrow(/Generated protocol method would overwrite: sendOffer/);
+  });
+});

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -1,0 +1,283 @@
+export type ProtocolDirection = 'inbound' | 'outbound' | 'duplex';
+
+export interface ProtocolCodec<Payload> {
+  encode(payload: Payload): unknown;
+  decode(payload: unknown): Payload;
+}
+
+export interface ProtocolMessageEnvelope<Name extends string, Payload> {
+  readonly wireName: Name;
+  readonly codec: ProtocolCodec<Payload>;
+}
+
+export interface DirectedProtocolMessage<
+  Name extends string,
+  Payload,
+  Direction extends ProtocolDirection,
+  EventName extends string | undefined = undefined,
+> extends ProtocolMessageEnvelope<Name, Payload> {
+  readonly direction: Direction;
+  readonly eventName?: EventName;
+  asEvent<Alias extends string>(
+    eventName: Alias,
+  ): DirectedProtocolMessage<Name, Payload, Direction, Alias>;
+}
+
+type AnyDirectedProtocolMessage = DirectedProtocolMessage<
+  string,
+  unknown,
+  ProtocolDirection,
+  string | undefined
+>;
+
+type MessagePayload<Message> =
+  Message extends ProtocolMessageEnvelope<string, infer Payload> ? Payload : never;
+
+type CamelFromSnake<Name extends string> =
+  Name extends `${infer Head}_${infer Tail}`
+    ? `${Lowercase<Head>}${Capitalize<CamelFromSnake<Tail>>}`
+    : Lowercase<Name>;
+
+type DefaultEventName<Name extends string> =
+  Name extends `${string}_${string}` ? CamelFromSnake<Name> : Uncapitalize<Name>;
+
+type SendMethodName<Name extends string> =
+  `send${Capitalize<DefaultEventName<Name>>}`;
+
+type ExplicitEventName<Message> =
+  Message extends { readonly eventName?: infer EventName }
+    ? EventName extends string
+      ? EventName
+      : never
+    : never;
+
+type EventNameForMessage<Message> =
+  ExplicitEventName<Message> extends never
+    ? Message extends { readonly wireName: infer Name extends string }
+      ? DefaultEventName<Name>
+      : never
+    : ExplicitEventName<Message>;
+
+type InboundMessage<Message> =
+  Message extends DirectedProtocolMessage<
+    string,
+    unknown,
+    infer Direction,
+    string | undefined
+  >
+    ? Direction extends 'inbound' | 'duplex'
+      ? Message
+      : never
+    : never;
+
+type OutboundMessage<Message> =
+  Message extends DirectedProtocolMessage<
+    string,
+    unknown,
+    infer Direction,
+    string | undefined
+  >
+    ? Direction extends 'outbound' | 'duplex'
+      ? Message
+      : never
+    : never;
+
+type EventPayloads<Messages extends readonly AnyDirectedProtocolMessage[]> = {
+  [Message in InboundMessage<Messages[number]> as EventNameForMessage<Message>]: MessagePayload<Message>;
+};
+
+type SendMethods<Messages extends readonly AnyDirectedProtocolMessage[]> = {
+  [Message in OutboundMessage<Messages[number]> as Message extends {
+    readonly wireName: infer Name extends string;
+  }
+    ? SendMethodName<Name>
+    : never]: (payload: MessagePayload<Message>) => void;
+};
+
+export type ProtocolIO<Messages extends readonly AnyDirectedProtocolMessage[]> =
+  SendMethods<Messages> & {
+    on<EventName extends keyof EventPayloads<Messages> & string>(
+      eventName: EventName,
+      listener: (payload: EventPayloads<Messages>[EventName]) => void,
+    ): () => void;
+    receive(wireName: string, payload: unknown): boolean;
+  };
+
+type ProtocolListener = (payload: unknown) => void;
+type ProtocolTarget = Record<string, unknown>;
+
+export function identityCodec<Payload>(): ProtocolCodec<Payload> {
+  return {
+    encode(payload) {
+      return payload;
+    },
+    decode(payload) {
+      return payload as Payload;
+    },
+  };
+}
+
+export function messageEnvelope<Name extends string, Payload>(
+  wireName: Name,
+  codec: ProtocolCodec<Payload>,
+): ProtocolMessageEnvelope<Name, Payload> {
+  return { wireName, codec };
+}
+
+export function inbound<Name extends string, Payload>(
+  envelope: ProtocolMessageEnvelope<Name, Payload>,
+): DirectedProtocolMessage<Name, Payload, 'inbound'> {
+  return directedMessage(envelope, 'inbound');
+}
+
+export function outbound<Name extends string, Payload>(
+  envelope: ProtocolMessageEnvelope<Name, Payload>,
+): DirectedProtocolMessage<Name, Payload, 'outbound'> {
+  return directedMessage(envelope, 'outbound');
+}
+
+export function duplex<Name extends string, Payload>(
+  envelope: ProtocolMessageEnvelope<Name, Payload>,
+): DirectedProtocolMessage<Name, Payload, 'duplex'> {
+  return directedMessage(envelope, 'duplex');
+}
+
+export function defaultEventName(wireName: string): string {
+  if (wireName.includes('_')) {
+    const [head = '', ...tail] = wireName.toLowerCase().split('_');
+    return `${head}${tail.map(capitalize).join('')}`;
+  }
+
+  return `${wireName.charAt(0).toLowerCase()}${wireName.slice(1)}`;
+}
+
+export function sendMethodName(wireName: string): string {
+  return `send${capitalize(defaultEventName(wireName))}`;
+}
+
+export function createProtocolIO<
+  const Messages extends readonly AnyDirectedProtocolMessage[],
+>(
+  messages: Messages,
+  send: (wireName: string, payload: unknown) => void,
+  target: object = {},
+): ProtocolIO<Messages> {
+  const protocolTarget = target as ProtocolTarget;
+  const inboundMessages = new Map<string, AnyDirectedProtocolMessage>();
+  const listeners = new Map<string, Set<ProtocolListener>>();
+  const wireNames = new Set<string>();
+  const eventNames = new Set<string>();
+  const sendMethods = new Set<string>();
+
+  for (const message of messages) {
+    if (wireNames.has(message.wireName)) {
+      throw new Error(`Duplicate protocol wire name: ${message.wireName}`);
+    }
+    wireNames.add(message.wireName);
+
+    if (receivesMessage(message)) {
+      const eventName = eventNameFor(message);
+      if (eventNames.has(eventName)) {
+        throw new Error(`Duplicate protocol event name: ${eventName}`);
+      }
+      eventNames.add(eventName);
+      inboundMessages.set(message.wireName, message);
+    }
+
+    if (sendsMessage(message)) {
+      const methodName = sendMethodName(message.wireName);
+      if (sendMethods.has(methodName)) {
+        throw new Error(`Duplicate protocol send method: ${methodName}`);
+      }
+      sendMethods.add(methodName);
+
+      if (methodName in protocolTarget) {
+        throw new Error(`Generated protocol method would overwrite: ${methodName}`);
+      }
+
+      Object.defineProperty(protocolTarget, methodName, {
+        configurable: true,
+        enumerable: false,
+        value: (payload: unknown) => {
+          send(message.wireName, message.codec.encode(payload));
+        },
+      });
+    }
+  }
+
+  Object.defineProperty(protocolTarget, 'on', {
+    configurable: true,
+    enumerable: false,
+    value: (eventName: string, listener: ProtocolListener): (() => void) => {
+      const eventListeners = listeners.get(eventName) ?? new Set();
+      eventListeners.add(listener);
+      listeners.set(eventName, eventListeners);
+
+      return () => {
+        eventListeners.delete(listener);
+      };
+    },
+  });
+
+  Object.defineProperty(protocolTarget, 'receive', {
+    configurable: true,
+    enumerable: false,
+    value: (wireName: string, payload: unknown): boolean => {
+      const message = inboundMessages.get(wireName);
+      if (!message) {
+        return false;
+      }
+
+      const eventListeners = listeners.get(eventNameFor(message));
+      if (!eventListeners) {
+        return true;
+      }
+
+      const decodedPayload = message.codec.decode(payload);
+      for (const listener of [...eventListeners]) {
+        listener(decodedPayload);
+      }
+      return true;
+    },
+  });
+
+  return protocolTarget as ProtocolIO<Messages>;
+}
+
+function directedMessage<
+  Name extends string,
+  Payload,
+  Direction extends ProtocolDirection,
+>(
+  envelope: ProtocolMessageEnvelope<Name, Payload>,
+  direction: Direction,
+): DirectedProtocolMessage<Name, Payload, Direction> {
+  return {
+    ...envelope,
+    direction,
+    asEvent<Alias extends string>(eventName: Alias) {
+      return {
+        ...envelope,
+        direction,
+        eventName,
+        asEvent: this.asEvent,
+      };
+    },
+  };
+}
+
+function eventNameFor(message: AnyDirectedProtocolMessage): string {
+  return message.eventName ?? defaultEventName(message.wireName);
+}
+
+function receivesMessage(message: AnyDirectedProtocolMessage): boolean {
+  return message.direction === 'inbound' || message.direction === 'duplex';
+}
+
+function sendsMessage(message: AnyDirectedProtocolMessage): boolean {
+  return message.direction === 'outbound' || message.direction === 'duplex';
+}
+
+function capitalize(value: string): string {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+}

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -1,37 +1,56 @@
 export type ProtocolDirection = 'inbound' | 'outbound' | 'duplex';
 
-export interface ProtocolCodec<Payload> {
-  encode(payload: Payload): unknown;
-  decode(payload: unknown): Payload;
+export interface ProtocolCodec<InboundPayload, OutboundPayload = InboundPayload> {
+  encode(payload: OutboundPayload): unknown;
+  decode(payload: unknown): InboundPayload;
 }
 
-export interface ProtocolMessageEnvelope<Name extends string, Payload> {
+export interface ProtocolMessageEnvelope<
+  Name extends string,
+  InboundPayload,
+  OutboundPayload = InboundPayload,
+> {
   readonly wireName: Name;
-  readonly codec: ProtocolCodec<Payload>;
+  readonly codec: ProtocolCodec<InboundPayload, OutboundPayload>;
 }
 
 export interface DirectedProtocolMessage<
   Name extends string,
-  Payload,
+  InboundPayload,
+  OutboundPayload,
   Direction extends ProtocolDirection,
   EventName extends string | undefined = undefined,
-> extends ProtocolMessageEnvelope<Name, Payload> {
+> extends ProtocolMessageEnvelope<Name, InboundPayload, OutboundPayload> {
   readonly direction: Direction;
   readonly eventName?: EventName;
   asEvent<Alias extends string>(
     eventName: Alias,
-  ): DirectedProtocolMessage<Name, Payload, Direction, Alias>;
+  ): DirectedProtocolMessage<
+    Name,
+    InboundPayload,
+    OutboundPayload,
+    Direction,
+    Alias
+  >;
 }
 
 export type AnyDirectedProtocolMessage = DirectedProtocolMessage<
   string,
   unknown,
+  unknown,
   ProtocolDirection,
   string | undefined
 >;
 
-type MessagePayload<Message> =
-  Message extends ProtocolMessageEnvelope<string, infer Payload> ? Payload : never;
+type InboundPayload<Message> =
+  Message extends ProtocolMessageEnvelope<string, infer Payload, unknown>
+    ? Payload
+    : never;
+
+type OutboundPayload<Message> =
+  Message extends ProtocolMessageEnvelope<string, unknown, infer Payload>
+    ? Payload
+    : never;
 
 type CamelFromSnake<Name extends string> =
   Name extends `${infer Head}_${infer Tail}`
@@ -62,6 +81,7 @@ type InboundMessage<Message> =
   Message extends DirectedProtocolMessage<
     string,
     unknown,
+    unknown,
     infer Direction,
     string | undefined
   >
@@ -74,6 +94,7 @@ type OutboundMessage<Message> =
   Message extends DirectedProtocolMessage<
     string,
     unknown,
+    unknown,
     infer Direction,
     string | undefined
   >
@@ -83,7 +104,7 @@ type OutboundMessage<Message> =
     : never;
 
 type EventPayloads<Messages extends readonly AnyDirectedProtocolMessage[]> = {
-  [Message in InboundMessage<Messages[number]> as EventNameForMessage<Message>]: MessagePayload<Message>;
+  [Message in InboundMessage<Messages[number]> as EventNameForMessage<Message>]: InboundPayload<Message>;
 };
 
 type SendMethods<Messages extends readonly AnyDirectedProtocolMessage[]> = {
@@ -91,7 +112,7 @@ type SendMethods<Messages extends readonly AnyDirectedProtocolMessage[]> = {
     readonly wireName: infer Name extends string;
   }
     ? SendMethodName<Name>
-    : never]: (payload: MessagePayload<Message>) => void;
+    : never]: (payload: OutboundPayload<Message>) => void;
 };
 
 export type ProtocolIO<Messages extends readonly AnyDirectedProtocolMessage[]> =
@@ -100,6 +121,10 @@ export type ProtocolIO<Messages extends readonly AnyDirectedProtocolMessage[]> =
       eventName: EventName,
       listener: (payload: EventPayloads<Messages>[EventName]) => void,
     ): () => void;
+    off<EventName extends keyof EventPayloads<Messages> & string>(
+      eventName: EventName,
+      listener: (payload: EventPayloads<Messages>[EventName]) => void,
+    ): void;
     receive(wireName: string, payload: unknown): boolean;
   };
 
@@ -117,28 +142,47 @@ export function identityCodec<Payload>(): ProtocolCodec<Payload> {
   };
 }
 
-export function messageEnvelope<Name extends string, Payload>(
+export function messageEnvelope<
+  Name extends string,
+  InboundPayload,
+  OutboundPayload = InboundPayload,
+>(
   wireName: Name,
-  codec: ProtocolCodec<Payload>,
-): ProtocolMessageEnvelope<Name, Payload> {
+  codec: ProtocolCodec<InboundPayload, OutboundPayload>,
+): ProtocolMessageEnvelope<Name, InboundPayload, OutboundPayload> {
   return { wireName, codec };
 }
 
-export function inbound<Name extends string, Payload>(
-  envelope: ProtocolMessageEnvelope<Name, Payload>,
-): DirectedProtocolMessage<Name, Payload, 'inbound'> {
+export function inbound<Name extends string, InboundPayload, OutboundPayload>(
+  envelope: ProtocolMessageEnvelope<Name, InboundPayload, OutboundPayload>,
+): DirectedProtocolMessage<
+  Name,
+  InboundPayload,
+  OutboundPayload,
+  'inbound'
+> {
   return directedMessage(envelope, 'inbound');
 }
 
-export function outbound<Name extends string, Payload>(
-  envelope: ProtocolMessageEnvelope<Name, Payload>,
-): DirectedProtocolMessage<Name, Payload, 'outbound'> {
+export function outbound<Name extends string, InboundPayload, OutboundPayload>(
+  envelope: ProtocolMessageEnvelope<Name, InboundPayload, OutboundPayload>,
+): DirectedProtocolMessage<
+  Name,
+  InboundPayload,
+  OutboundPayload,
+  'outbound'
+> {
   return directedMessage(envelope, 'outbound');
 }
 
-export function duplex<Name extends string, Payload>(
-  envelope: ProtocolMessageEnvelope<Name, Payload>,
-): DirectedProtocolMessage<Name, Payload, 'duplex'> {
+export function duplex<Name extends string, InboundPayload, OutboundPayload>(
+  envelope: ProtocolMessageEnvelope<Name, InboundPayload, OutboundPayload>,
+): DirectedProtocolMessage<
+  Name,
+  InboundPayload,
+  OutboundPayload,
+  'duplex'
+> {
   return directedMessage(envelope, 'duplex');
 }
 
@@ -241,17 +285,26 @@ export function createProtocolIO<
     },
   });
 
+  Object.defineProperty(protocolTarget, 'off', {
+    configurable: true,
+    enumerable: false,
+    value: (eventName: string, listener: ProtocolListener): void => {
+      listeners.get(eventName)?.delete(listener);
+    },
+  });
+
   return protocolTarget as ProtocolIO<Messages>;
 }
 
 function directedMessage<
   Name extends string,
-  Payload,
+  InboundPayload,
+  OutboundPayload,
   Direction extends ProtocolDirection,
 >(
-  envelope: ProtocolMessageEnvelope<Name, Payload>,
+  envelope: ProtocolMessageEnvelope<Name, InboundPayload, OutboundPayload>,
   direction: Direction,
-): DirectedProtocolMessage<Name, Payload, Direction> {
+): DirectedProtocolMessage<Name, InboundPayload, OutboundPayload, Direction> {
   return {
     ...envelope,
     direction,

--- a/src/protocol/messages.ts
+++ b/src/protocol/messages.ts
@@ -23,7 +23,7 @@ export interface DirectedProtocolMessage<
   ): DirectedProtocolMessage<Name, Payload, Direction, Alias>;
 }
 
-type AnyDirectedProtocolMessage = DirectedProtocolMessage<
+export type AnyDirectedProtocolMessage = DirectedProtocolMessage<
   string,
   unknown,
   ProtocolDirection,


### PR DESCRIPTION
## Summary

This PR lands the typed protocol IO registry and the deletion-first MCP/GMCP cleanup work without the later AWNS package commits.

It adds a shared typed message registry kernel, routes MCP SimpleEdit and package outputs through typed package events, moves GMCP package dispatch away from reflection and request-send wrappers, and centralizes default package registration in `createConfiguredClient()`.

It also moves app-level event wiring and lifecycle emits out of package/session internals, documents the service integration boundary, and keeps receive dispatch failures isolated so one bad listener does not break the rest of GMCP dispatch.

## Scope

Included:
- typed protocol message registry kernel
- MCP package registry/event routing cleanup
- GMCP typed registries for existing core, char, room, channel, IRE, and client utility packages
- generated outbound helpers for current registry-backed packages
- default package registration and app event wiring cleanup
- docs for the protocol registry workstream and GMCP service boundary

Excluded for the follow-up stacked PR:
- AWNS MCP package transports
- AWNS MCP UI wiring

## Validation

- `npm test -- --run src` passed: 87 files, 869 tests
- `npm run typecheck` passed
- `npm run lint` passed using the repo's staged-only lint script; it checked 0 staged files
- `git diff --check master..HEAD` passed