### PR TITLE
[codex] Fix keyboard shortcut handling

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,6 +7,7 @@ const {
   mockEnsurePushSubscription,
   mockHapticsRuntimes,
   mockPreferences,
+  mockReviewRecentOutputLine,
   mockSwitchToTab,
 } = vi.hoisted(() => {
   const mockClient = {
@@ -44,6 +45,7 @@ const {
       haptics: { enabled: false },
       midi: { enabled: false },
     },
+    mockReviewRecentOutputLine: vi.fn(),
     mockSwitchToTab: vi.fn(),
   };
 });
@@ -93,7 +95,12 @@ vi.mock('./components/input', () => ({
 vi.mock('./components/output', async () => {
   const ReactModule = await vi.importActual<typeof import('react')>('react');
   return {
-    default: ReactModule.forwardRef(() => <div data-testid="output" />),
+    default: ReactModule.forwardRef((_props, ref) => {
+      ReactModule.useImperativeHandle(ref, () => ({
+        reviewRecentOutputLine: mockReviewRecentOutputLine,
+      }));
+      return <div data-testid="output" />;
+    }),
   };
 });
 
@@ -227,6 +234,13 @@ describe('App haptics backend lifecycle', () => {
     expect(mockHapticsRuntimes[0].emergencyStop).toHaveBeenCalledOnce();
 
     fireEvent.keyDown(document, { ctrlKey: true, key: '1' });
+    expect(mockReviewRecentOutputLine).toHaveBeenCalledWith(1);
+    expect(mockSwitchToTab).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(document, { ctrlKey: true, key: '0' });
+    expect(mockReviewRecentOutputLine).toHaveBeenCalledWith(10);
+
+    fireEvent.keyDown(document, { ctrlKey: true, key: '1', shiftKey: true });
     expect(mockSwitchToTab).toHaveBeenCalledWith(0);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,17 +44,39 @@ function getRoomSubtitle(roomInfo: GMCPMessageRoomInfo): string | undefined {
   return roomInfo.name || roomInfo.area || undefined;
 }
 
-function getSidebarShortcutIndex(event: KeyboardEvent): number | null {
-  if (!event.ctrlKey) {
-    return null;
-  }
-
+function getShortcutDigit(event: KeyboardEvent): number | null {
   const digit = Number.parseInt(event.key, 10);
-  if (Number.isNaN(digit) || digit < 1 || digit > 9) {
+  if (Number.isNaN(digit) || digit < 0 || digit > 9) {
     return null;
   }
 
-  return digit - 1;
+  return digit;
+}
+
+function getOutputReviewLineNumber(event: KeyboardEvent): number | null {
+  if (!event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+    return null;
+  }
+
+  const digit = getShortcutDigit(event);
+  if (digit === null) {
+    return null;
+  }
+
+  return digit === 0 ? 10 : digit;
+}
+
+function getSidebarShortcutIndex(event: KeyboardEvent): number | null {
+  if (!event.ctrlKey || !event.shiftKey || event.altKey || event.metaKey) {
+    return null;
+  }
+
+  const digit = getShortcutDigit(event);
+  if (digit === null) {
+    return null;
+  }
+
+  return (digit === 0 ? 10 : digit) - 1;
 }
 
 function App() {
@@ -115,12 +137,19 @@ function App() {
         hapticsRuntimeRef.current?.emergencyStop();
       }
 
+      const outputReviewLineNumber = getOutputReviewLineNumber(event);
+      if (outputReviewLineNumber !== null) {
+        event.preventDefault();
+        outRef.current?.reviewRecentOutputLine(outputReviewLineNumber);
+        return;
+      }
+
       if (showSidebar) {
         const targetIndex = getSidebarShortcutIndex(event);
         if (targetIndex !== null) {
           event.preventDefault();
           console.log(
-            `App: Detected CTRL+${targetIndex + 1}, calling switchToTab(${targetIndex})`,
+            `App: Detected CTRL+SHIFT+${targetIndex + 1}, calling switchToTab(${targetIndex})`,
           );
           sidebarRef.current?.switchToTab(targetIndex);
         }

--- a/src/components/input.test.tsx
+++ b/src/components/input.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, createEvent } from '@testing-library/react';
 import CommandInput from './input';
 import { CommandHistory } from '../CommandHistory';
 
@@ -120,6 +120,29 @@ describe('CommandInput Component', () => {
       fireEvent.keyDown(textarea, { key: 'ArrowUp' });
       fireEvent.keyDown(textarea, { key: 'ArrowDown' });
     }).not.toThrow();
+  });
+
+  it('only suppresses plain Alt navigation keys', () => {
+    render(<CommandInput onSend={onSendMock} inputRef={inputRef} />);
+
+    const textarea = screen.getByRole('textbox');
+    const plainAltArrow = createEvent.keyDown(textarea, {
+      altKey: true,
+      code: 'ArrowLeft',
+      key: 'ArrowLeft',
+    });
+    const metaAltArrow = createEvent.keyDown(textarea, {
+      altKey: true,
+      code: 'ArrowLeft',
+      key: 'ArrowLeft',
+      metaKey: true,
+    });
+
+    fireEvent(textarea, plainAltArrow);
+    fireEvent(textarea, metaAltArrow);
+
+    expect(plainAltArrow.defaultPrevented).toBe(true);
+    expect(metaAltArrow.defaultPrevented).toBe(false);
   });
   
   it('loads command history from localStorage on mount', () => {

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -109,6 +109,7 @@ const CommandInput = ({ onSend, inputRef }: Props) => {
     const commandHistory = commandHistoryRef.current;
     const currentInputText = text;
     const textArea = inputRef.current;
+    const isPlainAlt = e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
 
     if (e.key === "Tab") {
       // e.preventDefault(); // Remove from here
@@ -206,13 +207,13 @@ const CommandInput = ({ onSend, inputRef }: Props) => {
     } else if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
-    } else if (e.altKey && (
+    } else if (isPlainAlt && (
       e.key === "ArrowUp" || e.key === "ArrowDown" || e.key === "ArrowLeft" || e.key === "ArrowRight" ||
       "ijklwasdchtnoe,".includes(e.key.toLowerCase()) ||
       "IJKLWASDCHTNOE".split("").some(c => e.code === `Key${c}`) || e.code === "Comma"
     )) {
       e.preventDefault();
-    } else if (e.altKey && e.code === "Space") {
+    } else if (isPlainAlt && e.code === "Space") {
       e.preventDefault();
     } else if (e.key === "ArrowUp") {
       e.preventDefault();

--- a/src/components/output.test.tsx
+++ b/src/components/output.test.tsx
@@ -2,7 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 import type React from "react";
 
 import type MudClient from "../client";
-import Output from "./output";
+import Output, { type OutputLine, OutputType } from "./output";
+
+const { mockAnnounce } = vi.hoisted(() => ({
+  mockAnnounce: vi.fn(),
+}));
+
+vi.mock("@react-aria/live-announcer", () => ({
+  announce: mockAnnounce,
+}));
 
 const makeKeyboardEvent = (
   init: Pick<React.KeyboardEvent<HTMLDivElement>, "altKey" | "code" | "key"> &
@@ -18,6 +26,35 @@ const makeKeyboardEvent = (
 } as unknown as React.KeyboardEvent<HTMLDivElement>);
 
 describe("Output keyboard handling", () => {
+  it("reviews recent output lines from the end", () => {
+    const output = new Output({ client: {} as MudClient });
+    const lines: OutputLine[] = [
+      {
+        content: <div>first line</div>,
+        id: 1,
+        sourceContent: "first line",
+        sourceType: "test",
+        type: OutputType.ServerMessage,
+      },
+      {
+        content: <div>second line</div>,
+        id: 2,
+        sourceContent: "second line",
+        sourceType: "test",
+        type: OutputType.ServerMessage,
+      },
+    ];
+    Object.defineProperty(output, "allLines", { value: lines });
+
+    output.reviewRecentOutputLine(1);
+    output.reviewRecentOutputLine(2);
+    output.reviewRecentOutputLine(3);
+
+    expect(mockAnnounce).toHaveBeenNthCalledWith(1, "second line", "polite");
+    expect(mockAnnounce).toHaveBeenNthCalledWith(2, "first line", "polite");
+    expect(mockAnnounce).toHaveBeenNthCalledWith(3, "No line", "polite");
+  });
+
   it("only suppresses plain Alt navigation keys", () => {
     const output = new Output({ client: {} as MudClient });
     const plainAltArrow = makeKeyboardEvent({

--- a/src/components/output.test.tsx
+++ b/src/components/output.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import type React from "react";
+
+import type MudClient from "../client";
+import Output from "./output";
+
+const makeKeyboardEvent = (
+  init: Pick<React.KeyboardEvent<HTMLDivElement>, "altKey" | "code" | "key"> &
+    Partial<Pick<React.KeyboardEvent<HTMLDivElement>, "ctrlKey" | "metaKey" | "shiftKey">>
+): React.KeyboardEvent<HTMLDivElement> => ({
+  altKey: init.altKey,
+  code: init.code,
+  ctrlKey: init.ctrlKey ?? false,
+  key: init.key,
+  metaKey: init.metaKey ?? false,
+  preventDefault: vi.fn(),
+  shiftKey: init.shiftKey ?? false,
+} as unknown as React.KeyboardEvent<HTMLDivElement>);
+
+describe("Output keyboard handling", () => {
+  it("only suppresses plain Alt navigation keys", () => {
+    const output = new Output({ client: {} as MudClient });
+    const plainAltArrow = makeKeyboardEvent({
+      altKey: true,
+      code: "ArrowLeft",
+      key: "ArrowLeft",
+    });
+    const metaAltArrow = makeKeyboardEvent({
+      altKey: true,
+      code: "ArrowLeft",
+      key: "ArrowLeft",
+      metaKey: true,
+    });
+
+    output.handleOutputKeyDown(plainAltArrow);
+    output.handleOutputKeyDown(metaAltArrow);
+
+    expect(plainAltArrow.preventDefault).toHaveBeenCalled();
+    expect(metaAltArrow.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/output.tsx
+++ b/src/components/output.tsx
@@ -749,6 +749,25 @@ scrollToBottom = () => { const output = this.outputRef.current; if (output) {
     announce(textContent, 'polite');
   };
 
+  reviewRecentOutputLine = (lineNumber: number) => {
+    const visibleOutput = this.allLines.filter(
+      line => this.state.localEchoActive || line.type !== OutputType.Command
+    );
+
+    if (visibleOutput.length === 0) {
+      announce("No output", "polite");
+      return;
+    }
+
+    const line = visibleOutput[visibleOutput.length - lineNumber];
+    if (!line) {
+      announce("No line", "polite");
+      return;
+    }
+
+    this.announceOutputLine(line);
+  };
+
   /**
    * Handle focus on output area
    */

--- a/src/components/output.tsx
+++ b/src/components/output.tsx
@@ -667,9 +667,11 @@ scrollToBottom = () => { const output = this.outputRef.current; if (output) {
    * Handle keyboard navigation through output lines
    */
   handleOutputKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const isPlainAlt = e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+
     // Suppress Alt+Arrow and Alt+letter so browser defaults
     // don't interfere with app-level keybindings
-    if (e.altKey && (
+    if (isPlainAlt && (
       e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight' ||
       'ijklwasdchtnoe,'.includes(e.key.toLowerCase()) ||
       'IJKLWASDCHTNOE'.split('').some(c => e.code === `Key${c}`) || e.code === 'Comma'
@@ -677,7 +679,7 @@ scrollToBottom = () => { const output = this.outputRef.current; if (output) {
       e.preventDefault();
       return;
     }
-    if (e.altKey && e.code === 'Space') {
+    if (isPlainAlt && e.code === 'Space') {
       e.preventDefault();
       return;
     }

--- a/src/hooks/useChannelHistory.test.tsx
+++ b/src/hooks/useChannelHistory.test.tsx
@@ -29,7 +29,9 @@ class FakeClient {
   }
 
   emit(eventName: string, payload: unknown): void {
-    this.listeners.get(eventName)?.forEach(listener => listener(payload));
+    this.listeners.get(eventName)?.forEach(listener => {
+      listener(payload);
+    });
   }
 
   listenerCount(eventName: string): number {
@@ -45,6 +47,17 @@ const makeMessages = (count: number) =>
     message: `message ${index}`,
     timestamp: index,
   }));
+
+const dispatchKeyboardEvent = (init: KeyboardEventInit): KeyboardEvent => {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+
+  document.dispatchEvent(event);
+  return event;
+};
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -218,6 +231,61 @@ describe("useChannelHistory", () => {
     expect(result.current.buffers.get("all")?.messages[0]?.message).toBe("message 10");
     expect(result.current.buffers.get("gossip")?.messages).toHaveLength(MAX_CHANNEL_BUFFER_MESSAGES);
     expect(result.current.buffers.get("gossip")?.messages[0]?.message).toBe("message 10");
+  });
+
+  it("handles plain Alt+Arrow buffer navigation", () => {
+    const client = new FakeClient();
+    const { result } = renderHook(() => useChannelHistory(asMudClient(client)));
+
+    act(() => {
+      client.emit("channelText", { channel: "gossip", talker: "Reader", text: "one" });
+    });
+
+    expect(result.current.bufferOrder).toEqual(["all", "gossip"]);
+    expect(result.current.currentBufferIndex).toBe(0);
+
+    let event = dispatchKeyboardEvent({});
+    act(() => {
+      event = dispatchKeyboardEvent({ altKey: true, key: "ArrowRight" });
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(result.current.currentBufferIndex).toBe(1);
+  });
+
+  it("does not handle Alt+Arrow when another modifier is also pressed", () => {
+    const client = new FakeClient();
+    const { result } = renderHook(() => useChannelHistory(asMudClient(client)));
+
+    act(() => {
+      client.emit("channelText", { channel: "gossip", talker: "Reader", text: "one" });
+    });
+
+    let event = dispatchKeyboardEvent({});
+    act(() => {
+      event = dispatchKeyboardEvent({ altKey: true, key: "ArrowRight", metaKey: true });
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(result.current.currentBufferIndex).toBe(0);
+  });
+
+  it("handles plain Alt+Arrow message navigation", () => {
+    const client = new FakeClient();
+    const { result } = renderHook(() => useChannelHistory(asMudClient(client)));
+
+    act(() => {
+      client.emit("channelText", { channel: "gossip", talker: "Reader", text: "one" });
+      client.emit("channelText", { channel: "gossip", talker: "Reader", text: "two" });
+    });
+
+    let event = dispatchKeyboardEvent({});
+    act(() => {
+      event = dispatchKeyboardEvent({ altKey: true, key: "ArrowUp" });
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(result.current.buffers.get("all")?.currentIndex).toBe(2);
   });
 });
 

--- a/src/hooks/useChannelHistory.tsx
+++ b/src/hooks/useChannelHistory.tsx
@@ -446,6 +446,7 @@ export const useChannelHistory = (client: MudClient | null) => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const now = Date.now();
       const key = `${e.altKey ? "alt+" : ""}${e.ctrlKey ? "ctrl+" : ""}${e.shiftKey ? "shift+" : ""}${e.key}`;
+      const isPlainAlt = e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
 
       let pressCount = 1;
       if (lastKeyPress.current && lastKeyPress.current.key === key && now - lastKeyPress.current.time < 500) {
@@ -455,25 +456,25 @@ export const useChannelHistory = (client: MudClient | null) => {
       lastKeyPress.current = { key, time: now, count: pressCount };
 
       // Alt+Arrow keys: always work regardless of scheme
-      if (e.key === "ArrowLeft" && e.altKey && !e.ctrlKey && !e.shiftKey) {
+      if (e.key === "ArrowLeft" && isPlainAlt) {
         e.preventDefault();
         changeBuffer(-1);
         return;
       }
 
-      if (e.key === "ArrowRight" && e.altKey && !e.ctrlKey && !e.shiftKey) {
+      if (e.key === "ArrowRight" && isPlainAlt) {
         e.preventDefault();
         changeBuffer(1);
         return;
       }
 
-      if (e.altKey && !e.ctrlKey && !e.shiftKey && e.key === "ArrowUp") {
+      if (isPlainAlt && e.key === "ArrowUp") {
         e.preventDefault();
         navigateMessage(-1);
         return;
       }
 
-      if (e.altKey && !e.ctrlKey && !e.shiftKey && e.key === "ArrowDown") {
+      if (isPlainAlt && e.key === "ArrowDown") {
         e.preventDefault();
         navigateMessage(1);
         return;
@@ -483,20 +484,20 @@ export const useChannelHistory = (client: MudClient | null) => {
       const scheme = usePreferences.getState().keyboard.navigationKeyScheme;
       const navKeys = navigationKeyMaps[scheme];
 
-      if (matchesNavKey(e, navKeys.left) && e.altKey && !e.ctrlKey && !e.shiftKey) {
+      if (matchesNavKey(e, navKeys.left) && isPlainAlt) {
         e.preventDefault();
         changeBuffer(-1);
         return;
       }
 
-      if (matchesNavKey(e, navKeys.right) && e.altKey && !e.ctrlKey && !e.shiftKey) {
+      if (matchesNavKey(e, navKeys.right) && isPlainAlt) {
         e.preventDefault();
         changeBuffer(1);
         return;
       }
 
       // Alt+1-0: Read from current buffer
-      if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+      if (isPlainAlt) {
         const digit = getDigit(e);
         if (digit !== null) {
           e.preventDefault();
@@ -537,13 +538,13 @@ export const useChannelHistory = (client: MudClient | null) => {
       }
 
       // Alt+letter: Navigate within buffer (using configured key scheme)
-      if (e.altKey && !e.ctrlKey && !e.shiftKey && matchesNavKey(e, navKeys.up)) {
+      if (isPlainAlt && matchesNavKey(e, navKeys.up)) {
         e.preventDefault();
         navigateMessage(-1);
         return;
       }
 
-      if (e.altKey && !e.ctrlKey && !e.shiftKey && matchesNavKey(e, navKeys.down)) {
+      if (isPlainAlt && matchesNavKey(e, navKeys.down)) {
         e.preventDefault();
         navigateMessage(1);
         return;
@@ -576,7 +577,7 @@ export const useChannelHistory = (client: MudClient | null) => {
       }
 
       // Alt+Space: Repeat current message
-      if (e.altKey && !e.shiftKey && e.key === " ") {
+      if (isPlainAlt && e.key === " ") {
         e.preventDefault();
         navigateMessage(0);
         return;


### PR DESCRIPTION
## Summary

- Tighten Alt navigation handling so the app only consumes plain Alt navigation chords, not Alt plus extra modifiers.
- Add output review shortcuts: Ctrl+1 through Ctrl+0 now read the last 1 through 10 output lines.
- Move sidebar tab switching to Ctrl+Shift+1 through Ctrl+Shift+0.

## Root Cause

The global channel-history handler and focused input/output suppressors treated some Alt chords too broadly. Separately, Ctrl+number was already reserved for sidebar tab switching, leaving no direct shortcut for reviewing recent output lines.

## Validation

- `npm test -- --run src/hooks/useChannelHistory.test.tsx src/components/input.test.tsx src/components/output.test.tsx src/App.test.tsx`
- `npm run typecheck`
- `git diff --check` on touched files
- Precommit hooks ran during both commits; typecheck passed. Biome reported existing warnings in `App.tsx` and `output.tsx`, but did not block.