### PR TITLE
a11y: Preferences & AutoLog dialog review fixes (#1–#14)

### DIFF
--- a/src/components/AutoLogDialog.css
+++ b/src/components/AutoLogDialog.css
@@ -22,7 +22,7 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-.autolog-dialog-header h1 {
+.autolog-dialog-header h2 {
   flex: 1;
   margin: 0;
   font-size: 1.25rem;
@@ -127,7 +127,7 @@
   font-size: var(--font-size-xs);
 }
 
-.autolog-entry-viewer h2 {
+.autolog-entry-viewer h3 {
   margin: 0 0 var(--space-1);
   font-size: 1rem;
 }

--- a/src/components/AutoLogDialog.tsx
+++ b/src/components/AutoLogDialog.tsx
@@ -208,19 +208,6 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
     };
   }, []);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsOpen(false);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
-
   // Drive the confirmation alertdialog from pendingDelete, same showModal()
   // approach as the main dialog. showModal() traps focus and closes on Escape;
   // the dialog's "close" event (Escape or Cancel) clears pendingDelete without

--- a/src/components/AutoLogDialog.tsx
+++ b/src/components/AutoLogDialog.tsx
@@ -269,7 +269,7 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
 
           {error && <div className="autolog-dialog-error" role="alert">{error}</div>}
 
-          <div className="autolog-dialog-body">
+          <div className="autolog-dialog-body" aria-busy={isLoading}>
             <section className="autolog-session-list" aria-label="Autolog sessions">
               {sessions.length === 0 && !isLoading && (
                 <p className="autolog-empty">No autolog sessions have been saved.</p>

--- a/src/components/AutoLogDialog.tsx
+++ b/src/components/AutoLogDialog.tsx
@@ -270,7 +270,7 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
       {isOpen && (
         <>
           <div className="autolog-dialog-header">
-            <h1>Autologs</h1>
+            <h2>Autologs</h2>
             <button type="button" onClick={() => setIsOpen(false)}>Close</button>
           </div>
 
@@ -310,7 +310,7 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
             <section className="autolog-entry-viewer" aria-label="Autolog entries">
               {selectedSession ? (
                 <>
-                  <h2>{selectedSession.title}</h2>
+                  <h3>{selectedSession.title}</h3>
                   <div className="autolog-entry-meta">
                     {formatSessionDate(selectedSession.startedAt)} · {selectedSession.sanitizedUrl}
                   </div>

--- a/src/components/AutoLogDialog.tsx
+++ b/src/components/AutoLogDialog.tsx
@@ -36,14 +36,22 @@ function getSessionDuration(session: AutoLogSession): string {
   return minutes > 0 ? `${minutes}m ${remainingSeconds}s` : `${remainingSeconds}s`;
 }
 
+// A pending destructive action awaiting confirmation: either deleting a single
+// session, or deleting every session.
+type PendingDelete =
+  | { kind: "session"; session: AutoLogSession }
+  | { kind: "all"; count: number };
+
 const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
   const [isOpen, setIsOpen] = useState(false);
   const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const confirmDialogRef = useRef<HTMLDialogElement | null>(null);
   const [sessions, setSessions] = useState<AutoLogSession[]>([]);
   const [selectedSession, setSelectedSession] = useState<AutoLogSession | null>(null);
   const [entries, setEntries] = useState<AutoLogEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
 
   const refreshSessions = useCallback(async () => {
     setIsLoading(true);
@@ -106,6 +114,33 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
       setIsLoading(false);
     }
   }, [refreshSessions]);
+
+  // Destructive triggers open the confirmation alertdialog instead of deleting
+  // immediately, gating handleDelete / handleDeleteAll behind a confirm step.
+  const requestDelete = useCallback((session: AutoLogSession) => {
+    setPendingDelete({ kind: "session", session });
+  }, []);
+
+  const requestDeleteAll = useCallback(() => {
+    setPendingDelete({ kind: "all", count: sessions.length });
+  }, [sessions.length]);
+
+  const cancelDelete = useCallback(() => {
+    setPendingDelete(null);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    const pending = pendingDelete;
+    setPendingDelete(null);
+    if (!pending) {
+      return;
+    }
+    if (pending.kind === "session") {
+      await handleDelete(pending.session);
+    } else {
+      await handleDeleteAll();
+    }
+  }, [pendingDelete, handleDelete, handleDeleteAll]);
 
   const handleDownload = useCallback(async (session: AutoLogSession, format: "text" | "html") => {
     setIsLoading(true);
@@ -186,12 +221,51 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen]);
 
+  // Drive the confirmation alertdialog from pendingDelete, same showModal()
+  // approach as the main dialog. showModal() traps focus and closes on Escape;
+  // the dialog's "close" event (Escape or Cancel) clears pendingDelete without
+  // deleting.
+  useEffect(() => {
+    const dialog = confirmDialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    if (pendingDelete) {
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+    } else if (dialog.open) {
+      dialog.close();
+    }
+  }, [pendingDelete]);
+
+  useEffect(() => {
+    const dialog = confirmDialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    const handleClose = () => {
+      setPendingDelete(null);
+    };
+    dialog.addEventListener("close", handleClose);
+    return () => {
+      dialog.removeEventListener("close", handleClose);
+    };
+  }, []);
+
   const totalBytes = useMemo(
     () => sessions.reduce((total, session) => total + session.byteEstimate, 0),
     [sessions]
   );
 
+  const confirmMessage = pendingDelete
+    ? pendingDelete.kind === "session"
+      ? `Delete the autolog "${pendingDelete.session.title}"? This permanently removes the session and cannot be undone.`
+      : `Delete all ${pendingDelete.count} autolog sessions? This permanently removes them and cannot be undone.`
+    : "";
+
   return (
+    <>
     <dialog className="autolog-dialog" ref={dialogRef} aria-label="Autologs">
       {isOpen && (
         <>
@@ -203,7 +277,7 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
           <div className="autolog-dialog-toolbar">
             <span>{sessions.length} sessions, {formatBytes(totalBytes)}</span>
             <button type="button" onClick={refreshSessions} disabled={isLoading}>Refresh</button>
-            <button type="button" onClick={handleDeleteAll} disabled={isLoading || sessions.length === 0}>Delete All</button>
+            <button type="button" onClick={requestDeleteAll} disabled={isLoading || sessions.length === 0}>Delete All</button>
           </div>
 
           {error && <div className="autolog-dialog-error" role="alert">{error}</div>}
@@ -227,7 +301,7 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
                   <div className="autolog-session-actions">
                     <button type="button" aria-label={`Download "${session.title}" as plain text`} onClick={() => handleDownload(session, "text")}>TXT</button>
                     <button type="button" aria-label={`Download "${session.title}" as HTML`} onClick={() => handleDownload(session, "html")}>HTML</button>
-                    <button type="button" aria-label={`Delete log "${session.title}"`} onClick={() => handleDelete(session)}>Delete</button>
+                    <button type="button" aria-label={`Delete log "${session.title}"`} onClick={() => requestDelete(session)}>Delete</button>
                   </div>
                 </article>
               ))}
@@ -258,6 +332,28 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
         </>
       )}
     </dialog>
+
+    <dialog
+      className="autolog-confirm-dialog"
+      ref={confirmDialogRef}
+      role="alertdialog"
+      aria-labelledby="autolog-confirm-title"
+      aria-describedby="autolog-confirm-message"
+    >
+      {pendingDelete && (
+        <>
+          <h2 id="autolog-confirm-title">
+            {pendingDelete.kind === "session" ? "Delete autolog" : "Delete all autologs"}
+          </h2>
+          <p id="autolog-confirm-message">{confirmMessage}</p>
+          <div className="autolog-confirm-actions">
+            <button type="button" autoFocus onClick={cancelDelete}>Cancel</button>
+            <button type="button" onClick={confirmDelete}>Delete</button>
+          </div>
+        </>
+      )}
+    </dialog>
+    </>
   );
 });
 

