### PR TITLE
[codex] distance-aware ambisonic attenuation

### DIFF
--- a/src/audio/AmbisonicRenderer.test.ts
+++ b/src/audio/AmbisonicRenderer.test.ts
@@ -19,12 +19,25 @@ function createNode() {
   };
 }
 
+function createGainNode() {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    gain: { value: 1 },
+  };
+}
+
+/** A context whose createGain hands back a single, inspectable gain node. */
+function createContext(gainNode = createGainNode()) {
+  return { createGain: vi.fn(() => gainNode) };
+}
+
 describe('AmbisonicRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('builds the stereo-upmix ambisonic playback graph against cacophony', async () => {
+  it('routes the stereo-upmix graph through a pre-encoder distance gain', async () => {
     const encoder = createNode();
     const input = createNode();
     const output = createNode();
@@ -38,8 +51,9 @@ describe('AmbisonicRenderer', () => {
     };
     mockCreateFOARenderer.mockReturnValue(renderer);
 
+    const gainNode = createGainNode();
     const cacophony = {
-      context: {},
+      context: createContext(gainNode),
       loadStereoToBFormatWorklet: vi.fn().mockResolvedValue(undefined),
       createStereoToBFormatNode: vi.fn().mockResolvedValue(encoder),
       globalGainNode: createNode(),
@@ -52,17 +66,16 @@ describe('AmbisonicRenderer', () => {
     const ambisonicRenderer = await AmbisonicRenderer.create(cacophony as any, 2);
     ambisonicRenderer.attachPlayback(playback as any);
 
-    expect(renderer.initialize).toHaveBeenCalledOnce();
-    expect(renderer.setRenderingMode).toHaveBeenCalledWith('ambisonic');
-    expect(cacophony.loadStereoToBFormatWorklet).toHaveBeenCalledOnce();
-    expect(cacophony.createStereoToBFormatNode).toHaveBeenCalledOnce();
+    expect(cacophony.context.createGain).toHaveBeenCalledOnce();
     expect(playback.disconnect).toHaveBeenCalledOnce();
-    expect(playback.connect).toHaveBeenCalledWith(encoder);
+    // playback → distanceGain → encoder → renderer.input
+    expect(playback.connect).toHaveBeenCalledWith(gainNode);
+    expect(gainNode.connect).toHaveBeenCalledWith(encoder);
     expect(encoder.connect).toHaveBeenCalledWith(input);
     expect(output.connect).toHaveBeenCalledWith(cacophony.globalGainNode);
   });
 
-  it('builds the FOA passthrough graph without a stereo encoder', async () => {
+  it('routes the FOA passthrough graph through the distance gain without an encoder', async () => {
     const input = createNode();
     const output = createNode();
     const renderer = {
@@ -75,11 +88,9 @@ describe('AmbisonicRenderer', () => {
     };
     mockCreateFOARenderer.mockReturnValue(renderer);
 
-    const gainNode = createNode();
-    const source = createNode();
-    const panner = createNode();
+    const gainNode = createGainNode();
     const cacophony = {
-      context: {},
+      context: createContext(gainNode),
       loadStereoToBFormatWorklet: vi.fn().mockResolvedValue(undefined),
       createStereoToBFormatNode: vi.fn(),
       globalGainNode: createNode(),
@@ -87,23 +98,16 @@ describe('AmbisonicRenderer', () => {
     const playback = {
       connect: vi.fn(),
       disconnect: vi.fn(),
-      gainNode,
-      panner,
-      source,
     };
 
     const ambisonicRenderer = await AmbisonicRenderer.create(cacophony as any, 4);
     ambisonicRenderer.attachPlayback(playback as any);
 
-    expect(renderer.initialize).toHaveBeenCalledOnce();
-    expect(renderer.setRenderingMode).toHaveBeenCalledWith('ambisonic');
-    expect(cacophony.loadStereoToBFormatWorklet).not.toHaveBeenCalled();
     expect(cacophony.createStereoToBFormatNode).not.toHaveBeenCalled();
     expect(playback.disconnect).toHaveBeenCalledOnce();
-    expect(playback.connect).toHaveBeenCalledWith(input);
-    expect(source.disconnect).not.toHaveBeenCalled();
-    expect(source.connect).not.toHaveBeenCalled();
-    expect(gainNode.connect).not.toHaveBeenCalled();
+    // playback → distanceGain → renderer.input
+    expect(playback.connect).toHaveBeenCalledWith(gainNode);
+    expect(gainNode.connect).toHaveBeenCalledWith(input);
     expect(output.connect).toHaveBeenCalledWith(cacophony.globalGainNode);
   });
 
@@ -121,7 +125,7 @@ describe('AmbisonicRenderer', () => {
     mockCreateFOARenderer.mockReturnValue(renderer);
 
     const cacophony = {
-      context: {},
+      context: createContext(),
       loadStereoToBFormatWorklet: vi.fn().mockResolvedValue(undefined),
       createStereoToBFormatNode: vi.fn(),
       globalGainNode: createNode(),
@@ -134,6 +138,63 @@ describe('AmbisonicRenderer', () => {
 
     expect(output.connect).toHaveBeenCalledWith(effectBusInput);
     expect(output.connect).not.toHaveBeenCalledWith(cacophony.globalGainNode);
+  });
+
+  it('sets and clamps the distance gain on the pre-encoder node', async () => {
+    const renderer = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      input: createNode(),
+      output: createNode(),
+      setRenderingMode: vi.fn(),
+      setRotationMatrix3: vi.fn(),
+      setRotationMatrix4: vi.fn(),
+    };
+    mockCreateFOARenderer.mockReturnValue(renderer);
+
+    const gainNode = createGainNode();
+    const cacophony = {
+      context: createContext(gainNode),
+      loadStereoToBFormatWorklet: vi.fn().mockResolvedValue(undefined),
+      createStereoToBFormatNode: vi.fn(),
+      globalGainNode: createNode(),
+    };
+    const playback = { connect: vi.fn(), disconnect: vi.fn() };
+
+    const ambisonicRenderer = await AmbisonicRenderer.create(cacophony as any, 4);
+    ambisonicRenderer.attachPlayback(playback as any);
+
+    ambisonicRenderer.setDistanceGain(0.3);
+    expect(gainNode.gain.value).toBeCloseTo(0.3, 9);
+
+    ambisonicRenderer.setDistanceGain(5);
+    expect(gainNode.gain.value).toBe(1);
+
+    ambisonicRenderer.setDistanceGain(-2);
+    expect(gainNode.gain.value).toBe(0);
+
+    ambisonicRenderer.setDistanceGain(Number.NaN);
+    expect(gainNode.gain.value).toBe(1);
+  });
+
+  it('is a no-op when setting distance gain before a playback is attached', async () => {
+    const renderer = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      input: createNode(),
+      output: createNode(),
+      setRenderingMode: vi.fn(),
+      setRotationMatrix3: vi.fn(),
+      setRotationMatrix4: vi.fn(),
+    };
+    mockCreateFOARenderer.mockReturnValue(renderer);
+    const cacophony = {
+      context: createContext(),
+      loadStereoToBFormatWorklet: vi.fn().mockResolvedValue(undefined),
+      createStereoToBFormatNode: vi.fn(),
+      globalGainNode: createNode(),
+    };
+
+    const ambisonicRenderer = await AmbisonicRenderer.create(cacophony as any, 4);
+    expect(() => ambisonicRenderer.setDistanceGain(0.5)).not.toThrow();
   });
 
   it('computes the expected yaw rotation matrix', () => {

--- a/src/audio/AmbisonicRenderer.ts
+++ b/src/audio/AmbisonicRenderer.ts
@@ -6,6 +6,8 @@ type AmbisonicInputMode = 'stereo-upmix' | 'foa-passthrough';
 
 export class AmbisonicRenderer {
   private attachedPlayback?: Playback;
+  /** Pre-encoder gain that attenuates the source by listener distance (ambisonic has no panner). */
+  private distanceGain?: GainNode;
 
   private constructor(
     private readonly cacophony: Cacophony,
@@ -39,22 +41,41 @@ export class AmbisonicRenderer {
   attachPlayback(playback: Playback, outputTarget?: CacophonyAudioNode): void {
     this.attachedPlayback = playback;
     playback.disconnect();
+    const distanceGain = (this.cacophony.context as unknown as BaseAudioContext).createGain();
+    this.distanceGain = distanceGain;
+    const distanceNode = distanceGain as unknown as CacophonyAudioNode;
+    playback.connect(distanceNode);
     if (this.mode === 'stereo-upmix') {
       if (!this.encoder) {
         throw new Error('Stereo ambisonic upmix requires an encoder node');
       }
-      playback.connect(this.encoder);
+      distanceNode.connect(this.encoder);
       this.encoder.connect(this.renderer.input as unknown as CacophonyAudioNode);
     } else {
-      playback.connect(this.renderer.input as unknown as CacophonyAudioNode);
+      distanceNode.connect(this.renderer.input as unknown as CacophonyAudioNode);
     }
     (this.renderer.output as unknown as CacophonyAudioNode).connect(
       outputTarget ?? this.cacophony.globalGainNode,
     );
   }
 
+  /**
+   * Set the pre-encoder distance attenuation (0..1). Lets a positioned ambisonic
+   * source fall off with listener distance the way an HRTF-panned source does,
+   * while the renderer still rotates the soundfield with head yaw.
+   */
+  setDistanceGain(gain: number): void {
+    if (!this.distanceGain) {
+      return;
+    }
+    const clamped = Number.isFinite(gain) ? Math.min(1, Math.max(0, gain)) : 1;
+    this.distanceGain.gain.value = clamped;
+  }
+
   cleanup(): void {
     this.renderer.output.disconnect();
+    this.distanceGain?.disconnect();
+    this.distanceGain = undefined;
     if (!this.attachedPlayback) {
       this.encoder?.disconnect();
       return;

--- a/src/audio/MediaService.ts
+++ b/src/audio/MediaService.ts
@@ -121,6 +121,7 @@ export interface ClientMediaListenerPositionPayload {
 export interface ExtendedSound extends Sound {
   ambisonicRenderer?: AmbisonicRenderer;
   inputChannels?: number;
+  mediaPosition?: Position;
   priority?: number;
   tag?: string;
   key?: string;
@@ -203,7 +204,7 @@ export class MediaService {
     if (!sound.ambisonicRenderer) {
       return;
     }
-    const distance = distanceBetween(this.cacophony.listenerPosition, sound.position);
+    const distance = distanceBetween(this.cacophony.listenerPosition, sound.mediaPosition);
     sound.ambisonicRenderer.setDistanceGain(inverseDistanceGain(distance));
   }
 
@@ -723,7 +724,8 @@ export class MediaService {
     }
 
     if (data.position?.length) {
-      sound.position = [data.position[0], data.position[1], data.position[2]];
+      sound.mediaPosition = [data.position[0], data.position[1], data.position[2]];
+      sound.position = sound.mediaPosition;
       this.updateAmbisonicDistance(sound as ExtendedSound);
     }
 

--- a/src/audio/MediaService.ts
+++ b/src/audio/MediaService.ts
@@ -8,6 +8,7 @@ import {
 
 import { usePreferences } from '../stores/preferencesStore';
 import { AmbisonicRenderer } from './AmbisonicRenderer';
+import { distanceBetween, inverseDistanceGain, SPATIAL_DISTANCE_MODEL } from './distanceModel';
 import { EffectChain } from './effects/EffectChain';
 import { MediaEffects } from './effects/MediaEffects';
 import type { EffectSpec } from './effects/types';
@@ -186,7 +187,24 @@ export class MediaService {
   setListenerPosition(position: Position | null | undefined): void {
     if (position?.length) {
       this.cacophony.listenerPosition = position;
+      for (const sound of this.allSounds) {
+        this.updateAmbisonicDistance(sound);
+      }
     }
+  }
+
+  /**
+   * Recompute an ambisonic source's distance attenuation from the current
+   * listener position. The HRTF panner gets distance from the Web Audio
+   * PannerNode for free; the ambisonic route has no panner, so we drive its
+   * pre-encoder gain with the same falloff curve ({@link inverseDistanceGain}).
+   */
+  private updateAmbisonicDistance(sound: ExtendedSound): void {
+    if (!sound.ambisonicRenderer) {
+      return;
+    }
+    const distance = distanceBetween(this.cacophony.listenerPosition, sound.position);
+    sound.ambisonicRenderer.setDistanceGain(inverseDistanceGain(distance));
   }
 
   setListenerOrientation(
@@ -652,6 +670,7 @@ export class MediaService {
     renderer.attachPlayback(playback, outputTarget);
     renderer.setRotationMatrixFromYaw(this.currentListenerYaw());
     sound.ambisonicRenderer = renderer;
+    this.updateAmbisonicDistance(sound);
   }
 
   private async resolveAmbisonicTarget(
@@ -697,14 +716,15 @@ export class MediaService {
         coneOuterAngle: 0,
         panningModel: 'HRTF',
         distanceModel: 'inverse',
-        refDistance: 4,
-        rolloffFactor: 0.5,
-        maxDistance: 200,
+        refDistance: SPATIAL_DISTANCE_MODEL.refDistance,
+        rolloffFactor: SPATIAL_DISTANCE_MODEL.rolloffFactor,
+        maxDistance: SPATIAL_DISTANCE_MODEL.maxDistance,
       };
     }
 
     if (data.position?.length) {
       sound.position = [data.position[0], data.position[1], data.position[2]];
+      this.updateAmbisonicDistance(sound as ExtendedSound);
     }
 
     if (data.start !== undefined) {

--- a/src/audio/distanceModel.test.ts
+++ b/src/audio/distanceModel.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { distanceBetween, inverseDistanceGain, SPATIAL_DISTANCE_MODEL } from './distanceModel';
+
+describe('inverseDistanceGain', () => {
+  it('is full volume at or inside the reference distance', () => {
+    expect(inverseDistanceGain(0)).toBe(1);
+    expect(inverseDistanceGain(SPATIAL_DISTANCE_MODEL.refDistance)).toBe(1);
+    expect(inverseDistanceGain(SPATIAL_DISTANCE_MODEL.refDistance - 0.5)).toBe(1);
+  });
+
+  it('matches the Web Audio inverse model beyond the reference distance', () => {
+    // refDistance 4, rolloff 0.5 → 4 / (4 + 0.5 * (58 - 4)) = 4 / 31 ≈ 0.129 (~ -18 dB),
+    // the value the panner-tuning commit cites for a ~58 m source.
+    expect(inverseDistanceGain(58)).toBeCloseTo(4 / 31, 6);
+    expect(inverseDistanceGain(8)).toBeCloseTo(4 / 6, 6);
+  });
+
+  it('falls off monotonically with distance', () => {
+    const a = inverseDistanceGain(10);
+    const b = inverseDistanceGain(40);
+    const c = inverseDistanceGain(120);
+    expect(a).toBeGreaterThan(b);
+    expect(b).toBeGreaterThan(c);
+    expect(c).toBeGreaterThan(0);
+  });
+
+  it('clamps distance at maxDistance so far sources settle to a floor', () => {
+    const atMax = inverseDistanceGain(SPATIAL_DISTANCE_MODEL.maxDistance);
+    expect(inverseDistanceGain(SPATIAL_DISTANCE_MODEL.maxDistance + 500)).toBeCloseTo(atMax, 9);
+    expect(inverseDistanceGain(99999)).toBeCloseTo(atMax, 9);
+  });
+
+  it('treats non-finite distance as full volume', () => {
+    expect(inverseDistanceGain(NaN)).toBe(1);
+    expect(inverseDistanceGain(Infinity)).toBe(1);
+  });
+
+  it('honours a custom model', () => {
+    const model = { refDistance: 1, rolloffFactor: 1, maxDistance: 10000 };
+    expect(inverseDistanceGain(2, model)).toBeCloseTo(1 / 2, 6);
+    expect(inverseDistanceGain(10, model)).toBeCloseTo(1 / 10, 6);
+  });
+});
+
+describe('distanceBetween', () => {
+  it('computes Euclidean distance', () => {
+    expect(distanceBetween([0, 0, 0], [3, 4, 0])).toBeCloseTo(5, 9);
+    expect(distanceBetween([1, 2, 3], [1, 2, 3])).toBe(0);
+    expect(distanceBetween([-5, -5, 0], [-88, -29, 0])).toBeCloseTo(
+      Math.sqrt(83 * 83 + 24 * 24),
+      6,
+    );
+  });
+
+  it('returns 0 for missing or short vectors', () => {
+    expect(distanceBetween(undefined, [1, 2, 3])).toBe(0);
+    expect(distanceBetween([1, 2, 3], null)).toBe(0);
+    expect(distanceBetween([1, 2], [1, 2, 3])).toBe(0);
+  });
+});

--- a/src/audio/distanceModel.ts
+++ b/src/audio/distanceModel.ts
@@ -1,0 +1,54 @@
+// Spatial distance attenuation shared by the HRTF panner (Web Audio PannerNode,
+// configured in MediaService.applySoundState) and the ambisonic gain path
+// (AmbisonicRenderer's pre-encoder distance gain). One source of truth so the two
+// spatialization routes fall off identically for the same meter-scale world.
+//
+// Mirrors the Web Audio 'inverse' distance model with the tuned parameters from
+// `fix(audio): tune 3D panner distance falloff for meter-scale world`.
+
+export type DistanceModel = {
+  /** Full volume within this radius (metres). */
+  readonly refDistance: number;
+  /** Falloff steepness beyond refDistance. */
+  readonly rolloffFactor: number;
+  /** Distance is clamped here, so far sources settle to a constant floor. */
+  readonly maxDistance: number;
+};
+
+export const SPATIAL_DISTANCE_MODEL: DistanceModel = {
+  refDistance: 4,
+  rolloffFactor: 0.5,
+  maxDistance: 200,
+};
+
+/**
+ * Web Audio 'inverse' distance gain (0..1), matching the PannerNode config so an
+ * ambisonic source attenuates exactly like an HRTF-panned one. At/inside
+ * refDistance the gain is 1; beyond it falls as refDistance / (refDistance +
+ * rolloffFactor * (clamp(distance, refDistance, maxDistance) - refDistance)).
+ */
+export function inverseDistanceGain(
+  distance: number,
+  model: DistanceModel = SPATIAL_DISTANCE_MODEL,
+): number {
+  const { refDistance, rolloffFactor, maxDistance } = model;
+  if (!Number.isFinite(distance) || distance <= refDistance) {
+    return 1;
+  }
+  const clamped = Math.min(distance, maxDistance);
+  return refDistance / (refDistance + rolloffFactor * (clamped - refDistance));
+}
+
+/** Euclidean distance between two 3D positions; missing/short vectors → 0 (co-located). */
+export function distanceBetween(
+  a?: readonly number[] | null,
+  b?: readonly number[] | null,
+): number {
+  if (!a || !b || a.length < 3 || b.length < 3) {
+    return 0;
+  }
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  const dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -563,6 +563,37 @@ describe('GMCPClientMedia', () => {
     expect(renderer.cleanup).toHaveBeenCalledOnce();
   });
 
+  it('attenuates positioned ambisonic playback when Cacophony stores no stereo position', async () => {
+    const renderer = {
+      attachPlayback: vi.fn(),
+      cleanup: vi.fn(),
+      setRotationMatrixFromYaw: vi.fn(),
+      setDistanceGain: vi.fn(),
+    };
+    mockAmbisonicRendererCreate.mockResolvedValue(renderer);
+    const sound = createMockSound('https://media.example/show.ogg');
+    const setPosition = vi.fn();
+    Object.defineProperty(sound, 'position', {
+      configurable: true,
+      get: () => [0, 0, 0],
+      set: setPosition,
+    });
+    mockCreateSound.mockResolvedValue(sound);
+
+    await handler.handlePlay({
+      key: 'show-1',
+      name: 'show.ogg',
+      position: [0, 0, 10],
+      type: 'sound',
+      upmix: 'ambisonic',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+
+    expect(setPosition).toHaveBeenCalledWith([0, 0, 10]);
+    expect(renderer.setDistanceGain).toHaveBeenCalledOnce();
+    expect(renderer.setDistanceGain.mock.calls[0][0]).toBeCloseTo(4 / 7);
+  });
+
   it('preserves omitted listener position and orientation fields', () => {
     client.media.cacophony.listenerPosition = [9, 8, 7];
     client.media.cacophony.listenerForwardOrientation = [0, 0, -1];

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../audio/AmbisonicRenderer', () => ({
   },
 }));
 
+import { MediaService } from '../../audio/MediaService';
 import {
   GMCPClientMedia,
   type GMCPMessageClientMediaListenerOrientation,
@@ -19,7 +20,6 @@ import {
   type GMCPMessageClientMediaStop,
   type GMCPMessageClientMediaUpdate,
 } from './Media';
-import { MediaService } from '../../audio/MediaService';
 
 type MockCacophony = ConstructorParameters<typeof MediaService>[0];
 
@@ -191,6 +191,7 @@ describe('GMCPClientMedia', () => {
       attachPlayback: vi.fn(),
       cleanup: vi.fn(),
       setRotationMatrixFromYaw: vi.fn(),
+      setDistanceGain: vi.fn(),
     });
     client = createMockClient();
     handler = new GMCPClientMedia(client as never);
@@ -357,6 +358,7 @@ describe('GMCPClientMedia', () => {
         attachPlayback: vi.fn(),
         cleanup: vi.fn(),
         setRotationMatrixFromYaw: vi.fn(),
+        setDistanceGain: vi.fn(),
       };
       mockAmbisonicRendererCreate.mockResolvedValue(renderer);
       const sound = createMockSound('https://media.example/amb.ogg');


### PR DESCRIPTION
## Summary

Adds distance-aware attenuation for ambisonic media playback so positioned ambisonic sources fall off consistently with HRTF-panned sources.

The branch introduces a shared inverse-distance model, applies it through the ambisonic renderer pre-encoder gain path, and keeps listener yaw/distance updates synchronized through `MediaService`.

## Review Fix

The follow-up commit fixes the stereo-created ambisonic route by retaining the raw media payload position on `ExtendedSound`. Cacophony's stereo `Sound.position` getter can report `[0, 0, 0]`, so ambisonic distance gain now reads the retained media position instead of round-tripping through Cacophony's HRTF-only position state.

## Validation

- `npm test -- src/audio/AmbisonicRenderer.test.ts src/audio/distanceModel.test.ts src/gmcp/Client/Media.test.ts`
- `npm run typecheck`
- `npx biome check src/audio/MediaService.ts src/gmcp/Client/Media.test.ts`
- `git diff --check`
- precommit hook on `ae921e3`: `npm run typecheck && npm run lint:staged`