### PR TITLE
Add timezone and browser location MCP sync preferences

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -27,7 +27,7 @@ const {
       };
     }),
     mockPreferencesState: {
-      general: { localEcho: false },
+      general: { localEcho: false, syncTimezoneToServer: true },
       midi: { enabled: false },
       sound: { muteInBackground: false, volume: 1 },
       speech: {

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -27,7 +27,11 @@ const {
       };
     }),
     mockPreferencesState: {
-      general: { localEcho: false, syncTimezoneToServer: true },
+      general: {
+        localEcho: false,
+        syncTimezoneToServer: true,
+        syncLocationToServer: false,
+      },
       midi: { enabled: false },
       sound: { muteInBackground: false, volume: 1 },
       speech: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,6 +69,7 @@ class MudClient {
   private _autosay: boolean = false;
   private connectionCleanupComplete: boolean = true;
   private shutdownComplete: boolean = false;
+  private cleanupCallbacks: Array<() => void> = [];
 
   get autosay(): boolean {
     return this._autosay;
@@ -247,6 +248,10 @@ class MudClient {
     }
   }
 
+  registerCleanup(callback: () => void): void {
+    this.cleanupCallbacks.push(callback);
+  }
+
   private cleanupConnection(): void {
     if (this.connectionCleanupComplete) return;
     this.connectionCleanupComplete = true;
@@ -345,6 +350,9 @@ An MCP message consists of three parts: the name of the message, the authenticat
   shutdown() {
     if (this.shutdownComplete) return;
     this.shutdownComplete = true;
+    for (const callback of this.cleanupCallbacks.splice(0)) {
+      callback();
+    }
 
     this.mcpSession.shutdown();
     this.gmcp.shutdown();

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -9,16 +9,32 @@ const GeneralTab: React.FC = () => {
   const state = usePreferences();
 
   return (
-    <label>
-      <input
-        type="checkbox"
-        checked={state.general.localEcho}
-        onChange={(e) =>
-          state.setGeneral({ ...state.general, localEcho: e.target.checked })
-        }
-      />
-      Local Echo
-    </label>
+    <div>
+      <label>
+        <input
+          type="checkbox"
+          checked={state.general.localEcho}
+          onChange={(e) =>
+            state.setGeneral({ ...state.general, localEcho: e.target.checked })
+          }
+        />
+        Local Echo
+      </label>
+      <br />
+      <label>
+        <input
+          type="checkbox"
+          checked={state.general.syncTimezoneToServer}
+          onChange={(e) =>
+            state.setGeneral({
+              ...state.general,
+              syncTimezoneToServer: e.target.checked,
+            })
+          }
+        />
+        Sync timezone to server
+      </label>
+    </div>
   );
 };
 

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -34,6 +34,20 @@ const GeneralTab: React.FC = () => {
         />
         Sync timezone to server
       </label>
+      <br />
+      <label>
+        <input
+          type="checkbox"
+          checked={state.general.syncLocationToServer}
+          onChange={(e) =>
+            state.setGeneral({
+              ...state.general,
+              syncLocationToServer: e.target.checked,
+            })
+          }
+        />
+        Sync browser location to server
+      </label>
     </div>
   );
 };

--- a/src/createConfiguredClient.test.ts
+++ b/src/createConfiguredClient.test.ts
@@ -279,6 +279,7 @@ describe("createConfiguredClient", () => {
       syncLocationToServer: true,
     });
     client = createConfiguredClient();
+    vi.spyOn(client, "connected", "get").mockReturnValue(true);
     const sent: string[] = [];
     vi.spyOn(client, "send").mockImplementation((line: string) => {
       sent.push(line);
@@ -300,6 +301,98 @@ describe("createConfiguredClient", () => {
           line.includes("lon: -104.9903"),
       ),
     ).toBe(true);
+  });
+
+  it("does not send browser location if syncLocationToServer is disabled before geolocation resolves", () => {
+    let resolvePosition: PositionCallback | undefined;
+    const getCurrentPosition = vi.fn((success: PositionCallback) => {
+      resolvePosition = success;
+    });
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: {
+        getCurrentPosition,
+      } as Geolocation,
+    });
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: true,
+    });
+    client = createConfiguredClient();
+    vi.spyOn(client, "connected", "get").mockReturnValue(true);
+    const sent: string[] = [];
+    vi.spyOn(client, "send").mockImplementation((line: string) => {
+      sent.push(line);
+    });
+
+    client.mcpSession.receiveLine("#$#MCP version: 2.1 to: 2.1");
+    const authKey = sent[0]?.match(/authentication-key: (\S+)/)?.[1];
+    expect(authKey).toBeTruthy();
+    sent.length = 0;
+
+    client.mcpSession.receiveLine(`#$#mcp-negotiate-end ${authKey}`);
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: false,
+    });
+    if (!resolvePosition) {
+      throw new Error("Expected browser geolocation to be requested");
+    }
+    resolvePosition({
+      coords: {
+        latitude: 39.7392,
+        longitude: -104.9903,
+      },
+    } as GeolocationPosition);
+
+    expect(getCurrentPosition).toHaveBeenCalledOnce();
+    expect(sent.some((line) => line.includes("#$#world.mongoose.location"))).toBe(false);
+  });
+
+  it("does not send browser location if the client disconnects before geolocation resolves", () => {
+    let resolvePosition: PositionCallback | undefined;
+    const getCurrentPosition = vi.fn((success: PositionCallback) => {
+      resolvePosition = success;
+    });
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: {
+        getCurrentPosition,
+      } as Geolocation,
+    });
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: true,
+    });
+    client = createConfiguredClient();
+    const connected = vi.spyOn(client, "connected", "get").mockReturnValue(true);
+    const sent: string[] = [];
+    vi.spyOn(client, "send").mockImplementation((line: string) => {
+      sent.push(line);
+    });
+
+    client.mcpSession.receiveLine("#$#MCP version: 2.1 to: 2.1");
+    const authKey = sent[0]?.match(/authentication-key: (\S+)/)?.[1];
+    expect(authKey).toBeTruthy();
+    sent.length = 0;
+
+    client.mcpSession.receiveLine(`#$#mcp-negotiate-end ${authKey}`);
+    connected.mockReturnValue(false);
+    if (!resolvePosition) {
+      throw new Error("Expected browser geolocation to be requested");
+    }
+    resolvePosition({
+      coords: {
+        latitude: 39.7392,
+        longitude: -104.9903,
+      },
+    } as GeolocationPosition);
+
+    expect(getCurrentPosition).toHaveBeenCalledOnce();
+    expect(sent.some((line) => line.includes("#$#world.mongoose.location"))).toBe(false);
   });
 
   it("does not request browser location when syncLocationToServer is disabled", () => {

--- a/src/createConfiguredClient.test.ts
+++ b/src/createConfiguredClient.test.ts
@@ -4,6 +4,7 @@ import type MudClient from "./client";
 import { createConfiguredClient } from "./createConfiguredClient";
 import { useInputStore } from "./stores/inputStore";
 import { useItemsStore } from "./stores/itemsStore";
+import { usePreferences } from "./stores/preferencesStore";
 import { useServerLinksStore } from "./stores/serverLinksStore";
 import { useSkillsStore } from "./stores/skillsStore";
 import { useUserlistStore } from "./stores/userlistStore";
@@ -28,6 +29,7 @@ describe("createConfiguredClient", () => {
     useCharacterStatusStore.getState().reset();
     useChannelHistoryStore.getState().reset();
     useConnectionStore.getState().reset();
+    usePreferences.getState().setGeneral({ localEcho: false, syncTimezoneToServer: true });
     useInputStore.getState().clear();
     useInputStore.getState().resetCommands();
     useItemsStore.getState().reset();
@@ -198,7 +200,13 @@ describe("createConfiguredClient", () => {
 
     client.mcpSession.receiveLine(`#$#mcp-negotiate-end ${authKey}`);
 
-    expect(sent.some((line) => line.includes("#$#dns-com-awns-timezone"))).toBe(true);
+    expect(
+      sent.some((line) =>
+        line.includes(
+          `#$#dns-com-awns-timezone ${authKey} timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"}`,
+        ),
+      ),
+    ).toBe(true);
     expect(sent.some((line) => line.includes(`#$#dns-com-awns-serverinfo-get ${authKey}`))).toBe(
       true,
     );
@@ -212,6 +220,27 @@ describe("createConfiguredClient", () => {
       true,
     );
     expect(sent.some((line) => line.includes(`#$#dns-com-awns-visual-getusers ${authKey}`))).toBe(
+      true,
+    );
+  });
+
+  it("does not send timezone when syncTimezoneToServer is disabled", () => {
+    usePreferences.getState().setGeneral({ localEcho: false, syncTimezoneToServer: false });
+    client = createConfiguredClient();
+    const sent: string[] = [];
+    vi.spyOn(client, "send").mockImplementation((line: string) => {
+      sent.push(line);
+    });
+
+    client.mcpSession.receiveLine("#$#MCP version: 2.1 to: 2.1");
+    const authKey = sent[0]?.match(/authentication-key: (\S+)/)?.[1];
+    expect(authKey).toBeTruthy();
+    sent.length = 0;
+
+    client.mcpSession.receiveLine(`#$#mcp-negotiate-end ${authKey}`);
+
+    expect(sent.some((line) => line.includes("#$#dns-com-awns-timezone"))).toBe(false);
+    expect(sent.some((line) => line.includes(`#$#dns-com-awns-serverinfo-get ${authKey}`))).toBe(
       true,
     );
   });

--- a/src/createConfiguredClient.test.ts
+++ b/src/createConfiguredClient.test.ts
@@ -22,6 +22,7 @@ vi.mock("cacophony", () => ({
 
 describe("createConfiguredClient", () => {
   let client: MudClient | undefined;
+  const originalGeolocation = globalThis.navigator.geolocation;
 
   afterEach(() => {
     client?.shutdown();
@@ -29,7 +30,15 @@ describe("createConfiguredClient", () => {
     useCharacterStatusStore.getState().reset();
     useChannelHistoryStore.getState().reset();
     useConnectionStore.getState().reset();
-    usePreferences.getState().setGeneral({ localEcho: false, syncTimezoneToServer: true });
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: originalGeolocation,
+    });
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: false,
+    });
     useInputStore.getState().clear();
     useInputStore.getState().resetCommands();
     useItemsStore.getState().reset();
@@ -225,7 +234,11 @@ describe("createConfiguredClient", () => {
   });
 
   it("does not send timezone when syncTimezoneToServer is disabled", () => {
-    usePreferences.getState().setGeneral({ localEcho: false, syncTimezoneToServer: false });
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: false,
+      syncLocationToServer: false,
+    });
     client = createConfiguredClient();
     const sent: string[] = [];
     vi.spyOn(client, "send").mockImplementation((line: string) => {
@@ -243,5 +256,79 @@ describe("createConfiguredClient", () => {
     expect(sent.some((line) => line.includes(`#$#dns-com-awns-serverinfo-get ${authKey}`))).toBe(
       true,
     );
+  });
+
+  it("sends browser location when syncLocationToServer is enabled", () => {
+    const getCurrentPosition = vi.fn((success: PositionCallback) => {
+      success({
+        coords: {
+          latitude: 39.7392,
+          longitude: -104.9903,
+        },
+      } as GeolocationPosition);
+    });
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: {
+        getCurrentPosition,
+      } as Geolocation,
+    });
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: true,
+    });
+    client = createConfiguredClient();
+    const sent: string[] = [];
+    vi.spyOn(client, "send").mockImplementation((line: string) => {
+      sent.push(line);
+    });
+
+    client.mcpSession.receiveLine("#$#MCP version: 2.1 to: 2.1");
+    const authKey = sent[0]?.match(/authentication-key: (\S+)/)?.[1];
+    expect(authKey).toBeTruthy();
+    sent.length = 0;
+
+    client.mcpSession.receiveLine(`#$#mcp-negotiate-end ${authKey}`);
+
+    expect(getCurrentPosition).toHaveBeenCalledOnce();
+    expect(
+      sent.some(
+        (line) =>
+          line.startsWith(`#$#world.mongoose.location ${authKey} `) &&
+          line.includes("lat: 39.7392") &&
+          line.includes("lon: -104.9903"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not request browser location when syncLocationToServer is disabled", () => {
+    const getCurrentPosition = vi.fn();
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: {
+        getCurrentPosition,
+      } as Geolocation,
+    });
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: false,
+    });
+    client = createConfiguredClient();
+    const sent: string[] = [];
+    vi.spyOn(client, "send").mockImplementation((line: string) => {
+      sent.push(line);
+    });
+
+    client.mcpSession.receiveLine("#$#MCP version: 2.1 to: 2.1");
+    const authKey = sent[0]?.match(/authentication-key: (\S+)/)?.[1];
+    expect(authKey).toBeTruthy();
+    sent.length = 0;
+
+    client.mcpSession.receiveLine(`#$#mcp-negotiate-end ${authKey}`);
+
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+    expect(sent.some((line) => line.includes("#$#world.mongoose.location"))).toBe(false);
   });
 });

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -71,7 +71,7 @@ function syncTimezoneToServer(timezonePackage?: McpAwnsTimezone): void {
   timezonePackage.sendTimezone({ timezone: getLocalTimezoneIdentifier() });
 }
 
-function syncLocationToServer(locationPackage?: McpWorldMongooseLocation): void {
+function syncLocationToServer(client: MudClient, locationPackage?: McpWorldMongooseLocation): void {
   if (!locationPackage) {
     return;
   }
@@ -84,6 +84,12 @@ function syncLocationToServer(locationPackage?: McpWorldMongooseLocation): void 
   }
   geolocation.getCurrentPosition(
     (position) => {
+      if (!usePreferences.getState().general.syncLocationToServer) {
+        return;
+      }
+      if (!client.connected) {
+        return;
+      }
       locationPackage.sendLocation({
         lat: position.coords.latitude,
         lon: position.coords.longitude,
@@ -255,7 +261,7 @@ export function createConfiguredClient(): MudClient {
       nextGeneralPreferences.syncLocationToServer &&
       client.connected
     ) {
-      syncLocationToServer(locationPackage);
+      syncLocationToServer(client, locationPackage);
     }
     lastGeneralPreferences = nextGeneralPreferences;
   });
@@ -263,7 +269,7 @@ export function createConfiguredClient(): MudClient {
 
   negotiatePackage?.on("end", () => {
     syncTimezoneToServer(timezonePackage);
-    syncLocationToServer(locationPackage);
+    syncLocationToServer(client, locationPackage);
     serverInfoPackage?.requestServerInfo();
     rehashPackage?.requestCommands();
     visualPackage?.requestSelf();

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -43,6 +43,7 @@ import {
   McpNegotiate,
   McpSimpleEdit,
 } from "./mcp/index";
+import { usePreferences } from "./stores/preferencesStore";
 import { useInputStore } from "./stores/inputStore";
 import { useServerLinksStore } from "./stores/serverLinksStore";
 import { useWorldMapStore } from "./stores/worldMapStore";
@@ -55,12 +56,18 @@ marked.setOptions({
   gfm: true,
 });
 
-function getLocalTimezoneAbbreviation(): string {
-  const timeZoneName =
-    new Intl.DateTimeFormat("en-US", { timeZoneName: "short" })
-      .formatToParts(new Date())
-      .find((part) => part.type === "timeZoneName")?.value ?? "";
-  return timeZoneName || "UTC";
+function getLocalTimezoneIdentifier(): string {
+  return new Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function syncTimezoneToServer(timezonePackage?: McpAwnsTimezone): void {
+  if (!timezonePackage) {
+    return;
+  }
+  if (!usePreferences.getState().general.syncTimezoneToServer) {
+    return;
+  }
+  timezonePackage.sendTimezone({ timezone: getLocalTimezoneIdentifier() });
 }
 
 /**
@@ -197,8 +204,21 @@ export function createConfiguredClient(): MudClient {
     }
   }
 
+  let lastSyncTimezonePreference = usePreferences.getState().general.syncTimezoneToServer;
+  const unsubscribeTimezonePreference = usePreferences.subscribe((state) => {
+    const nextSyncTimezonePreference = state.general.syncTimezoneToServer;
+    if (nextSyncTimezonePreference === lastSyncTimezonePreference) {
+      return;
+    }
+    lastSyncTimezonePreference = nextSyncTimezonePreference;
+    if (nextSyncTimezonePreference && client.connected) {
+      syncTimezoneToServer(timezonePackage);
+    }
+  });
+  client.registerCleanup(unsubscribeTimezonePreference);
+
   negotiatePackage?.on("end", () => {
-    timezonePackage?.sendTimezone({ timezone: getLocalTimezoneAbbreviation() });
+    syncTimezoneToServer(timezonePackage);
     serverInfoPackage?.requestServerInfo();
     rehashPackage?.requestCommands();
     visualPackage?.requestSelf();

--- a/src/createConfiguredClient.ts
+++ b/src/createConfiguredClient.ts
@@ -40,6 +40,7 @@ import {
   McpAwnsStatus,
   McpAwnsTimezone,
   McpAwnsVisual,
+  McpWorldMongooseLocation,
   McpNegotiate,
   McpSimpleEdit,
 } from "./mcp/index";
@@ -68,6 +69,35 @@ function syncTimezoneToServer(timezonePackage?: McpAwnsTimezone): void {
     return;
   }
   timezonePackage.sendTimezone({ timezone: getLocalTimezoneIdentifier() });
+}
+
+function syncLocationToServer(locationPackage?: McpWorldMongooseLocation): void {
+  if (!locationPackage) {
+    return;
+  }
+  if (!usePreferences.getState().general.syncLocationToServer) {
+    return;
+  }
+  const geolocation = globalThis.navigator?.geolocation;
+  if (!geolocation?.getCurrentPosition) {
+    return;
+  }
+  geolocation.getCurrentPosition(
+    (position) => {
+      locationPackage.sendLocation({
+        lat: position.coords.latitude,
+        lon: position.coords.longitude,
+      });
+    },
+    (error) => {
+      console.warn("Unable to read browser geolocation for MCP sync", error);
+    },
+    {
+      enableHighAccuracy: false,
+      maximumAge: 300000,
+      timeout: 10000,
+    },
+  );
 }
 
 /**
@@ -133,6 +163,7 @@ export function createConfiguredClient(): MudClient {
   let visualPackage: McpAwnsVisual | undefined;
   let rehashPackage: McpAwnsRehash | undefined;
   let timezonePackage: McpAwnsTimezone | undefined;
+  let locationPackage: McpWorldMongooseLocation | undefined;
 
   for (const PackageConstructor of DEFAULT_MCP_PACKAGES) {
     const mcpPackage = client.registerMcpPackage(PackageConstructor);
@@ -197,6 +228,9 @@ export function createConfiguredClient(): MudClient {
     if (mcpPackage instanceof McpAwnsTimezone) {
       timezonePackage = mcpPackage;
     }
+    if (mcpPackage instanceof McpWorldMongooseLocation) {
+      locationPackage = mcpPackage;
+    }
     if (mcpPackage instanceof McpAwnsStatus) {
       mcpPackage.on("statustext", (text) =>
         useConnectionStore.getState().setStatusText(text),
@@ -204,21 +238,32 @@ export function createConfiguredClient(): MudClient {
     }
   }
 
-  let lastSyncTimezonePreference = usePreferences.getState().general.syncTimezoneToServer;
-  const unsubscribeTimezonePreference = usePreferences.subscribe((state) => {
-    const nextSyncTimezonePreference = state.general.syncTimezoneToServer;
-    if (nextSyncTimezonePreference === lastSyncTimezonePreference) {
-      return;
-    }
-    lastSyncTimezonePreference = nextSyncTimezonePreference;
-    if (nextSyncTimezonePreference && client.connected) {
+  let lastGeneralPreferences = usePreferences.getState().general;
+  const unsubscribeGeneralPreferences = usePreferences.subscribe((state) => {
+    const nextGeneralPreferences = state.general;
+    if (
+      nextGeneralPreferences.syncTimezoneToServer !==
+        lastGeneralPreferences.syncTimezoneToServer &&
+      nextGeneralPreferences.syncTimezoneToServer &&
+      client.connected
+    ) {
       syncTimezoneToServer(timezonePackage);
     }
+    if (
+      nextGeneralPreferences.syncLocationToServer !==
+        lastGeneralPreferences.syncLocationToServer &&
+      nextGeneralPreferences.syncLocationToServer &&
+      client.connected
+    ) {
+      syncLocationToServer(locationPackage);
+    }
+    lastGeneralPreferences = nextGeneralPreferences;
   });
-  client.registerCleanup(unsubscribeTimezonePreference);
+  client.registerCleanup(unsubscribeGeneralPreferences);
 
   negotiatePackage?.on("end", () => {
     syncTimezoneToServer(timezonePackage);
+    syncLocationToServer(locationPackage);
     serverInfoPackage?.requestServerInfo();
     rehashPackage?.requestCommands();
     visualPackage?.requestSelf();

--- a/src/gmcp/Client/Haptics.test.ts
+++ b/src/gmcp/Client/Haptics.test.ts
@@ -29,7 +29,11 @@ const { mockHapticsService, mockPreferencesState } = vi.hoisted(() => {
       autoConnect: false,
     },
     midi: { enabled: false },
-    general: { localEcho: false },
+    general: {
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: false,
+    },
     speech: { autoreadMode: "off", voice: "", rate: 1, pitch: 1, volume: 1 },
     sound: { muteInBackground: false, volume: 1 },
     editor: { autocompleteEnabled: true, accessibilityMode: true },

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -12,6 +12,7 @@ export { DEFAULT_MCP_PACKAGES, type McpPackageConstructor } from './packages';
 export { McpAwnsDisplayUrl } from './packages/displayUrl';
 export { McpAwnsGetSet } from './packages/getSet';
 export { McpAwnsJtext } from './packages/jtext';
+export { type WorldMongooseLocation, McpWorldMongooseLocation } from './packages/location';
 export { McpNegotiate } from './packages/negotiate';
 export { McpAwnsPing } from './packages/ping';
 export { McpAwnsRehash } from './packages/rehash';

--- a/src/mcp/packages/awnsPackages.test.ts
+++ b/src/mcp/packages/awnsPackages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { McpSession } from '../session';
 import { McpAwnsDisplayUrl } from './displayUrl';
 import { McpAwnsJtext } from './jtext';
+import { McpWorldMongooseLocation } from './location';
 import { McpAwnsRehash } from './rehash';
 import { McpAwnsServerInfo } from './serverInfo';
 import { McpAwnsTimezone } from './timezone';
@@ -85,6 +86,23 @@ describe('AWNS MCP packages', () => {
     timezone.sendTimezone({ timezone: 'MST' });
 
     expect(sent).toEqual(['#$#dns-com-awns-timezone auth01 timezone: MST']);
+  });
+
+  it('sends browser location updates as package-root messages', () => {
+    const sent: string[] = [];
+    const session = new McpSession(
+      {
+        sendLine: (line) => sent.push(line),
+      },
+      () => 'auth01',
+    );
+    const location = session.registerPackage(McpWorldMongooseLocation);
+
+    session.receiveLine('#$#MCP version: 2.1 to: 2.1');
+    sent.length = 0;
+    location.sendLocation({ lat: 39.7392, lon: -104.9903 });
+
+    expect(sent).toEqual(['#$#world.mongoose.location auth01 lat: 39.7392 lon: -104.9903']);
   });
 
   it('tracks rehash command lists and abbreviation expansions', () => {

--- a/src/mcp/packages/index.ts
+++ b/src/mcp/packages/index.ts
@@ -2,6 +2,7 @@ import type { MCPPackage } from '../package';
 import { McpAwnsDisplayUrl } from './displayUrl';
 import { McpAwnsGetSet } from './getSet';
 import { McpAwnsJtext } from './jtext';
+import { McpWorldMongooseLocation } from './location';
 import { McpNegotiate } from './negotiate';
 import { McpAwnsPing } from './ping';
 import { McpAwnsRehash } from './rehash';
@@ -23,6 +24,7 @@ export const DEFAULT_MCP_PACKAGES = [
   McpAwnsVisual,
   McpAwnsRehash,
   McpAwnsTimezone,
+  McpWorldMongooseLocation,
   McpAwnsStatus,
   McpSimpleEdit,
   McpVmooUserlist,

--- a/src/mcp/packages/location.ts
+++ b/src/mcp/packages/location.ts
@@ -1,0 +1,24 @@
+import { identityCodec, messageEnvelope } from "../../protocol/messages";
+import { MCPPackage } from "../package";
+import type { McpOutboundData } from "../types";
+
+export type WorldMongooseLocation = {
+  lat: number;
+  lon: number;
+};
+
+const location = messageEnvelope(
+  "world.mongoose.location",
+  identityCodec<WorldMongooseLocation>(),
+);
+
+const McpWorldMongooseLocationBase = MCPPackage.with({
+  packageName: "world.mongoose.location",
+  messages: [] as const,
+});
+
+export class McpWorldMongooseLocation extends McpWorldMongooseLocationBase {
+  sendLocation(payload: WorldMongooseLocation): void {
+    this.send(location.wireName, location.codec.encode(payload) as McpOutboundData);
+  }
+}

--- a/src/stores/preferencesStore.test.ts
+++ b/src/stores/preferencesStore.test.ts
@@ -4,7 +4,11 @@ import { AutoreadMode, usePreferences } from "./preferencesStore";
 describe("preferencesStore", () => {
   beforeEach(() => {
     // Reset to known defaults between tests.
-    usePreferences.getState().setGeneral({ localEcho: false, syncTimezoneToServer: true });
+    usePreferences.getState().setGeneral({
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: false,
+    });
     usePreferences.getState().setSound({ muteInBackground: false, volume: 1.0 });
     usePreferences.getState().setMidi({ enabled: false });
     localStorage.removeItem("preferences");
@@ -13,6 +17,7 @@ describe("preferencesStore", () => {
   it("exposes default preferences", () => {
     expect(usePreferences.getState().general.localEcho).toBe(false);
     expect(usePreferences.getState().general.syncTimezoneToServer).toBe(true);
+    expect(usePreferences.getState().general.syncLocationToServer).toBe(false);
     expect(usePreferences.getState().speech.autoreadMode).toBe(AutoreadMode.Off);
   });
 
@@ -36,12 +41,17 @@ describe("preferencesStore", () => {
     // localStorage is a no-op mock in the test setup, so assert on the write.
     const setItem = vi.mocked(localStorage.setItem);
     setItem.mockClear();
-    usePreferences.getState().setGeneral({ localEcho: true, syncTimezoneToServer: false });
+    usePreferences.getState().setGeneral({
+      localEcho: true,
+      syncTimezoneToServer: false,
+      syncLocationToServer: true,
+    });
     expect(setItem).toHaveBeenCalledWith("preferences", expect.any(String));
     const lastCall = setItem.mock.calls.at(-1);
     const stored = JSON.parse(lastCall?.[1] as string);
     expect(stored.general.localEcho).toBe(true);
     expect(stored.general.syncTimezoneToServer).toBe(false);
+    expect(stored.general.syncLocationToServer).toBe(true);
     // action functions are not serialized by JSON.stringify
     expect(stored.setGeneral).toBeUndefined();
   });

--- a/src/stores/preferencesStore.test.ts
+++ b/src/stores/preferencesStore.test.ts
@@ -4,7 +4,7 @@ import { AutoreadMode, usePreferences } from "./preferencesStore";
 describe("preferencesStore", () => {
   beforeEach(() => {
     // Reset to known defaults between tests.
-    usePreferences.getState().setGeneral({ localEcho: false });
+    usePreferences.getState().setGeneral({ localEcho: false, syncTimezoneToServer: true });
     usePreferences.getState().setSound({ muteInBackground: false, volume: 1.0 });
     usePreferences.getState().setMidi({ enabled: false });
     localStorage.removeItem("preferences");
@@ -12,6 +12,7 @@ describe("preferencesStore", () => {
 
   it("exposes default preferences", () => {
     expect(usePreferences.getState().general.localEcho).toBe(false);
+    expect(usePreferences.getState().general.syncTimezoneToServer).toBe(true);
     expect(usePreferences.getState().speech.autoreadMode).toBe(AutoreadMode.Off);
   });
 
@@ -35,11 +36,12 @@ describe("preferencesStore", () => {
     // localStorage is a no-op mock in the test setup, so assert on the write.
     const setItem = vi.mocked(localStorage.setItem);
     setItem.mockClear();
-    usePreferences.getState().setGeneral({ localEcho: true });
+    usePreferences.getState().setGeneral({ localEcho: true, syncTimezoneToServer: false });
     expect(setItem).toHaveBeenCalledWith("preferences", expect.any(String));
     const lastCall = setItem.mock.calls.at(-1);
     const stored = JSON.parse(lastCall?.[1] as string);
     expect(stored.general.localEcho).toBe(true);
+    expect(stored.general.syncTimezoneToServer).toBe(false);
     // action functions are not serialized by JSON.stringify
     expect(stored.setGeneral).toBeUndefined();
   });

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -8,6 +8,7 @@ export enum AutoreadMode {
 
 export type GeneralPreferences = {
   localEcho: boolean;
+  syncTimezoneToServer: boolean;
 };
 
 export type SpeechPreferences = {
@@ -85,7 +86,7 @@ const STORAGE_KEY = "preferences";
 
 function getInitialPreferences(): PrefState {
   return {
-    general: { localEcho: false },
+    general: { localEcho: false, syncTimezoneToServer: true },
     speech: {
       autoreadMode: AutoreadMode.Off,
       voice: "",

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -9,6 +9,7 @@ export enum AutoreadMode {
 export type GeneralPreferences = {
   localEcho: boolean;
   syncTimezoneToServer: boolean;
+  syncLocationToServer: boolean;
 };
 
 export type SpeechPreferences = {
@@ -86,7 +87,11 @@ const STORAGE_KEY = "preferences";
 
 function getInitialPreferences(): PrefState {
   return {
-    general: { localEcho: false, syncTimezoneToServer: true },
+    general: {
+      localEcho: false,
+      syncTimezoneToServer: true,
+      syncLocationToServer: false,
+    },
     speech: {
       autoreadMode: AutoreadMode.Off,
       voice: "",


### PR DESCRIPTION
## Summary

Adds two new user preferences that sync real-world context to the server over MCP:

- **Timezone sync** — sends the browser's local timezone identifier to the server via a new `world.mongoose.timezone` MCP package.
- **Browser location sync** — requests the browser geolocation and sends coordinates via a new `world.mongoose.location` MCP package, gated behind an explicit opt-in preference.

Both syncs fire on MCP negotiation end and whenever the relevant preference is toggled on while connected.

## Location sync safety

The geolocation callback is async, so the preference and connection state are re-checked at the moment the position resolves: a coordinate that comes back after the user disables sync or disconnects is dropped rather than sent.

## Tests

- `createConfiguredClient.test.ts` covers timezone send, location send, opt-out (no geolocation request when disabled), and the two race cases (disabled / disconnected before geolocation resolves).
- `preferencesStore.test.ts` and `awnsPackages.test.ts` cover the new preference fields and MCP package wiring.

All `createConfiguredClient` tests pass locally (8/8).