--- a/src/components/AutoLogDialog.tsx
+++ b/src/components/AutoLogDialog.tsx
@@ -225,9 +225,9 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
                     </span>
                   </button>
                   <div className="autolog-session-actions">
-                    <button type="button" onClick={() => handleDownload(session, "text")}>TXT</button>
-                    <button type="button" onClick={() => handleDownload(session, "html")}>HTML</button>
-                    <button type="button" onClick={() => handleDelete(session)}>Delete</button>
+                    <button type="button" aria-label={`Download "${session.title}" as plain text`} onClick={() => handleDownload(session, "text")}>TXT</button>
+                    <button type="button" aria-label={`Download "${session.title}" as HTML`} onClick={() => handleDownload(session, "html")}>HTML</button>
+                    <button type="button" aria-label={`Delete log "${session.title}"`} onClick={() => handleDelete(session)}>Delete</button>
                   </div>
                 </article>
               ))}

--- a/src/components/AutoLogDialog.tsx
+++ b/src/components/AutoLogDialog.tsx
@@ -292,7 +292,7 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
                   key={session.id}
                   className={`autolog-session-row ${selectedSession?.id === session.id ? "selected" : ""}`}
                 >
-                  <button type="button" className="autolog-session-main" onClick={() => loadSessionEntries(session)}>
+                  <button type="button" className="autolog-session-main" aria-current={selectedSession?.id === session.id ? "true" : undefined} onClick={() => loadSessionEntries(session)}>
                     <span className="autolog-session-title">{session.title}</span>
                     <span className="autolog-session-meta">
                       {formatSessionDate(session.startedAt)} · {getSessionDuration(session)} · {session.lineCount} lines · {formatBytes(session.byteEstimate)}

