### PR TITLE
[codex] Add AWNS MCP package support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,9 @@ import FileTransferManager from "./FileTransferManager.js";
 import { useRoomStore } from "./stores/roomStore";
 import { useSpatialStore } from "./stores/spatialStore";
 import { useLiveKitStore } from "./stores/liveKitStore";
+import { useInputStore } from "./stores/inputStore";
+import { useServerLinksStore } from "./stores/serverLinksStore";
+import { useWorldMapStore } from "./stores/worldMapStore";
 
 function resetMidiIntentionalDisconnectFlags(): void {
   if (!usePreferences.getState().midi.enabled) return;
@@ -257,6 +260,9 @@ class MudClient extends EventEmitter {
     this.telnetBuffer = "";
     useRoomStore.getState().reset(); // Reset room info on cleanup
     useSpatialStore.getState().reset(); // Reset spatial scene on cleanup
+    useWorldMapStore.getState().reset();
+    useServerLinksStore.getState().reset();
+    useInputStore.getState().resetCommands();
     this.fileTransferManager?.cleanup();
     this.gmcp.reset();
     useLiveKitStore.getState().reset();

--- a/src/components/CommandList.css
+++ b/src/components/CommandList.css
@@ -1,0 +1,60 @@
+.command-list-panel {
+  font-size: 0.9em;
+}
+
+.command-list-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.command-list-panel h4 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+}
+
+.command-list-panel button {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-text);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+
+.command-list-panel button:hover:not(:disabled),
+.command-list-panel button:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.command-list-panel button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.command-list-panel ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
+  gap: var(--space-1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.command-list-panel li {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+}
+
+.command-list-panel p {
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/src/components/CommandList.tsx
+++ b/src/components/CommandList.tsx
@@ -1,0 +1,45 @@
+import type React from 'react';
+import type MudClient from '../client';
+import { McpAwnsRehash } from '../mcp';
+import { useInputStore } from '../stores/inputStore';
+import './CommandList.css';
+
+interface CommandListProps {
+  client: MudClient;
+}
+
+const CommandList: React.FC<CommandListProps> = ({ client }) => {
+  const visibleCommands = useInputStore((state) => state.visibleCommands);
+  const rehashPackage = client.mcpSession.packageHandlers['dns-com-awns-rehash'];
+  const canRefresh = rehashPackage instanceof McpAwnsRehash;
+
+  return (
+    <section className="command-list-panel" aria-labelledby="command-list-heading">
+      <div className="command-list-heading-row">
+        <h4 id="command-list-heading">Commands</h4>
+        <button
+          type="button"
+          onClick={() => {
+            if (rehashPackage instanceof McpAwnsRehash) {
+              rehashPackage.requestCommands();
+            }
+          }}
+          disabled={!canRefresh}
+        >
+          Refresh
+        </button>
+      </div>
+      {visibleCommands.length === 0 ? (
+        <p>No command list from the server yet.</p>
+      ) : (
+        <ul aria-label="Visible commands">
+          {visibleCommands.map((command) => (
+            <li key={command}>{command}</li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default CommandList;

--- a/src/components/ServerFeaturesPanel.css
+++ b/src/components/ServerFeaturesPanel.css
@@ -1,0 +1,9 @@
+.server-features-panel {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.server-features-panel > section:not(:first-child) {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-4);
+}

--- a/src/components/ServerFeaturesPanel.tsx
+++ b/src/components/ServerFeaturesPanel.tsx
@@ -1,0 +1,20 @@
+import type React from 'react';
+import type MudClient from '../client';
+import CommandList from './CommandList';
+import ServerLinksPanel from './ServerLinksPanel';
+import WorldMapPanel from './WorldMapPanel';
+import './ServerFeaturesPanel.css';
+
+interface ServerFeaturesPanelProps {
+  client: MudClient;
+}
+
+const ServerFeaturesPanel: React.FC<ServerFeaturesPanelProps> = ({ client }) => (
+  <div className="server-features-panel">
+    <ServerLinksPanel client={client} />
+    <CommandList client={client} />
+    <WorldMapPanel client={client} />
+  </div>
+);
+
+export default ServerFeaturesPanel;

--- a/src/components/ServerLinksPanel.css
+++ b/src/components/ServerLinksPanel.css
@@ -1,0 +1,98 @@
+.server-links-panel {
+  font-size: 0.9em;
+}
+
+.panel-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.server-links-panel h4,
+.server-links-panel h5 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+}
+
+.server-link-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.server-links-panel button {
+  min-width: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-text);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+
+.server-links-panel button:hover:not(:disabled),
+.server-links-panel button:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.server-links-panel button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.server-links-section {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.jtext-form {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.jtext-form label {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.jtext-form label span {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.jtext-form input {
+  min-width: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-deep);
+  color: var(--color-text);
+  padding: var(--space-1) var(--space-2);
+}
+
+.server-links-section ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.server-links-section li {
+  margin-bottom: var(--space-2);
+}
+
+.server-links-section li button {
+  width: 100%;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+.server-links-section p {
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/src/components/ServerLinksPanel.tsx
+++ b/src/components/ServerLinksPanel.tsx
@@ -1,0 +1,114 @@
+import type React from 'react';
+import { useState } from 'react';
+import type MudClient from '../client';
+import { McpAwnsJtext, McpAwnsServerInfo } from '../mcp';
+import { useServerLinksStore } from '../stores/serverLinksStore';
+import './ServerLinksPanel.css';
+
+interface ServerLinksPanelProps {
+  client: MudClient;
+}
+
+function openUrl(url: string): void {
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+const ServerLinksPanel: React.FC<ServerLinksPanelProps> = ({ client }) => {
+  const homeUrl = useServerLinksStore((state) => state.homeUrl);
+  const helpUrl = useServerLinksStore((state) => state.helpUrl);
+  const recentUrls = useServerLinksStore((state) => state.recentUrls);
+  const clearRecentUrls = useServerLinksStore((state) => state.clearRecentUrls);
+  const serverInfoPackage = client.mcpSession.packageHandlers['dns-com-awns-serverinfo'];
+  const jtextPackage = client.mcpSession.packageHandlers['dns-com-awns-jtext'];
+  const canRefresh = serverInfoPackage instanceof McpAwnsServerInfo;
+  const canPickJtext = jtextPackage instanceof McpAwnsJtext;
+  const [jtextType, setJtextType] = useState('');
+  const [jtextArgs, setJtextArgs] = useState('');
+
+  return (
+    <section className="server-links-panel" aria-labelledby="server-links-heading">
+      <div className="panel-heading-row">
+        <h4 id="server-links-heading">Server Links</h4>
+        <button
+          type="button"
+          onClick={() => {
+            if (serverInfoPackage instanceof McpAwnsServerInfo) {
+              serverInfoPackage.requestServerInfo();
+            }
+          }}
+          disabled={!canRefresh}
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="server-link-actions">
+        <button type="button" onClick={() => openUrl(homeUrl)} disabled={!homeUrl}>
+          Home
+        </button>
+        <button type="button" onClick={() => openUrl(helpUrl)} disabled={!helpUrl}>
+          Help
+        </button>
+      </div>
+
+      <div className="server-links-section">
+        <h5>JText</h5>
+        <form
+          className="jtext-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (jtextPackage instanceof McpAwnsJtext && jtextType && jtextArgs) {
+              jtextPackage.pick(jtextType, jtextArgs);
+            }
+          }}
+        >
+          <label>
+            <span>Type</span>
+            <input
+              type="text"
+              value={jtextType}
+              onChange={(event) => setJtextType(event.target.value)}
+              disabled={!canPickJtext}
+            />
+          </label>
+          <label>
+            <span>Args</span>
+            <input
+              type="text"
+              value={jtextArgs}
+              onChange={(event) => setJtextArgs(event.target.value)}
+              disabled={!canPickJtext}
+            />
+          </label>
+          <button type="submit" disabled={!canPickJtext || !jtextType || !jtextArgs}>
+            Open
+          </button>
+        </form>
+      </div>
+
+      <div className="server-links-section">
+        <div className="panel-heading-row">
+          <h5>Recent URLs</h5>
+          <button type="button" onClick={clearRecentUrls} disabled={recentUrls.length === 0}>
+            Clear
+          </button>
+        </div>
+        {recentUrls.length === 0 ? (
+          <p>No server-sent URLs yet.</p>
+        ) : (
+          <ul>
+            {recentUrls.map((entry) => (
+              <li key={entry.id}>
+                <button type="button" onClick={() => openUrl(entry.url)}>
+                  {entry.url}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default ServerLinksPanel;

--- a/src/components/WorldMapPanel.css
+++ b/src/components/WorldMapPanel.css
@@ -1,0 +1,93 @@
+.world-map-panel {
+  font-size: 0.9em;
+}
+
+.world-map-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.world-map-panel h4,
+.world-map-panel h5 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+}
+
+.world-map-panel button {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-text);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+
+.world-map-panel button:hover:not(:disabled),
+.world-map-panel button:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.world-map-panel button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.world-map-summary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
+}
+
+.world-map-summary div {
+  min-width: 0;
+}
+
+.world-map-summary dt {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.world-map-summary dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.world-map-section {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.world-map-section ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.world-map-section li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-1);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.world-map-section li span {
+  overflow-wrap: anywhere;
+}
+
+.world-map-section li span:not(:first-child),
+.world-map-section p {
+  color: var(--color-text-muted);
+}
+
+.world-map-section p {
+  font-style: italic;
+}

--- a/src/components/WorldMapPanel.tsx
+++ b/src/components/WorldMapPanel.tsx
@@ -1,0 +1,87 @@
+import type React from 'react';
+import type MudClient from '../client';
+import { McpAwnsVisual } from '../mcp';
+import { useWorldMapStore } from '../stores/worldMapStore';
+import './WorldMapPanel.css';
+
+interface WorldMapPanelProps {
+  client: MudClient;
+}
+
+const WorldMapPanel: React.FC<WorldMapPanelProps> = ({ client }) => {
+  const locationId = useWorldMapStore((state) => state.locationId);
+  const selfId = useWorldMapStore((state) => state.selfId);
+  const users = useWorldMapStore((state) => state.users);
+  const rooms = useWorldMapStore((state) => state.rooms);
+  const visualPackage = client.mcpSession.packageHandlers['dns-com-awns-visual'];
+  const canRefresh = visualPackage instanceof McpAwnsVisual;
+
+  const refresh = () => {
+    if (!(visualPackage instanceof McpAwnsVisual)) {
+      return;
+    }
+    visualPackage.requestSelf();
+    visualPackage.requestLocation();
+    visualPackage.requestUsers();
+    if (locationId) {
+      visualPackage.requestTopology(locationId, 2);
+    }
+  };
+
+  return (
+    <section className="world-map-panel" aria-labelledby="world-map-heading">
+      <div className="world-map-heading-row">
+        <h4 id="world-map-heading">World</h4>
+        <button type="button" onClick={refresh} disabled={!canRefresh}>
+          Refresh
+        </button>
+      </div>
+
+      <dl className="world-map-summary">
+        <div>
+          <dt>You</dt>
+          <dd>{selfId || 'Unknown'}</dd>
+        </div>
+        <div>
+          <dt>Location</dt>
+          <dd>{locationId || 'Unknown'}</dd>
+        </div>
+      </dl>
+
+      <section className="world-map-section" aria-labelledby="world-users-heading">
+        <h5 id="world-users-heading">Online Users</h5>
+        {users.length === 0 ? (
+          <p>No AWNS visual user data yet.</p>
+        ) : (
+          <ul>
+            {users.map((user) => (
+              <li key={user.id}>
+                <span>{user.name || user.id}</span>
+                <span>{user.locationId || 'unknown'}</span>
+                {user.idleSeconds !== null && <span>{user.idleSeconds}s idle</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="world-map-section" aria-labelledby="world-rooms-heading">
+        <h5 id="world-rooms-heading">Nearby Rooms</h5>
+        {rooms.length === 0 ? (
+          <p>No topology data yet.</p>
+        ) : (
+          <ul>
+            {rooms.map((room) => (
+              <li key={room.id}>
+                <span>{room.name || room.id}</span>
+                <span>{room.exits || 'No exits listed'}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+};
+
+export default WorldMapPanel;

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -13,7 +13,7 @@ type SendFunction = (text: string) => void;
 type Props = {
   onSend: SendFunction;
   inputRef: React.RefObject<HTMLTextAreaElement>;
-  client: MudClient; // Added client prop
+  client?: MudClient;
 };
 
 const STORAGE_KEY = 'command_history';
@@ -47,12 +47,12 @@ const parseWordForCompletion = (word: string): { leadingPunctuation: string, nam
   }
 };
 
-const CommandInput = ({ onSend, inputRef, client }: Props) => {
+const CommandInput = ({ onSend, inputRef }: Props) => {
   const commandHistoryRef = useRef(new CommandHistory());
   const text = useInputStore((s) => s.text);
 
   // Refs for tab completion state
-  const completionCandidatesRef = useRef<RoomPlayer[]>([]); // Store RoomPlayer objects
+  const completionCandidatesRef = useRef<string[]>([]);
   const completionIndexRef = useRef<number>(0);
   // Stores the full word (e.g., "-Da", "David") that initiated the current completion sequence
   const completionActiveOriginalWordRef = useRef<string | null>(null); 
@@ -139,21 +139,13 @@ const CommandInput = ({ onSend, inputRef, client }: Props) => {
 
       let isCycling = false;
       if (completionActiveOriginalWordRef.current !== null && completionCandidatesRef.current.length > 0) {
-        const activeCyclePlayer = completionCandidatesRef.current[completionIndexRef.current];
-        // Parse the original word that started this completion sequence to get its leading punctuation
-        const { leadingPunctuation: activeOriginalLeadingPunctuation } = parseWordForCompletion(completionActiveOriginalWordRef.current);
-        const expectedCompletedWord = activeOriginalLeadingPunctuation + quoteNameIfNeeded(activeCyclePlayer.name);
-        isCycling = currentWord === expectedCompletedWord;
+        const activeCompletion = completionCandidatesRef.current[completionIndexRef.current];
+        isCycling = currentWord === activeCompletion;
       }
 
       if (isCycling) { // We are cycling
         completionIndexRef.current = (completionIndexRef.current + 1) % completionCandidatesRef.current.length;
-        const nextCandidatePlayer = completionCandidatesRef.current[completionIndexRef.current];
-        
-        // Re-parse the original word to get its leading punctuation for consistency
-        const { leadingPunctuation: activeOriginalLeadingPunctuation } = parseWordForCompletion(completionActiveOriginalWordRef.current!);
-        const baseCompletedName = quoteNameIfNeeded(nextCandidatePlayer.name);
-        const completedName = activeOriginalLeadingPunctuation + baseCompletedName;
+        const completedName = completionCandidatesRef.current[completionIndexRef.current];
 
         const newText = currentInputText.substring(0, wordStartIndex) + completedName + currentInputText.substring(cursorPos);
         useInputStore.getState().setText(newText);
@@ -170,8 +162,17 @@ const CommandInput = ({ onSend, inputRef, client }: Props) => {
           return;
         }
         
+        const visibleCommandCandidates =
+          wordStartIndex === 0 && initialLeadingPunctuation === "" && !currentWord.startsWith('"')
+            ? useInputStore
+                .getState()
+                .visibleCommands.filter((command) =>
+                  command.toLowerCase().startsWith(initialNamePart.toLowerCase()),
+                )
+            : [];
+
         const roomPlayersData: RoomPlayer[] = useRoomStore.getState().roomPlayers;
-        const candidatePlayers = roomPlayersData
+        const playerCandidates = roomPlayersData
           .filter(p => {
             const nameMatch = typeof p.name === 'string' && p.name.toLowerCase().startsWith(initialNamePart.toLowerCase());
             const fullnameWords = typeof p.fullname === 'string' ? p.fullname.toLowerCase().split(' ') : [];
@@ -182,16 +183,17 @@ const CommandInput = ({ onSend, inputRef, client }: Props) => {
             const nameCompare = a.name.localeCompare(b.name);
             if (nameCompare !== 0) return nameCompare;
             return a.fullname.localeCompare(b.fullname);
-          });
+          })
+          .map((player) => initialLeadingPunctuation + quoteNameIfNeeded(player.name));
+        const completionCandidates = [
+          ...new Set([...visibleCommandCandidates, ...playerCandidates]),
+        ];
 
-        if (candidatePlayers.length > 0) {
+        if (completionCandidates.length > 0) {
           completionActiveOriginalWordRef.current = currentWord; // Store the word that initiated this sequence
-          completionCandidatesRef.current = candidatePlayers;
+          completionCandidatesRef.current = completionCandidates;
           completionIndexRef.current = 0;
-          
-          const firstCandidatePlayer = candidatePlayers[0];
-          const baseCompletedName = quoteNameIfNeeded(firstCandidatePlayer.name);
-          const completedName = initialLeadingPunctuation + baseCompletedName;
+          const completedName = completionCandidates[0];
           
           const newText = currentInputText.substring(0, wordStartIndex) + completedName + currentInputText.substring(cursorPos);
           useInputStore.getState().setText(newText);
@@ -230,7 +232,7 @@ const CommandInput = ({ onSend, inputRef, client }: Props) => {
         resetCompletionState();
       }
     }
-  }, [text, client, inputRef, resetCompletionState, handleSend]); // Added handleSend and resetCompletionState
+  }, [text, inputRef, resetCompletionState, handleSend]); // Added handleSend and resetCompletionState
 
   return (
     <div className="command-input-container">

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -18,6 +18,7 @@ import HapticsStatus from './HapticsStatus'; // Import Haptics component
 import { usePreferences } from '../stores/preferencesStore';
 import { useRoomStore } from '../stores/roomStore';
 import { hapticsService } from '../HapticsService';
+import ServerFeaturesPanel from './ServerFeaturesPanel';
 
 // Define the type for the imperative handle
 export type SidebarRef = {
@@ -111,6 +112,12 @@ const Sidebar = React.forwardRef<SidebarRef, SidebarProps>(
         condition: true,
       },
       {
+        id: 'server-tab',
+        label: 'Server',
+        content: <ServerFeaturesPanel client={client} />,
+        condition: true,
+      },
+      {
         id: 'midi-tab',
         label: 'MIDI',
         content: (
@@ -169,17 +176,7 @@ const Sidebar = React.forwardRef<SidebarRef, SidebarProps>(
       },
     ];
 
-    // Memoize visibleTabs to prevent unnecessary effect re-runs if conditions don't change
-    // Note: If tab conditions become more dynamic, add them to the dependency array.
-    const visibleTabs = React.useMemo(() => {
-      return allTabs.filter((tab) => tab.condition ?? true); // Default condition to true
-    }, [
-      hasRoomData,
-      hasInventoryData,
-      preferences.midi.enabled,
-      preferences.haptics.enabled,
-      users,
-    ]); // Add dependencies based on actual conditions used
+    const visibleTabs = allTabs.filter((tab) => tab.condition ?? true);
 
     // Expose switchToTab function via useImperativeHandle
     React.useImperativeHandle(

--- a/src/createConfiguredClient.test.ts
+++ b/src/createConfiguredClient.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type MudClient from "./client";
 import { createConfiguredClient } from "./createConfiguredClient";
+import { useInputStore } from "./stores/inputStore";
+import { useServerLinksStore } from "./stores/serverLinksStore";
+import { useWorldMapStore } from "./stores/worldMapStore";
 
 vi.mock("cacophony", () => ({
   Cacophony: class {
@@ -16,6 +19,10 @@ describe("createConfiguredClient", () => {
   afterEach(() => {
     client?.shutdown();
     client = undefined;
+    useInputStore.getState().clear();
+    useInputStore.getState().resetCommands();
+    useServerLinksStore.getState().reset();
+    useWorldMapStore.getState().reset();
   });
 
   it("wires Char.Name to sessionReady once", () => {
@@ -32,5 +39,74 @@ describe("createConfiguredClient", () => {
     expect(client.gmcp.sessionReady).toBe(true);
     expect(handleSessionReady).toHaveBeenCalledOnce();
     expect(handleStatusText).toHaveBeenCalledTimes(2);
+  });
+
+  it("wires AWNS MCP packages to semantic stores", () => {
+    client = createConfiguredClient();
+
+    client.mcpSession.packageHandlers["dns-com-awns-displayurl"].handle({
+      name: "dns-com-awns-displayurl",
+      keyvals: { url: "https://example.test/help" },
+    });
+    client.mcpSession.packageHandlers["dns-com-awns-serverinfo"].handle({
+      name: "dns-com-awns-serverinfo",
+      keyvals: {
+        home_url: "https://example.test/",
+        help_url: "https://example.test/help",
+      },
+    });
+    client.mcpSession.packageHandlers["dns-com-awns-rehash"].handle({
+      name: "dns-com-awns-rehash-commands",
+      keyvals: { list: "open r*ead" },
+    });
+    client.mcpSession.packageHandlers["dns-com-awns-visual"].handle({
+      name: "dns-com-awns-visual-location",
+      keyvals: { id: "#100" },
+    });
+    client.mcpSession.packageHandlers["dns-com-awns-visual"].handle({
+      name: "dns-com-awns-visual-self",
+      keyvals: { id: "#42" },
+    });
+
+    expect(useServerLinksStore.getState().recentUrls.map((entry) => entry.url)).toEqual([
+      "https://example.test/help",
+    ]);
+    expect(useServerLinksStore.getState().homeUrl).toBe("https://example.test/");
+    expect(useServerLinksStore.getState().helpUrl).toBe("https://example.test/help");
+    expect(useInputStore.getState().visibleCommands).toEqual(["open", "r", "re", "rea", "read"]);
+    expect(useWorldMapStore.getState().locationId).toBe("#100");
+    expect(useWorldMapStore.getState().selfId).toBe("#42");
+  });
+
+  it("requests AWNS MCP data after MCP negotiation ends", () => {
+    client = createConfiguredClient();
+    const sent: string[] = [];
+    vi.spyOn(client, "send").mockImplementation((line: string) => {
+      sent.push(line);
+    });
+
+    client.mcpSession.receiveLine("#$#MCP version: 2.1 to: 2.1");
+    const authKey = sent[0]?.match(/authentication-key: (\S+)/)?.[1];
+    expect(authKey).toBeTruthy();
+    sent.length = 0;
+
+    client.mcpSession.receiveLine(`#$#mcp-negotiate-end ${authKey}`);
+
+    expect(sent.some((line) => line.includes("#$#dns-com-awns-timezone"))).toBe(true);
+    expect(sent.some((line) => line.includes(`#$#dns-com-awns-serverinfo-get ${authKey}`))).toBe(
+      true,
+    );
+    expect(sent.some((line) => line.includes(`#$#dns-com-awns-rehash-getcommands ${authKey}`))).toBe(
+      true,
+    );
+    expect(sent.some((line) => line.includes(`#$#dns-com-awns-visual-getself ${authKey}`))).toBe(
+      true,
+    );
+    expect(sent.some((line) => line.includes(`#$#dns-com-awns-visual-getlocation ${authKey}`))).toBe(
+      true,
+    );
+    expect(sent.some((line) => line.includes(`#$#dns-com-awns-visual-getusers ${authKey}`))).toBe(
+      true,
+    );
   });
 });

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -34,17 +34,34 @@ import {
 } from "./gmcp";
 import {
   DEFAULT_MCP_PACKAGES,
+  McpAwnsDisplayUrl,
   McpAwnsGetSet,
+  McpAwnsRehash,
+  McpAwnsServerInfo,
   McpAwnsStatus,
+  McpAwnsTimezone,
+  McpAwnsVisual,
+  McpNegotiate,
   McpSimpleEdit,
   McpVmooUserlist,
 } from "./mcp/index";
+import { useInputStore } from "./stores/inputStore";
+import { useServerLinksStore } from "./stores/serverLinksStore";
 import { useSpatialStore } from "./stores/spatialStore";
+import { useWorldMapStore } from "./stores/worldMapStore";
 
 marked.setOptions({
   breaks: true,
   gfm: true,
 });
+
+function getLocalTimezoneAbbreviation(): string {
+  const timeZoneName =
+    new Intl.DateTimeFormat("en-US", { timeZoneName: "short" })
+      .formatToParts(new Date())
+      .find((part) => part.type === "timeZoneName")?.value ?? "";
+  return timeZoneName || "UTC";
+}
 
 /**
  * Create a MudClient with all GMCP and MCP packages registered.
@@ -190,10 +207,83 @@ export function createConfiguredClient(): MudClient {
   );
 
   // MCP packages
+  let negotiatePackage: McpNegotiate | undefined;
+  let serverInfoPackage: McpAwnsServerInfo | undefined;
+  let visualPackage: McpAwnsVisual | undefined;
+  let rehashPackage: McpAwnsRehash | undefined;
+  let timezonePackage: McpAwnsTimezone | undefined;
+
   for (const PackageConstructor of DEFAULT_MCP_PACKAGES) {
     const mcpPackage = client.registerMcpPackage(PackageConstructor);
+    if (mcpPackage instanceof McpNegotiate) {
+      negotiatePackage = mcpPackage;
+    }
     if (mcpPackage instanceof McpSimpleEdit) {
       client.configureEditors(mcpPackage);
+    }
+    if (mcpPackage instanceof McpAwnsDisplayUrl) {
+      mcpPackage.on("displayUrl", (url) => {
+        useServerLinksStore.getState().addRecentUrl(url);
+        client.emit("displayUrl", url);
+        client.emit("statustext", `Server sent URL: ${url}`);
+      });
+    }
+    if (mcpPackage instanceof McpAwnsServerInfo) {
+      serverInfoPackage = mcpPackage;
+      mcpPackage.on("serverInfo", (info) => {
+        useServerLinksStore.getState().setServerInfo(info);
+        client.emit("serverInfo", info);
+      });
+    }
+    if (mcpPackage instanceof McpAwnsVisual) {
+      visualPackage = mcpPackage;
+      mcpPackage.on("location", ({ id }) => {
+        useWorldMapStore.getState().setLocation(id);
+        client.emit("worldLocation", id);
+      });
+      mcpPackage.on("self", ({ id }) => {
+        useWorldMapStore.getState().setSelf(id);
+        client.emit("worldSelf", id);
+      });
+      mcpPackage.on("users", (users) => {
+        useWorldMapStore.getState().setUsers(
+          users.map((user) => ({
+            id: user.id,
+            name: user.name,
+            locationId: user.location,
+            idleSeconds: Number.isFinite(Number(user.idle)) ? Number(user.idle) : null,
+          })),
+        );
+        client.emit("worldUsers", users);
+      });
+      mcpPackage.on("topology", (rooms) => {
+        useWorldMapStore.getState().setRooms(
+          rooms.map((room) => ({
+            id: room.id,
+            name: room.name,
+            exits: room.exit,
+          })),
+        );
+        client.emit("worldTopology", rooms);
+      });
+    }
+    if (mcpPackage instanceof McpAwnsRehash) {
+      rehashPackage = mcpPackage;
+      mcpPackage.on("commands", ({ commands }) => {
+        useInputStore.getState().setVisibleCommands(commands);
+        client.emit("visibleCommands", commands);
+      });
+      mcpPackage.on("add", ({ commands }) => {
+        useInputStore.getState().addVisibleCommands(commands);
+        client.emit("visibleCommands", useInputStore.getState().visibleCommands);
+      });
+      mcpPackage.on("remove", ({ commands }) => {
+        useInputStore.getState().removeVisibleCommands(commands);
+        client.emit("visibleCommands", useInputStore.getState().visibleCommands);
+      });
+    }
+    if (mcpPackage instanceof McpAwnsTimezone) {
+      timezonePackage = mcpPackage;
     }
     if (mcpPackage instanceof McpAwnsStatus) {
       mcpPackage.on("statustext", (text) => client.emit("statustext", text));
@@ -207,5 +297,15 @@ export function createConfiguredClient(): MudClient {
       mcpPackage.on("userlist", (players) => client.emit("userlist", players));
     }
   }
+
+  negotiatePackage?.on("end", () => {
+    timezonePackage?.sendTimezone({ timezone: getLocalTimezoneAbbreviation() });
+    serverInfoPackage?.requestServerInfo();
+    rehashPackage?.requestCommands();
+    visualPackage?.requestSelf();
+    visualPackage?.requestLocation();
+    visualPackage?.requestUsers();
+  });
+
   return client;
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -6,15 +6,27 @@ export {
   parseMcpMessage,
   parseMcpMultiline,
 } from './codec';
-export { mooListToArray, type MooListValue } from './mooList';
+export { type MooListValue, mooListToArray } from './mooList';
 export { MCPPackage } from './package';
 export { DEFAULT_MCP_PACKAGES, type McpPackageConstructor } from './packages';
+export { McpAwnsDisplayUrl } from './packages/displayUrl';
 export { McpAwnsGetSet } from './packages/getSet';
+export { McpAwnsJtext } from './packages/jtext';
 export { McpNegotiate } from './packages/negotiate';
 export { McpAwnsPing } from './packages/ping';
+export { McpAwnsRehash } from './packages/rehash';
+export { type AwnsServerInfo, McpAwnsServerInfo } from './packages/serverInfo';
 export { McpSimpleEdit } from './packages/simpleEdit';
 export { McpAwnsStatus } from './packages/status';
+export { type AwnsTimezone, McpAwnsTimezone } from './packages/timezone';
 export { McpVmooUserlist, type UserlistPlayer } from './packages/userlist';
+export {
+  type AwnsVisualLocation,
+  type AwnsVisualTopologyRequest,
+  type AwnsVisualTopologyRoom,
+  type AwnsVisualUser,
+  McpAwnsVisual,
+} from './packages/visual';
 export { generateTag, McpSession, type McpSessionHost } from './session';
 export type {
   EditorSession,

--- a/src/mcp/packages/awnsPackages.test.ts
+++ b/src/mcp/packages/awnsPackages.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import { McpSession } from '../session';
+import { McpAwnsDisplayUrl } from './displayUrl';
+import { McpAwnsJtext } from './jtext';
+import { McpAwnsRehash } from './rehash';
+import { McpAwnsServerInfo } from './serverInfo';
+import { McpAwnsTimezone } from './timezone';
+import { McpAwnsVisual } from './visual';
+
+describe('AWNS MCP packages', () => {
+  it('emits display URL requests', () => {
+    const urls: string[] = [];
+    const session = new McpSession(
+      {
+        sendLine: () => undefined,
+      },
+      () => 'auth01',
+    );
+    const displayUrl = session.registerPackage(McpAwnsDisplayUrl);
+    displayUrl.on('displayUrl', (url) => urls.push(url));
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    session.receiveLine('#$#dns-com-awns-displayurl auth01 url: "https://example.test/help"');
+
+    expect(urls).toEqual(['https://example.test/help']);
+  });
+
+  it('requests and emits server info URLs', () => {
+    const sent: string[] = [];
+    const infos: unknown[] = [];
+    const session = new McpSession(
+      {
+        sendLine: (line) => sent.push(line),
+      },
+      () => 'auth01',
+    );
+    const serverInfo = session.registerPackage(McpAwnsServerInfo);
+    serverInfo.on('serverInfo', (payload) => infos.push(payload));
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    sent.length = 0;
+    serverInfo.requestServerInfo();
+    session.receiveLine(
+      '#$#dns-com-awns-serverinfo auth01 home_url: "https://example.test/" help_url: "https://example.test/help"',
+    );
+
+    expect(sent).toEqual(['#$#dns-com-awns-serverinfo-get auth01']);
+    expect(infos).toEqual([
+      {
+        homeUrl: 'https://example.test/',
+        helpUrl: 'https://example.test/help',
+      },
+    ]);
+  });
+
+  it('sends jtext pick requests with package-local typed payloads', () => {
+    const sent: string[] = [];
+    const session = new McpSession(
+      {
+        sendLine: (line) => sent.push(line),
+      },
+      () => 'auth01',
+    );
+    const jtext = session.registerPackage(McpAwnsJtext);
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    sent.length = 0;
+    jtext.pick('help', 'topic: intro');
+
+    expect(sent).toEqual(['#$#dns-com-awns-jtext-pick auth01 type: help args: "topic: intro"']);
+  });
+
+  it('sends timezone updates as package-root messages', () => {
+    const sent: string[] = [];
+    const session = new McpSession(
+      {
+        sendLine: (line) => sent.push(line),
+      },
+      () => 'auth01',
+    );
+    const timezone = session.registerPackage(McpAwnsTimezone);
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    sent.length = 0;
+    timezone.sendTimezone({ timezone: 'MST' });
+
+    expect(sent).toEqual(['#$#dns-com-awns-timezone auth01 timezone: MST']);
+  });
+
+  it('tracks rehash command lists and abbreviation expansions', () => {
+    const sent: string[] = [];
+    const commandEvents: unknown[] = [];
+    const addEvents: unknown[] = [];
+    const removeEvents: unknown[] = [];
+    const session = new McpSession(
+      {
+        sendLine: (line) => sent.push(line),
+      },
+      () => 'auth01',
+    );
+    const rehash = session.registerPackage(McpAwnsRehash);
+    rehash.on('commands', (payload) => commandEvents.push(payload));
+    rehash.on('add', (payload) => addEvents.push(payload));
+    rehash.on('remove', (payload) => removeEvents.push(payload));
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    sent.length = 0;
+    rehash.requestCommands();
+    session.receiveLine('#$#dns-com-awns-rehash-commands auth01 list: "open close r*ead"');
+    session.receiveLine('#$#dns-com-awns-rehash-add auth01 list: "l*ook"');
+    session.receiveLine('#$#dns-com-awns-rehash-remove auth01 list: "r*ead"');
+
+    expect(sent).toEqual(['#$#dns-com-awns-rehash-getcommands auth01']);
+    expect(commandEvents).toEqual([
+      {
+        list: 'open close r*ead',
+        commands: ['open', 'close', 'r', 're', 'rea', 'read'],
+      },
+    ]);
+    expect(addEvents).toEqual([
+      {
+        list: 'l*ook',
+        commands: ['l', 'lo', 'loo', 'look'],
+      },
+    ]);
+    expect(removeEvents).toEqual([
+      {
+        list: 'r*ead',
+        commands: ['r', 're', 'rea', 'read'],
+      },
+    ]);
+    expect(rehash.commands).toEqual(['open', 'close', 'l', 'lo', 'loo', 'look']);
+  });
+
+  it('sends visual requests with the server package gettopology spelling', () => {
+    const sent: string[] = [];
+    const session = new McpSession(
+      {
+        sendLine: (line) => sent.push(line),
+      },
+      () => 'auth01',
+    );
+    const visual = session.registerPackage(McpAwnsVisual);
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    sent.length = 0;
+    visual.requestUsers();
+    visual.requestLocation();
+    visual.requestTopology('#123', 2);
+    visual.requestSelf();
+
+    expect(sent).toEqual([
+      '#$#dns-com-awns-visual-getusers auth01',
+      '#$#dns-com-awns-visual-getlocation auth01',
+      '#$#dns-com-awns-visual-gettopology auth01 location: #123 distance: 2',
+      '#$#dns-com-awns-visual-getself auth01',
+    ]);
+  });
+
+  it('emits visual locations, users, topology, and self messages', () => {
+    const locations: unknown[] = [];
+    const users: unknown[] = [];
+    const topologies: unknown[] = [];
+    const selves: unknown[] = [];
+    const session = new McpSession(
+      {
+        sendLine: () => undefined,
+      },
+      () => 'auth01',
+    );
+    const visual = session.registerPackage(McpAwnsVisual);
+    visual.on('location', (payload) => locations.push(payload));
+    visual.on('users', (payload) => users.push(payload));
+    visual.on('topology', (payload) => topologies.push(payload));
+    visual.on('self', (payload) => selves.push(payload));
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    session.receiveLine('#$#dns-com-awns-visual-location auth01 id: "#100"');
+    session.receiveLine('#$#dns-com-awns-visual-self auth01 id: "#42"');
+    session.receiveLine(
+      '#$#dns-com-awns-visual-users auth01 id*: "" name*: "" location*: "" idle*: "" _data-tag: users1',
+    );
+    session.receiveLine('#$#* users1 id: #1');
+    session.receiveLine('#$#* users1 id: #2');
+    session.receiveLine('#$#* users1 name: Alice');
+    session.receiveLine('#$#* users1 name: Bob B');
+    session.receiveLine('#$#* users1 location: #10');
+    session.receiveLine('#$#* users1 location: #11');
+    session.receiveLine('#$#* users1 idle: 0');
+    session.receiveLine('#$#* users1 idle: 30');
+    session.receiveLine('#$#: users1');
+    session.receiveLine(
+      '#$#dns-com-awns-visual-topology auth01 id*: "" name*: "" exit*: "" _data-tag: top1',
+    );
+    session.receiveLine('#$#* top1 id: #10');
+    session.receiveLine('#$#* top1 name: Courtyard');
+    session.receiveLine('#$#* top1 exit: north #11 east #12');
+    session.receiveLine('#$#: top1');
+
+    expect(locations).toEqual([{ id: '#100' }]);
+    expect(selves).toEqual([{ id: '#42' }]);
+    expect(users).toEqual([
+      [
+        { id: '#1', name: 'Alice', location: '#10', idle: '0' },
+        { id: '#2', name: 'Bob B', location: '#11', idle: '30' },
+      ],
+    ]);
+    expect(topologies).toEqual([[{ id: '#10', name: 'Courtyard', exit: 'north #11 east #12' }]]);
+    expect(visual.location).toBe('#100');
+    expect(visual.self).toBe('#42');
+  });
+});

--- a/src/mcp/packages/displayUrl.ts
+++ b/src/mcp/packages/displayUrl.ts
@@ -1,0 +1,20 @@
+import { identityCodec, inbound, messageEnvelope } from '../../protocol/messages';
+import { MCPPackage } from '../package';
+import type { McpMessage } from '../types';
+
+const displayUrl = messageEnvelope('displayUrl', identityCodec<string>());
+
+const McpAwnsDisplayUrlBase = MCPPackage.with({
+  packageName: 'dns-com-awns-displayurl',
+  messages: [inbound(displayUrl).asEvent('displayUrl')] as const,
+});
+
+export class McpAwnsDisplayUrl extends McpAwnsDisplayUrlBase {
+  handle(message: McpMessage): void {
+    if (message.name !== 'dns-com-awns-displayurl') {
+      return;
+    }
+
+    this.emitRegisteredMessage(displayUrl.wireName, message.keyvals.url);
+  }
+}

--- a/src/mcp/packages/index.ts
+++ b/src/mcp/packages/index.ts
@@ -1,19 +1,30 @@
-import type { MCPPackage } from "../package";
-import { McpAwnsGetSet } from "./getSet";
-import { McpNegotiate } from "./negotiate";
-import { McpAwnsPing } from "./ping";
-import { McpSimpleEdit } from "./simpleEdit";
-import { McpAwnsStatus } from "./status";
-import { McpVmooUserlist } from "./userlist";
+import type { MCPPackage } from '../package';
+import { McpAwnsDisplayUrl } from './displayUrl';
+import { McpAwnsGetSet } from './getSet';
+import { McpAwnsJtext } from './jtext';
+import { McpNegotiate } from './negotiate';
+import { McpAwnsPing } from './ping';
+import { McpAwnsRehash } from './rehash';
+import { McpAwnsServerInfo } from './serverInfo';
+import { McpSimpleEdit } from './simpleEdit';
+import { McpAwnsStatus } from './status';
+import { McpAwnsTimezone } from './timezone';
+import { McpVmooUserlist } from './userlist';
+import { McpAwnsVisual } from './visual';
 
 export type McpPackageConstructor = new () => MCPPackage;
 
 export const DEFAULT_MCP_PACKAGES = [
   McpNegotiate,
   McpAwnsGetSet,
+  McpAwnsDisplayUrl,
+  McpAwnsServerInfo,
+  McpAwnsJtext,
+  McpAwnsVisual,
+  McpAwnsRehash,
+  McpAwnsTimezone,
   McpAwnsStatus,
   McpSimpleEdit,
   McpVmooUserlist,
   McpAwnsPing,
 ] satisfies McpPackageConstructor[];
-

--- a/src/mcp/packages/jtext.ts
+++ b/src/mcp/packages/jtext.ts
@@ -1,0 +1,20 @@
+import { identityCodec, messageEnvelope, outbound } from '../../protocol/messages';
+import { MCPPackage } from '../package';
+
+export interface AwnsJtextPickRequest {
+  type: string;
+  args: string;
+}
+
+const jtextPick = messageEnvelope('pick', identityCodec<AwnsJtextPickRequest>());
+
+const McpAwnsJtextBase = MCPPackage.with({
+  packageName: 'dns-com-awns-jtext',
+  messages: [outbound(jtextPick)] as const,
+});
+
+export class McpAwnsJtext extends McpAwnsJtextBase {
+  pick(type: string, args: string): void {
+    this.sendPick({ type, args });
+  }
+}

--- a/src/mcp/packages/negotiate.ts
+++ b/src/mcp/packages/negotiate.ts
@@ -1,15 +1,24 @@
+import { duplex, identityCodec, messageEnvelope } from '../../protocol/messages';
 import { MCPPackage } from '../package';
 import type { McpMessage } from '../types';
 
-export class McpNegotiate extends MCPPackage {
-  public packageName = 'mcp-negotiate';
+const negotiateEnd = messageEnvelope('end', identityCodec<undefined>());
+
+const McpNegotiateBase = MCPPackage.with({
+  packageName: 'mcp-negotiate',
+  messages: [duplex(negotiateEnd).asEvent('end')] as const,
+});
+
+export class McpNegotiate extends McpNegotiateBase {
   public minVersion = 2.0;
   public maxVersion = 2.0;
 
   handle(message: McpMessage): void {
     switch (message.name) {
       case 'mcp-negotiate-can':
+        break;
       case 'mcp-negotiate-end':
+        this.emitRegisteredMessage(negotiateEnd.wireName, undefined);
         break;
       default:
         break;
@@ -17,6 +26,6 @@ export class McpNegotiate extends MCPPackage {
   }
 
   sendNegotiate(): void {
-    this.send('end');
+    this.sendEnd(undefined);
   }
 }

--- a/src/mcp/packages/rehash.ts
+++ b/src/mcp/packages/rehash.ts
@@ -1,0 +1,87 @@
+import { identityCodec, inbound, messageEnvelope, outbound } from '../../protocol/messages';
+import { MCPPackage } from '../package';
+import type { McpMessage } from '../types';
+
+export interface AwnsRehashCommandUpdate {
+  list: string;
+  commands: string[];
+}
+
+const rehashGetcommands = messageEnvelope('getcommands', identityCodec<undefined>());
+const rehashCommands = messageEnvelope('commands', identityCodec<AwnsRehashCommandUpdate>());
+const rehashAdd = messageEnvelope('add', identityCodec<AwnsRehashCommandUpdate>());
+const rehashRemove = messageEnvelope('remove', identityCodec<AwnsRehashCommandUpdate>());
+
+const McpAwnsRehashBase = MCPPackage.with({
+  packageName: 'dns-com-awns-rehash',
+  messages: [
+    outbound(rehashGetcommands),
+    inbound(rehashCommands),
+    inbound(rehashAdd),
+    inbound(rehashRemove),
+  ] as const,
+});
+
+export class McpAwnsRehash extends McpAwnsRehashBase {
+  public commands: string[] = [];
+
+  handle(message: McpMessage): void {
+    switch (message.name) {
+      case 'dns-com-awns-rehash-commands': {
+        const update = commandUpdateFrom(message.keyvals.list ?? '');
+        this.commands = [...update.commands];
+        this.emitRegisteredMessage(rehashCommands.wireName, update);
+        break;
+      }
+
+      case 'dns-com-awns-rehash-add': {
+        const update = commandUpdateFrom(message.keyvals.list ?? '');
+        const known = new Set(this.commands);
+        for (const command of update.commands) {
+          if (!known.has(command)) {
+            this.commands.push(command);
+            known.add(command);
+          }
+        }
+        this.emitRegisteredMessage(rehashAdd.wireName, update);
+        break;
+      }
+
+      case 'dns-com-awns-rehash-remove': {
+        const update = commandUpdateFrom(message.keyvals.list ?? '');
+        const removed = new Set(update.commands);
+        this.commands = this.commands.filter((command) => !removed.has(command));
+        this.emitRegisteredMessage(rehashRemove.wireName, update);
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  requestCommands(): void {
+    this.sendGetcommands(undefined);
+  }
+}
+
+function commandUpdateFrom(list: string): AwnsRehashCommandUpdate {
+  return {
+    list,
+    commands: list.trim().split(/\s+/).filter(Boolean).flatMap(expandCommand),
+  };
+}
+
+function expandCommand(command: string): string[] {
+  const marker = command.indexOf('*');
+  if (marker === -1) {
+    return [command];
+  }
+
+  const expanded = command.slice(0, marker) + command.slice(marker + 1);
+  const commands: string[] = [];
+  for (let length = marker; length <= expanded.length; length += 1) {
+    commands.push(expanded.slice(0, length));
+  }
+  return commands;
+}

--- a/src/mcp/packages/serverInfo.ts
+++ b/src/mcp/packages/serverInfo.ts
@@ -1,0 +1,33 @@
+import { identityCodec, inbound, messageEnvelope, outbound } from '../../protocol/messages';
+import { MCPPackage } from '../package';
+import type { McpMessage } from '../types';
+
+export type AwnsServerInfo = {
+  homeUrl: string;
+  helpUrl: string;
+};
+
+const serverInfo = messageEnvelope('serverInfo', identityCodec<AwnsServerInfo>());
+const serverInfoGet = messageEnvelope('get', identityCodec<Record<string, never>>());
+
+const McpAwnsServerInfoBase = MCPPackage.with({
+  packageName: 'dns-com-awns-serverinfo',
+  messages: [inbound(serverInfo).asEvent('serverInfo'), outbound(serverInfoGet)] as const,
+});
+
+export class McpAwnsServerInfo extends McpAwnsServerInfoBase {
+  handle(message: McpMessage): void {
+    if (message.name !== 'dns-com-awns-serverinfo') {
+      return;
+    }
+
+    this.emitRegisteredMessage(serverInfo.wireName, {
+      homeUrl: message.keyvals.home_url ?? '',
+      helpUrl: message.keyvals.help_url ?? '',
+    });
+  }
+
+  requestServerInfo(): void {
+    this.sendGet({});
+  }
+}

--- a/src/mcp/packages/timezone.ts
+++ b/src/mcp/packages/timezone.ts
@@ -1,0 +1,20 @@
+import { identityCodec, messageEnvelope } from '../../protocol/messages';
+import { MCPPackage } from '../package';
+import type { McpOutboundData } from '../types';
+
+export type AwnsTimezone = {
+  timezone: string;
+};
+
+const timezone = messageEnvelope('dns-com-awns-timezone', identityCodec<AwnsTimezone>());
+
+const McpAwnsTimezoneBase = MCPPackage.with({
+  packageName: 'dns-com-awns-timezone',
+  messages: [] as const,
+});
+
+export class McpAwnsTimezone extends McpAwnsTimezoneBase {
+  sendTimezone(payload: AwnsTimezone): void {
+    this.send(timezone.wireName, timezone.codec.encode(payload) as McpOutboundData);
+  }
+}

--- a/src/mcp/packages/visual.ts
+++ b/src/mcp/packages/visual.ts
@@ -1,0 +1,234 @@
+import { identityCodec, inbound, messageEnvelope, outbound } from '../../protocol/messages';
+import { MCPPackage } from '../package';
+import type { McpMessage } from '../types';
+
+export interface AwnsVisualLocation {
+  id: string;
+}
+
+export interface AwnsVisualTopologyRequest {
+  location: string;
+  distance: string | number;
+}
+
+export interface AwnsVisualUser {
+  id: string;
+  name: string;
+  location: string;
+  idle: string;
+}
+
+export interface AwnsVisualTopologyRoom {
+  id: string;
+  name: string;
+  exit: string;
+  idle?: string;
+}
+
+type PendingVisualMessage =
+  | {
+      kind: 'users';
+      id: string[];
+      name: string[];
+      location: string[];
+      idle: string[];
+    }
+  | {
+      kind: 'topology';
+      id: string[];
+      name: string[];
+      exit: string[];
+      idle: string[];
+    };
+
+const visualGetusers = messageEnvelope('getusers', identityCodec<undefined>());
+const visualGetlocation = messageEnvelope('getlocation', identityCodec<undefined>());
+const visualGettopology = messageEnvelope(
+  'gettopology',
+  identityCodec<AwnsVisualTopologyRequest>(),
+);
+const visualGetself = messageEnvelope('getself', identityCodec<undefined>());
+const visualLocation = messageEnvelope('location', identityCodec<AwnsVisualLocation>());
+const visualUsers = messageEnvelope('users', identityCodec<AwnsVisualUser[]>());
+const visualTopology = messageEnvelope('topology', identityCodec<AwnsVisualTopologyRoom[]>());
+const visualSelf = messageEnvelope('self', identityCodec<AwnsVisualLocation>());
+
+const McpAwnsVisualBase = MCPPackage.with({
+  packageName: 'dns-com-awns-visual',
+  messages: [
+    outbound(visualGetusers),
+    outbound(visualGetlocation),
+    outbound(visualGettopology),
+    outbound(visualGetself),
+    inbound(visualLocation),
+    inbound(visualUsers),
+    inbound(visualTopology),
+    inbound(visualSelf),
+  ] as const,
+});
+
+export class McpAwnsVisual extends McpAwnsVisualBase {
+  public location: string | undefined;
+  public self: string | undefined;
+  public users: AwnsVisualUser[] = [];
+  public topology: AwnsVisualTopologyRoom[] = [];
+  private pendingMessages = new Map<string, PendingVisualMessage>();
+
+  handle(message: McpMessage): void {
+    switch (message.name) {
+      case 'dns-com-awns-visual-location': {
+        const payload = { id: message.keyvals.id ?? '' };
+        this.location = payload.id;
+        this.emitRegisteredMessage(visualLocation.wireName, payload);
+        break;
+      }
+
+      case 'dns-com-awns-visual-self': {
+        const payload = { id: message.keyvals.id ?? '' };
+        this.self = payload.id;
+        this.emitRegisteredMessage(visualSelf.wireName, payload);
+        break;
+      }
+
+      case 'dns-com-awns-visual-users':
+        this.beginUsers(message);
+        break;
+
+      case 'dns-com-awns-visual-topology':
+        this.beginTopology(message);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  handleMultiline(message: McpMessage): void {
+    const pending = this.pendingMessages.get(message.name);
+    if (!pending) {
+      console.log(`Unexpected visual ML ${message.name}`);
+      return;
+    }
+
+    if ('id' in message.keyvals) {
+      pending.id.push(message.keyvals.id);
+    }
+    if ('name' in message.keyvals) {
+      pending.name.push(message.keyvals.name);
+    }
+
+    if (pending.kind === 'users') {
+      if ('location' in message.keyvals) {
+        pending.location.push(message.keyvals.location);
+      }
+      if ('idle' in message.keyvals) {
+        pending.idle.push(message.keyvals.idle);
+      }
+      return;
+    }
+
+    if ('exit' in message.keyvals) {
+      pending.exit.push(message.keyvals.exit);
+    }
+    if ('idle' in message.keyvals) {
+      pending.idle.push(message.keyvals.idle);
+    }
+  }
+
+  closeMultiline(closure: McpMessage): void {
+    const pending = this.pendingMessages.get(closure.name);
+    if (!pending) {
+      return;
+    }
+
+    if (pending.kind === 'users') {
+      const count = Math.max(
+        pending.id.length,
+        pending.name.length,
+        pending.location.length,
+        pending.idle.length,
+      );
+      this.users = [];
+      for (let index = 0; index < count; index += 1) {
+        this.users.push({
+          id: pending.id[index] ?? '',
+          name: pending.name[index] ?? '',
+          location: pending.location[index] ?? '',
+          idle: pending.idle[index] ?? '',
+        });
+      }
+      this.emitRegisteredMessage(visualUsers.wireName, this.users);
+      this.pendingMessages.delete(closure.name);
+      return;
+    }
+
+    const count = Math.max(
+      pending.id.length,
+      pending.name.length,
+      pending.exit.length,
+      pending.idle.length,
+    );
+    this.topology = [];
+    for (let index = 0; index < count; index += 1) {
+      const room: AwnsVisualTopologyRoom = {
+        id: pending.id[index] ?? '',
+        name: pending.name[index] ?? '',
+        exit: pending.exit[index] ?? '',
+      };
+      if (pending.idle[index] !== undefined) {
+        room.idle = pending.idle[index];
+      }
+      this.topology.push(room);
+    }
+    this.emitRegisteredMessage(visualTopology.wireName, this.topology);
+    this.pendingMessages.delete(closure.name);
+  }
+
+  requestUsers(): void {
+    this.sendGetusers(undefined);
+  }
+
+  requestLocation(): void {
+    this.sendGetlocation(undefined);
+  }
+
+  requestTopology(location: string, distance: string | number): void {
+    this.sendGettopology({ location, distance });
+  }
+
+  requestSelf(): void {
+    this.sendGetself(undefined);
+  }
+
+  private beginUsers(message: McpMessage): void {
+    const tag = message.keyvals['_data-tag'];
+    if (!tag) {
+      console.log('Ignoring visual users without _data-tag');
+      return;
+    }
+
+    this.pendingMessages.set(tag, {
+      kind: 'users',
+      id: [],
+      name: [],
+      location: [],
+      idle: [],
+    });
+  }
+
+  private beginTopology(message: McpMessage): void {
+    const tag = message.keyvals['_data-tag'];
+    if (!tag) {
+      console.log('Ignoring visual topology without _data-tag');
+      return;
+    }
+
+    this.pendingMessages.set(tag, {
+      kind: 'topology',
+      id: [],
+      name: [],
+      exit: [],
+      idle: [],
+    });
+  }
+}

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -127,10 +127,6 @@ export class McpSession {
       return;
     }
 
-    if (message.name === "mcp-negotiate-end") {
-      return;
-    }
-
     if (message.authKey !== this.authKey) {
       console.log(
         `Unexpected authkey "${message.authKey}", probably a spoofed message.`,

--- a/src/stores/inputStore.test.ts
+++ b/src/stores/inputStore.test.ts
@@ -4,6 +4,7 @@ import { useInputStore } from "./inputStore";
 describe("inputStore", () => {
   beforeEach(() => {
     useInputStore.getState().clear();
+    useInputStore.getState().resetCommands();
   });
 
   it("starts empty", () => {
@@ -29,5 +30,19 @@ describe("inputStore", () => {
     useInputStore.getState().setText("x");
     unsub();
     expect(notified).toBe(1);
+  });
+
+  it("stores visible commands as a sorted unique list", () => {
+    useInputStore.getState().setVisibleCommands(["look", "open", "look"]);
+    useInputStore.getState().addVisibleCommands(["close", "open"]);
+
+    expect(useInputStore.getState().visibleCommands).toEqual(["close", "look", "open"]);
+  });
+
+  it("removes visible commands", () => {
+    useInputStore.getState().setVisibleCommands(["close", "look", "open"]);
+    useInputStore.getState().removeVisibleCommands(["look"]);
+
+    expect(useInputStore.getState().visibleCommands).toEqual(["close", "open"]);
   });
 });

--- a/src/stores/inputStore.ts
+++ b/src/stores/inputStore.ts
@@ -3,8 +3,14 @@ import { create } from "zustand";
 interface InputStoreState {
   /** Current text in the command input. */
   text: string;
+  /** Commands currently visible to the player, used by command input completion. */
+  visibleCommands: string[];
   setText: (text: string) => void;
+  setVisibleCommands: (commands: string[]) => void;
+  addVisibleCommands: (commands: string[]) => void;
+  removeVisibleCommands: (commands: string[]) => void;
   clear: () => void;
+  resetCommands: () => void;
 }
 
 /**
@@ -13,6 +19,26 @@ interface InputStoreState {
  */
 export const useInputStore = create<InputStoreState>((set) => ({
   text: "",
+  visibleCommands: [],
   setText: (text) => set({ text }),
+  setVisibleCommands: (commands) => set({ visibleCommands: sortedUnique(commands) }),
+  addVisibleCommands: (commands) =>
+    set((state) => ({
+      visibleCommands: sortedUnique([...state.visibleCommands, ...commands]),
+    })),
+  removeVisibleCommands: (commands) =>
+    set((state) => {
+      const removed = new Set(commands);
+      return {
+        visibleCommands: state.visibleCommands.filter((command) => !removed.has(command)),
+      };
+    }),
   clear: () => set({ text: "" }),
+  resetCommands: () => set({ visibleCommands: [] }),
 }));
+
+function sortedUnique(commands: string[]): string[] {
+  return [...new Set(commands.filter(Boolean))].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}

--- a/src/stores/serverLinksStore.test.ts
+++ b/src/stores/serverLinksStore.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useServerLinksStore } from './serverLinksStore';
+
+describe('serverLinksStore', () => {
+  beforeEach(() => {
+    useServerLinksStore.getState().reset();
+  });
+
+  it('stores home and help links', () => {
+    useServerLinksStore.getState().setServerInfo({
+      homeUrl: 'https://example.test/',
+      helpUrl: 'https://example.test/help',
+    });
+
+    expect(useServerLinksStore.getState().homeUrl).toBe('https://example.test/');
+    expect(useServerLinksStore.getState().helpUrl).toBe('https://example.test/help');
+  });
+
+  it('keeps recent server-sent URLs newest first and de-duped', () => {
+    useServerLinksStore.getState().addRecentUrl('https://example.test/one', 1);
+    useServerLinksStore.getState().addRecentUrl('https://example.test/two', 2);
+    useServerLinksStore.getState().addRecentUrl('https://example.test/one', 3);
+
+    expect(useServerLinksStore.getState().recentUrls.map((entry) => entry.url)).toEqual([
+      'https://example.test/one',
+      'https://example.test/two',
+    ]);
+    expect(useServerLinksStore.getState().recentUrls[0].receivedAt).toBe(3);
+  });
+});

--- a/src/stores/serverLinksStore.ts
+++ b/src/stores/serverLinksStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+export interface RecentServerUrl {
+  id: number;
+  url: string;
+  receivedAt: number;
+}
+
+interface ServerLinksState {
+  homeUrl: string;
+  helpUrl: string;
+  recentUrls: RecentServerUrl[];
+  setServerInfo: (info: { homeUrl: string; helpUrl: string }) => void;
+  addRecentUrl: (url: string, receivedAt?: number) => void;
+  clearRecentUrls: () => void;
+  reset: () => void;
+}
+
+let nextUrlId = 1;
+
+export const useServerLinksStore = create<ServerLinksState>((set) => ({
+  homeUrl: '',
+  helpUrl: '',
+  recentUrls: [],
+  setServerInfo: ({ homeUrl, helpUrl }) => set({ homeUrl, helpUrl }),
+  addRecentUrl: (url, receivedAt = Date.now()) =>
+    set((state) => ({
+      recentUrls: [
+        { id: nextUrlId++, url, receivedAt },
+        ...state.recentUrls.filter((entry) => entry.url !== url),
+      ].slice(0, 10),
+    })),
+  clearRecentUrls: () => set({ recentUrls: [] }),
+  reset: () => set({ homeUrl: '', helpUrl: '', recentUrls: [] }),
+}));

--- a/src/stores/worldMapStore.test.ts
+++ b/src/stores/worldMapStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useWorldMapStore } from './worldMapStore';
+
+describe('worldMapStore', () => {
+  beforeEach(() => {
+    useWorldMapStore.getState().reset();
+  });
+
+  it('tracks current location and self id', () => {
+    useWorldMapStore.getState().setLocation('#100');
+    useWorldMapStore.getState().setSelf('#42');
+
+    expect(useWorldMapStore.getState().locationId).toBe('#100');
+    expect(useWorldMapStore.getState().selfId).toBe('#42');
+  });
+
+  it('sorts users and rooms by display name', () => {
+    useWorldMapStore.getState().setUsers([
+      { id: '#2', name: 'Bravo', locationId: '#20', idleSeconds: 0 },
+      { id: '#1', name: 'Alpha', locationId: '#10', idleSeconds: null },
+    ]);
+    useWorldMapStore.getState().setRooms([
+      { id: '#20', name: 'West Hall', exits: 'east #10' },
+      { id: '#10', name: 'Atrium', exits: 'west #20' },
+    ]);
+
+    expect(useWorldMapStore.getState().users.map((user) => user.name)).toEqual([
+      'Alpha',
+      'Bravo',
+    ]);
+    expect(useWorldMapStore.getState().rooms.map((room) => room.name)).toEqual([
+      'Atrium',
+      'West Hall',
+    ]);
+  });
+});

--- a/src/stores/worldMapStore.ts
+++ b/src/stores/worldMapStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+export interface WorldMapUser {
+  id: string;
+  name: string;
+  locationId: string;
+  idleSeconds: number | null;
+}
+
+export interface WorldMapRoom {
+  id: string;
+  name: string;
+  exits: string;
+}
+
+interface WorldMapState {
+  locationId: string;
+  selfId: string;
+  users: WorldMapUser[];
+  rooms: WorldMapRoom[];
+  setLocation: (locationId: string) => void;
+  setSelf: (selfId: string) => void;
+  setUsers: (users: WorldMapUser[]) => void;
+  setRooms: (rooms: WorldMapRoom[]) => void;
+  reset: () => void;
+}
+
+export const useWorldMapStore = create<WorldMapState>((set) => ({
+  locationId: '',
+  selfId: '',
+  users: [],
+  rooms: [],
+  setLocation: (locationId) => set({ locationId }),
+  setSelf: (selfId) => set({ selfId }),
+  setUsers: (users) =>
+    set({
+      users: [...users].sort((left, right) => left.name.localeCompare(right.name)),
+    }),
+  setRooms: (rooms) =>
+    set({
+      rooms: [...rooms].sort((left, right) => left.name.localeCompare(right.name)),
+    }),
+  reset: () => set({ locationId: '', selfId: '', users: [], rooms: [] }),
+}));


### PR DESCRIPTION
## Summary

This PR builds on the typed protocol registry cleanup from #45 and adds the AWNS MCP package support as the next slice.

It adds typed MCP package transports for AWNS-style server data, including server info/features, links, world map, display URL, JTEXT, rehash, timezone, and visual command data. It also wires the negotiated package data into semantic stores and UI panels so the client can present server links, features, map data, and command lists from MCP-provided state.

## Scope

Included:
- AWNS MCP package implementations and tests
- negotiation follow-up requests for AWNS package data
- semantic stores for server links and world map data
- command-list input integration
- sidebar panels for server links, server features, and world map data

This PR intentionally contains only the two commits after #45:
- `3132582 Add AWNS MCP package transports`
- `d3d13b2 Wire AWNS MCP features into UI`

## Validation

- `npm test -- --run src` passed: 90 files, 884 tests
- `npm run typecheck` passed
- `npm run lint` passed using the repo's staged-only lint script; it checked 0 staged files
- `git diff --check origin/master..HEAD` passed