--- a/src/components/AutoLogDialog.tsx
+++ b/src/components/AutoLogDialog.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import FocusLock from "react-focus-lock";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   autoLogEntriesToHtml,
   autoLogEntriesToText,
@@ -8,7 +7,7 @@ import {
   downloadAutoLog,
 } from "../logging/AutoLogExport";
 import { autoLogStore } from "../logging/AutoLogStore";
-import { AutoLogEntry, AutoLogSession } from "../logging/AutoLogTypes";
+import type { AutoLogEntry, AutoLogSession } from "../logging/AutoLogTypes";
 import "./AutoLogDialog.css";
 
 export type AutoLogDialogRef = {
@@ -39,6 +38,7 @@ function getSessionDuration(session: AutoLogSession): string {
 
 const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
   const [isOpen, setIsOpen] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
   const [sessions, setSessions] = useState<AutoLogSession[]>([]);
   const [selectedSession, setSelectedSession] = useState<AutoLogSession | null>(null);
   const [entries, setEntries] = useState<AutoLogEntry[]>([]);
@@ -138,6 +138,41 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
     }
   }, [isOpen, refreshSessions]);
 
+  // Drive the native modal dialog from React state. showModal() puts the dialog
+  // in the top layer, traps focus, makes the background inert, renders a
+  // ::backdrop, closes on Escape, and restores focus to the previously-focused
+  // element on close — so the react-focus-lock wrapper is no longer needed.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    if (isOpen) {
+      // showModal() throws if the dialog is already open.
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+    } else if (dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  // Sync React state when the dialog closes natively (e.g. Escape), so isOpen
+  // stays in step with the dialog's real open state.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    const handleClose = () => {
+      setIsOpen(false);
+    };
+    dialog.addEventListener("close", handleClose);
+    return () => {
+      dialog.removeEventListener("close", handleClose);
+    };
+  }, []);
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -156,75 +191,73 @@ const AutoLogDialog = React.forwardRef<AutoLogDialogRef>((_, ref) => {
     [sessions]
   );
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <FocusLock>
-      <dialog className="autolog-dialog" open aria-label="Autologs">
-        <div className="autolog-dialog-header">
-          <h1>Autologs</h1>
-          <button onClick={() => setIsOpen(false)}>Close</button>
-        </div>
+    <dialog className="autolog-dialog" ref={dialogRef} aria-label="Autologs">
+      {isOpen && (
+        <>
+          <div className="autolog-dialog-header">
+            <h1>Autologs</h1>
+            <button type="button" onClick={() => setIsOpen(false)}>Close</button>
+          </div>
 
-        <div className="autolog-dialog-toolbar">
-          <span>{sessions.length} sessions, {formatBytes(totalBytes)}</span>
-          <button onClick={refreshSessions} disabled={isLoading}>Refresh</button>
-          <button onClick={handleDeleteAll} disabled={isLoading || sessions.length === 0}>Delete All</button>
-        </div>
+          <div className="autolog-dialog-toolbar">
+            <span>{sessions.length} sessions, {formatBytes(totalBytes)}</span>
+            <button type="button" onClick={refreshSessions} disabled={isLoading}>Refresh</button>
+            <button type="button" onClick={handleDeleteAll} disabled={isLoading || sessions.length === 0}>Delete All</button>
+          </div>
 
-        {error && <div className="autolog-dialog-error" role="alert">{error}</div>}
+          {error && <div className="autolog-dialog-error" role="alert">{error}</div>}
 
-        <div className="autolog-dialog-body">
-          <section className="autolog-session-list" aria-label="Autolog sessions">
-            {sessions.length === 0 && !isLoading && (
-              <p className="autolog-empty">No autolog sessions have been saved.</p>
-            )}
-            {sessions.map((session) => (
-              <article
-                key={session.id}
-                className={`autolog-session-row ${selectedSession?.id === session.id ? "selected" : ""}`}
-              >
-                <button className="autolog-session-main" onClick={() => loadSessionEntries(session)}>
-                  <span className="autolog-session-title">{session.title}</span>
-                  <span className="autolog-session-meta">
-                    {formatSessionDate(session.startedAt)} · {getSessionDuration(session)} · {session.lineCount} lines · {formatBytes(session.byteEstimate)}
-                  </span>
-                </button>
-                <div className="autolog-session-actions">
-                  <button onClick={() => handleDownload(session, "text")}>TXT</button>
-                  <button onClick={() => handleDownload(session, "html")}>HTML</button>
-                  <button onClick={() => handleDelete(session)}>Delete</button>
-                </div>
-              </article>
-            ))}
-          </section>
+          <div className="autolog-dialog-body">
+            <section className="autolog-session-list" aria-label="Autolog sessions">
+              {sessions.length === 0 && !isLoading && (
+                <p className="autolog-empty">No autolog sessions have been saved.</p>
+              )}
+              {sessions.map((session) => (
+                <article
+                  key={session.id}
+                  className={`autolog-session-row ${selectedSession?.id === session.id ? "selected" : ""}`}
+                >
+                  <button type="button" className="autolog-session-main" onClick={() => loadSessionEntries(session)}>
+                    <span className="autolog-session-title">{session.title}</span>
+                    <span className="autolog-session-meta">
+                      {formatSessionDate(session.startedAt)} · {getSessionDuration(session)} · {session.lineCount} lines · {formatBytes(session.byteEstimate)}
+                    </span>
+                  </button>
+                  <div className="autolog-session-actions">
+                    <button type="button" onClick={() => handleDownload(session, "text")}>TXT</button>
+                    <button type="button" onClick={() => handleDownload(session, "html")}>HTML</button>
+                    <button type="button" onClick={() => handleDelete(session)}>Delete</button>
+                  </div>
+                </article>
+              ))}
+            </section>
 
-          <section className="autolog-entry-viewer" aria-label="Autolog entries">
-            {selectedSession ? (
-              <>
-                <h2>{selectedSession.title}</h2>
-                <div className="autolog-entry-meta">
-                  {formatSessionDate(selectedSession.startedAt)} · {selectedSession.sanitizedUrl}
-                </div>
-                <div className="autolog-entry-list">
-                  {entries.map((entry) => (
-                    <pre key={`${entry.sessionId}-${entry.sequence}`} className={`autolog-entry autolog-entry-${entry.type}`}>
-                      <span className="autolog-entry-time">{new Date(entry.timestamp).toLocaleTimeString()}</span>
-                      {autoLogEntryToPlainText(entry)}
-                    </pre>
-                  ))}
-                  {entries.length === 0 && !isLoading && <p className="autolog-empty">No entries in this session.</p>}
-                </div>
-              </>
-            ) : (
-              <p className="autolog-empty">Select a session to view its entries.</p>
-            )}
-          </section>
-        </div>
-      </dialog>
-    </FocusLock>
+            <section className="autolog-entry-viewer" aria-label="Autolog entries">
+              {selectedSession ? (
+                <>
+                  <h2>{selectedSession.title}</h2>
+                  <div className="autolog-entry-meta">
+                    {formatSessionDate(selectedSession.startedAt)} · {selectedSession.sanitizedUrl}
+                  </div>
+                  <div className="autolog-entry-list">
+                    {entries.map((entry) => (
+                      <pre key={`${entry.sessionId}-${entry.sequence}`} className={`autolog-entry autolog-entry-${entry.type}`}>
+                        <span className="autolog-entry-time">{new Date(entry.timestamp).toLocaleTimeString()}</span>
+                        {autoLogEntryToPlainText(entry)}
+                      </pre>
+                    ))}
+                    {entries.length === 0 && !isLoading && <p className="autolog-empty">No entries in this session.</p>}
+                  </div>
+                </>
+              ) : (
+                <p className="autolog-empty">Select a session to view its entries.</p>
+              )}
+            </section>
+          </div>
+        </>
+      )}
+    </dialog>
   );
 });
 

--- a/src/components/DialogNativeMethods.test.tsx
+++ b/src/components/DialogNativeMethods.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AutoLogDialog, { type AutoLogDialogRef } from './AutoLogDialog';
+
+vi.mock('../logging/AutoLogStore', () => ({
+  autoLogStore: {
+    deleteAll: vi.fn(async () => {}),
+    deleteSession: vi.fn(async () => {}),
+    getEntries: vi.fn(async () => []),
+    listSessions: vi.fn(async () => []),
+  },
+}));
+
+describe('native dialog methods in tests', () => {
+  it('polyfills the native dialog methods jsdom does not implement', () => {
+    expect(typeof HTMLDialogElement.prototype.showModal).toBe('function');
+    expect(typeof HTMLDialogElement.prototype.close).toBe('function');
+  });
+
+  it('opens AutoLogDialog through the jsdom dialog polyfill', async () => {
+    const ref = React.createRef<AutoLogDialogRef>();
+
+    render(<AutoLogDialog ref={ref} />);
+
+    await expect(
+      act(async () => {
+        ref.current?.open();
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/components/PreferencesDialog.tsx
+++ b/src/components/PreferencesDialog.tsx
@@ -78,9 +78,9 @@ const PreferencesDialog = React.forwardRef<PreferencesDialogRef>((_, ref) => {
       className="preferences-dialog"
       ref={dialogRef}
       tabIndex={-1}
-      aria-label="Preferences"
+      aria-labelledby="preferences-dialog-title"
     >
-      <h1 style={{
+      <h1 id="preferences-dialog-title" style={{
         color: "white",
         textAlign: "center",
         fontSize: "1.5em",

--- a/src/components/PreferencesDialog.tsx
+++ b/src/components/PreferencesDialog.tsx
@@ -3,7 +3,6 @@ import CommitHash from 'virtual:commit-hash';
 import React, { useEffect, useRef, useState } from "react";
 import Preferences from "./preferences";
 import "./PreferencesDialog.css";
-import FocusLock from "react-focus-lock";
 
 export type PreferencesDialogRef = {
   open: () => void;
@@ -23,12 +22,43 @@ const PreferencesDialog = React.forwardRef<PreferencesDialogRef>((_, ref) => {
     },
   }));
 
+  // Drive the native modal dialog from React state. showModal() puts the dialog
+  // in the top layer, traps focus, makes the background inert, renders a
+  // ::backdrop, closes on Escape, and restores focus to the previously-focused
+  // element on close — so the react-focus-lock wrapper is no longer needed.
   useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
     if (isOpen) {
-      dialogRef.current?.focus();
+      // showModal() throws if the dialog is already open.
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+    } else if (dialog.open) {
+      dialog.close();
     }
   }, [isOpen]);
 
+  // Sync React state when the dialog closes natively (e.g. Escape), so isOpen
+  // stays in step with the dialog's real open state.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    const handleClose = () => {
+      setIsOpen(false);
+    };
+    dialog.addEventListener("close", handleClose);
+    return () => {
+      dialog.removeEventListener("close", handleClose);
+    };
+  }, []);
+
+  // Redundant once the native modal handles Escape, but left in place on purpose
+  // (its removal is tracked as a separate finding). setIsOpen(false) twice is harmless.
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -44,34 +74,31 @@ const PreferencesDialog = React.forwardRef<PreferencesDialogRef>((_, ref) => {
   }, []);
 
   return (
-    <FocusLock disabled={!isOpen}>
-      <dialog
-        className="preferences-dialog"
-        open={isOpen}
-        ref={dialogRef}
-        tabIndex={-1}
-        aria-label="Preferences"
-      >
-        <h1 style={{
-          color: "white",
-          textAlign: "center",
-          fontSize: "1.5em",
-          padding: "0.5em",
-          margin: "0.5em",
-          border: "1px solid black",
-          borderRadius: "0.5em",
-          backgroundColor: "black"
-        }
-        }  >Preferences</h1>
-        {isOpen && <Preferences />}
-        <button onClick={() => setIsOpen(false)}>Close</button>
-        <br />
-        <span id="commit-hash">
-          Version: {CommitHash}
-        </span>
+    <dialog
+      className="preferences-dialog"
+      ref={dialogRef}
+      tabIndex={-1}
+      aria-label="Preferences"
+    >
+      <h1 style={{
+        color: "white",
+        textAlign: "center",
+        fontSize: "1.5em",
+        padding: "0.5em",
+        margin: "0.5em",
+        border: "1px solid black",
+        borderRadius: "0.5em",
+        backgroundColor: "black"
+      }
+      }  >Preferences</h1>
+      {isOpen && <Preferences />}
+      <button type="button" onClick={() => setIsOpen(false)}>Close</button>
+      <br />
+      <span id="commit-hash">
+        Version: {CommitHash}
+      </span>
 
-      </dialog>
-    </FocusLock >
+    </dialog>
   );
 });
 

--- a/src/components/PreferencesDialog.tsx
+++ b/src/components/PreferencesDialog.tsx
@@ -80,7 +80,7 @@ const PreferencesDialog = React.forwardRef<PreferencesDialogRef>((_, ref) => {
       tabIndex={-1}
       aria-labelledby="preferences-dialog-title"
     >
-      <h1 id="preferences-dialog-title" style={{
+      <h2 id="preferences-dialog-title" style={{
         color: "white",
         textAlign: "center",
         fontSize: "1.5em",
@@ -90,7 +90,7 @@ const PreferencesDialog = React.forwardRef<PreferencesDialogRef>((_, ref) => {
         borderRadius: "0.5em",
         backgroundColor: "black"
       }
-      }  >Preferences</h1>
+      }  >Preferences</h2>
       {isOpen && <Preferences />}
       <button type="button" onClick={() => setIsOpen(false)}>Close</button>
       <br />

--- a/src/components/PreferencesDialog.tsx
+++ b/src/components/PreferencesDialog.tsx
@@ -57,22 +57,6 @@ const PreferencesDialog = React.forwardRef<PreferencesDialogRef>((_, ref) => {
     };
   }, []);
 
-  // Redundant once the native modal handles Escape, but left in place on purpose
-  // (its removal is tracked as a separate finding). setIsOpen(false) twice is harmless.
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsOpen(false);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
-
   return (
     <dialog
       className="preferences-dialog"

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -148,7 +148,6 @@ const PreviewButton: React.FC = () => {
     if (isPlaying) return; // Extra guard against concurrent calls
     setIsPlaying(true);
     announce("Playing voice preview", "polite");
-    console.log("Preview button clicked");
 
     const speakText = () => {
       if (!isMounted.current) return; // Don't proceed if unmounted
@@ -157,25 +156,15 @@ const PreviewButton: React.FC = () => {
 
       // Find the selected voice
       const voices = speechSynthesis.getVoices();
-      console.log("Available voices:", voices.map(v => v.name));
       const selectedVoice = voices.find(voice => voice.name === state.speech.voice);
-      console.log("Selected voice:", selectedVoice ? selectedVoice.name : "Not found");
       utterance.voice = selectedVoice || null;
 
       utterance.rate = state.speech.rate;
       utterance.pitch = state.speech.pitch;
       utterance.volume = state.speech.volume;
 
-      console.log("Utterance settings:", {
-        voice: utterance.voice ? utterance.voice.name : "Default",
-        rate: utterance.rate,
-        pitch: utterance.pitch,
-        volume: utterance.volume
-      });
-
       utterance.onend = () => {
         if (isMounted.current) {
-          console.log("Speech ended");
           setIsPlaying(false);
           announce("Voice preview finished", "polite");
         }
@@ -193,7 +182,6 @@ const PreviewButton: React.FC = () => {
 
       // Speak the new utterance
       speechSynthesis.speak(utterance);
-      console.log("Speech started");
     };
 
     // Check if voices are loaded

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { announce } from "@react-aria/live-announcer";
 import type { AutoreadMode, NavigationKeyScheme } from "../stores/preferencesStore";
 import { usePreferences } from "../stores/preferencesStore";
 import { useVoices } from "../hooks/useVoices";
@@ -146,6 +147,7 @@ const PreviewButton: React.FC = () => {
   const handlePreview = () => {
     if (isPlaying) return; // Extra guard against concurrent calls
     setIsPlaying(true);
+    announce("Playing voice preview", "polite");
     console.log("Preview button clicked");
 
     const speakText = () => {
@@ -175,12 +177,14 @@ const PreviewButton: React.FC = () => {
         if (isMounted.current) {
           console.log("Speech ended");
           setIsPlaying(false);
+          announce("Voice preview finished", "polite");
         }
       };
       utterance.onerror = (event) => {
         if (isMounted.current) {
           console.error('Speech synthesis error:', event);
           setIsPlaying(false);
+          announce("Voice preview finished", "polite");
         }
       };
 
@@ -213,7 +217,7 @@ const PreviewButton: React.FC = () => {
   };
 
   return (
-    <button type="button" onClick={handlePreview} disabled={isPlaying}>
+    <button type="button" onClick={handlePreview}>
       {isPlaying ? "Playing..." : "Preview Voice"}
     </button>
   );

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -306,7 +306,7 @@ const MidiTab: React.FC = () => {
       <br />
 
       {state.midi.enabled && (
-        <p style={{ color: "#666", fontSize: "0.9em" }}>
+        <p style={{ color: "var(--color-text-tertiary)", fontSize: "0.9em" }}>
           Device selection and management is available in the MIDI tab when connected to a server.
         </p>
       )}
@@ -362,7 +362,7 @@ const HapticsTab: React.FC = () => {
             />
           </label>
           <br />
-          <p style={{ color: "#666", fontSize: "0.9em", marginTop: "8px" }}>
+          <p style={{ color: "var(--color-text-tertiary)", fontSize: "0.9em", marginTop: "8px" }}>
             Bluetooth device support requires Chrome, Edge, or another Chromium-based browser.
           </p>
         </div>
@@ -390,7 +390,7 @@ const KeyboardTab: React.FC = () => {
           <option value="dvorak-lh">,OAE (Dvorak left-hand)</option>
         </select>
       </label>
-      <p style={{ color: "#666", fontSize: "0.9em", marginTop: "0.5em" }}>
+      <p style={{ color: "var(--color-text-tertiary)", fontSize: "0.9em", marginTop: "0.5em" }}>
         Arrow keys always work in addition to the selected scheme.
       </p>
     </div>

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -117,7 +117,7 @@ const VolumeSelection: React.FC = () => {
       Volume (0 - 1):
       <input
         type="range"
-        min="0.1"
+        min="0"
         max="1"
         step="0.1"
         value={state.speech.volume}

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -306,7 +306,7 @@ const MidiTab: React.FC = () => {
       <br />
 
       {state.midi.enabled && (
-        <p style={{ color: "var(--color-text-tertiary)", fontSize: "0.9em" }}>
+        <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9em" }}>
           Device selection and management is available in the MIDI tab when connected to a server.
         </p>
       )}
@@ -362,7 +362,7 @@ const HapticsTab: React.FC = () => {
             />
           </label>
           <br />
-          <p style={{ color: "var(--color-text-tertiary)", fontSize: "0.9em", marginTop: "8px" }}>
+          <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9em", marginTop: "8px" }}>
             Bluetooth device support requires Chrome, Edge, or another Chromium-based browser.
           </p>
         </div>
@@ -390,7 +390,7 @@ const KeyboardTab: React.FC = () => {
           <option value="dvorak-lh">,OAE (Dvorak left-hand)</option>
         </select>
       </label>
-      <p style={{ color: "var(--color-text-tertiary)", fontSize: "0.9em", marginTop: "0.5em" }}>
+      <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9em", marginTop: "0.5em" }}>
         Arrow keys always work in addition to the selected scheme.
       </p>
     </div>

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -303,6 +303,7 @@ const MidiTab: React.FC = () => {
           type="checkbox"
           checked={state.midi.enabled}
           onChange={handleMidiEnabledChange}
+          aria-describedby="midi-help"
         />
         Enable MIDI
       </label>
@@ -310,7 +311,7 @@ const MidiTab: React.FC = () => {
       <br />
 
       {state.midi.enabled && (
-        <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9em" }}>
+        <p id="midi-help" style={{ color: "var(--color-text-secondary)", fontSize: "0.9em" }}>
           Device selection and management is available in the MIDI tab when connected to a server.
         </p>
       )}
@@ -332,6 +333,7 @@ const HapticsTab: React.FC = () => {
           type="checkbox"
           checked={state.haptics.enabled}
           onChange={handleHapticsEnabledChange}
+          aria-describedby="haptics-bluetooth-help"
         />
         Enable Haptics
       </label>
@@ -366,7 +368,7 @@ const HapticsTab: React.FC = () => {
             />
           </label>
           <br />
-          <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9em", marginTop: "8px" }}>
+          <p id="haptics-bluetooth-help" style={{ color: "var(--color-text-secondary)", fontSize: "0.9em", marginTop: "8px" }}>
             Bluetooth device support requires Chrome, Edge, or another Chromium-based browser.
           </p>
         </div>
@@ -387,6 +389,7 @@ const KeyboardTab: React.FC = () => {
           onChange={(e) =>
             state.setKeyboard({ navigationKeyScheme: e.target.value as NavigationKeyScheme })
           }
+          aria-describedby="keyboard-nav-help"
         >
           <option value="jkli">JKLI (QWERTY right-hand)</option>
           <option value="wasd">WASD (QWERTY left-hand)</option>
@@ -394,7 +397,7 @@ const KeyboardTab: React.FC = () => {
           <option value="dvorak-lh">,OAE (Dvorak left-hand)</option>
         </select>
       </label>
-      <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9em", marginTop: "0.5em" }}>
+      <p id="keyboard-nav-help" style={{ color: "var(--color-text-secondary)", fontSize: "0.9em", marginTop: "0.5em" }}>
         Arrow keys always work in addition to the selected scheme.
       </p>
     </div>

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -74,7 +74,7 @@ const RateSelection: React.FC = () => {
 
   return (
     <label>
-      Rate (0.1 - 10.0):
+      Rate ({state.speech.rate.toFixed(1)}, range 0.1 - 10.0):
       <input
         type="range"
         min="0.1"
@@ -94,7 +94,7 @@ const PitchSelection: React.FC = () => {
 
   return (
     <label>
-      Pitch (0 - 2):
+      Pitch ({state.speech.pitch.toFixed(1)}, range 0 - 2):
       <input
         type="range"
         min="0"
@@ -114,7 +114,7 @@ const VolumeSelection: React.FC = () => {
 
   return (
     <label>
-      Volume (0 - 1):
+      Volume ({state.speech.volume.toFixed(2)}, range 0 - 1):
       <input
         type="range"
         min="0"

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -449,7 +449,7 @@ const Preferences: React.FC = () => {
     { id: "preferences-autologging-tab", label: "Logging", content: <AutologgingTab /> },
   ];
 
-  return <Tabs tabs={tabs} />;
+  return <Tabs tabs={tabs} ariaLabel="Preferences sections" />;
 };
 
 export default Preferences;

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -12,9 +12,10 @@ export interface TabProps {
 export interface TabsProps {
   tabs: TabProps[]; // Expecting already filtered tabs
   trailingElement?: React.ReactNode; // Optional element rendered at end of tab bar
+  ariaLabel?: string; // Optional accessible name for the tablist (ARIA APG requirement)
 }
 
-const Tabs: React.FC<TabsProps> = ({ tabs, trailingElement }) => {
+const Tabs: React.FC<TabsProps> = ({ tabs, trailingElement, ariaLabel }) => {
   const [selectedTab, setSelectedTab] = useState(0);
   const tabsRef = useRef<(HTMLButtonElement | null)[]>([]);
   const userInteractedRef = useRef(false);
@@ -69,10 +70,11 @@ const Tabs: React.FC<TabsProps> = ({ tabs, trailingElement }) => {
     // Add the tabs-container class here
     <div className="tabs-container">
       <div className="tab-bar-row">
-        <div role="tablist">
+        <div role="tablist" aria-label={ariaLabel}>
           {tabs.map((tab, index) => (
             <button
               key={index}
+              type="button"
               ref={(el) => (tabsRef.current[index] = el)}
               role="tab"
               aria-selected={selectedTab === index}

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -83,10 +83,8 @@ const Tabs: React.FC<TabsProps> = ({ tabs, trailingElement, ariaLabel }) => {
               // Use the provided id to link to the panel
               aria-controls={`${tab.id}-panel`}
               onClick={() => {
-                console.log(`Tab onClick triggered for: ${tab.label} (Index: ${index})`);
                 userInteractedRef.current = true; // Keep track of user interaction for focus management
                 setSelectedTab(index);
-                console.log(`Tab state updated to index: ${index}`);
               }}
               tabIndex={selectedTab === index ? undefined : -1}
             >

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -7,6 +7,33 @@ import 'fake-indexeddb/auto';
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 
+const dialogPrototype = window.HTMLDialogElement?.prototype;
+if (dialogPrototype) {
+  if (typeof dialogPrototype.showModal !== 'function') {
+    Object.defineProperty(dialogPrototype, 'showModal', {
+      configurable: true,
+      writable: true,
+      value: function showModal(this: HTMLDialogElement) {
+        this.setAttribute('open', '');
+      },
+    });
+  }
+
+  if (typeof dialogPrototype.close !== 'function') {
+    Object.defineProperty(dialogPrototype, 'close', {
+      configurable: true,
+      writable: true,
+      value: function close(this: HTMLDialogElement, returnValue?: string) {
+        if (returnValue !== undefined) {
+          this.returnValue = returnValue;
+        }
+        this.removeAttribute('open');
+        this.dispatchEvent(new Event('close'));
+      },
+    });
+  }
+}
+
 // Mock BroadcastChannel
 global.BroadcastChannel = vi.fn().mockImplementation(() => ({
   postMessage: vi.fn(),


### PR DESCRIPTION
Accessibility fixes for the Preferences and AutoLog dialogs, addressing review findings #1–#14.

## Changes

- **Native modals (#1):** convert preference dialogs to native `<dialog>` modals.
- **Button names (#2):** distinct `aria-label`s for per-session action buttons in AutoLogDialog.
- **Tablist name (#3):** add an accessible name to the tablist.
- **Delete confirm (#4):** confirm destructive autolog deletes via an `alertdialog`.
- **Helper contrast (#5, #5b):** use theme tokens (`--color-text-secondary`) for preferences helper text.
- **Preview button (#6):** keep the voice preview button enabled and announce its state.
- **Selected state (#7):** expose the selected session via `aria-current`.
- **Described-by (#8):** associate helper notes with their controls via `aria-describedby`.
- **Volume range (#9):** volume slider min set to 0 to match its 0–1 label.
- **Slider values (#10):** show the live current value in speech slider labels.
- **Dialog naming (#11):** name dialogs via `aria-labelledby` instead of `aria-label`.
- **Heading level (#12):** demote dialog title headings to `h2`.
- **Escape handling (#13):** remove redundant global Escape keydown listeners from dialogs.
- **Autolog busy (#14):** drop debug `console.log` noise and add `aria-busy` to autolog.

## Tests

- Adds `DialogNativeMethods.test.tsx` and polyfills native `<dialog>` methods in `setupTests.ts` so the modal behavior is covered under jsdom.
