### PR TITLE
Strip MUD ANSI tags from room name in title and sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,16 +37,20 @@ const WINDOW_TITLE = "Mongoose Client";
 const DOUBLE_PRESS_WINDOW_MS = 500;
 
 function setWindowSubtitle(subtitle?: string) {
-  const cleanSubtitle = subtitle ? stripMudAnsiTags(subtitle) : subtitle;
-  document.title = cleanSubtitle ? `${WINDOW_TITLE} - ${cleanSubtitle}` : WINDOW_TITLE;
+  document.title = subtitle ? `${WINDOW_TITLE} - ${subtitle}` : WINDOW_TITLE;
 }
 
 function getRoomSubtitle(roomInfo: GMCPMessageRoomInfo): string | undefined {
-  if (roomInfo.area && roomInfo.name) {
-    return `${roomInfo.area}: ${roomInfo.name}`;
+  // Strip before composing: a field that is nothing but markup has to read as
+  // empty here, or it drags an orphaned separator into the title.
+  const area = roomInfo.area ? stripMudAnsiTags(roomInfo.area) : "";
+  const name = roomInfo.name ? stripMudAnsiTags(roomInfo.name) : "";
+
+  if (area && name) {
+    return `${area}: ${name}`;
   }
 
-  return roomInfo.name || roomInfo.area || undefined;
+  return name || area || undefined;
 }
 
 function getShortcutDigit(event: KeyboardEvent): number | null {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,13 +30,15 @@ import {
 import { usePreferences } from "./stores/preferencesStore";
 import { useRoomStore } from "./stores/roomStore";
 import { useConnectionStore } from "./stores/connectionStore";
+import { stripMudAnsiTags } from "./stripMudAnsiTags";
 import { ensurePushSubscription } from "./webpush";
 
 const WINDOW_TITLE = "Mongoose Client";
 const DOUBLE_PRESS_WINDOW_MS = 500;
 
 function setWindowSubtitle(subtitle?: string) {
-  document.title = subtitle ? `${WINDOW_TITLE} - ${subtitle}` : WINDOW_TITLE;
+  const cleanSubtitle = subtitle ? stripMudAnsiTags(subtitle) : subtitle;
+  document.title = cleanSubtitle ? `${WINDOW_TITLE} - ${cleanSubtitle}` : WINDOW_TITLE;
 }
 
 function getRoomSubtitle(roomInfo: GMCPMessageRoomInfo): string | undefined {

--- a/src/components/RoomInfoDisplay.tsx
+++ b/src/components/RoomInfoDisplay.tsx
@@ -113,6 +113,10 @@ const RoomInfoDisplay: React.FC<RoomInfoDisplayProps> = ({ client }) => {
   }
 
   const exits = roomInfo?.exits ? Object.entries(roomInfo.exits).sort(([dirA], [dirB]) => dirA.localeCompare(dirB)) : [];
+  // Strip before the fallback checks so a name that is only markup still
+  // renders the placeholder rather than an empty heading.
+  const roomName = roomInfo?.name ? stripMudAnsiTags(roomInfo.name) : "";
+  const roomArea = roomInfo?.area ? stripMudAnsiTags(roomInfo.area) : "";
 
   return (
     <div
@@ -122,8 +126,8 @@ const RoomInfoDisplay: React.FC<RoomInfoDisplayProps> = ({ client }) => {
     >
       {roomInfo && (
         <>
-          <h4 id={headingId}>{roomInfo.name ? stripMudAnsiTags(roomInfo.name) : "Current Room"}</h4>
-          {roomInfo.area && <p className="room-area">Area: {stripMudAnsiTags(roomInfo.area)}</p>}
+          <h4 id={headingId}>{roomName || "Current Room"}</h4>
+          {roomArea && <p className="room-area">Area: {roomArea}</p>}
           {exits.length > 0 && (
             <div className="room-exits">
               <h5>Exits</h5>

--- a/src/components/RoomInfoDisplay.tsx
+++ b/src/components/RoomInfoDisplay.tsx
@@ -5,6 +5,7 @@ import type { RoomPlayer } from "../gmcp/Room";
 import { useRoomStore } from "../stores/roomStore";
 import type { Item } from "../gmcp/Char/Items";
 import { useItemsStore } from "../stores/itemsStore";
+import { stripMudAnsiTags } from "../stripMudAnsiTags";
 import AccessibleList from "./AccessibleList"; // Import AccessibleList
 import ItemCard from "./ItemCard"; // Import ItemCard
 import PlayerCard from "./PlayerCard"; // Import PlayerCard
@@ -121,8 +122,8 @@ const RoomInfoDisplay: React.FC<RoomInfoDisplayProps> = ({ client }) => {
     >
       {roomInfo && (
         <>
-          <h4 id={headingId}>{roomInfo.name || "Current Room"}</h4>
-          {roomInfo.area && <p className="room-area">Area: {roomInfo.area}</p>}
+          <h4 id={headingId}>{roomInfo.name ? stripMudAnsiTags(roomInfo.name) : "Current Room"}</h4>
+          {roomInfo.area && <p className="room-area">Area: {stripMudAnsiTags(roomInfo.area)}</p>}
           {exits.length > 0 && (
             <div className="room-exits">
               <h5>Exits</h5>

--- a/src/stripMudAnsiTags.test.ts
+++ b/src/stripMudAnsiTags.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { stripMudAnsiTags } from "./stripMudAnsiTags";
+
+const ESC = String.fromCharCode(27);
+
+describe("stripMudAnsiTags", () => {
+  it("strips the bracketed markup the MUD embeds in GMCP room names", () => {
+    expect(
+      stripMudAnsiTags("[red]O[bold][red]ute[red]r R[bold][red]i[red]m[normal]"),
+    ).toBe("Outer Rim");
+  });
+
+  it("matches tags case-insensitively", () => {
+    expect(stripMudAnsiTags("[RED]Vault[Normal]")).toBe("Vault");
+  });
+
+  it("strips real ANSI escapes as well", () => {
+    expect(stripMudAnsiTags(`${ESC}[31mOuter Rim${ESC}[0m`)).toBe("Outer Rim");
+  });
+
+  it("trims padding left behind by the markup", () => {
+    expect(stripMudAnsiTags("[red] Outer Rim [normal]")).toBe("Outer Rim");
+  });
+
+  it("returns an empty string when the value is nothing but markup", () => {
+    expect(stripMudAnsiTags("[red][normal]")).toBe("");
+  });
+
+  it("leaves bracketed text that is not a known tag alone", () => {
+    expect(stripMudAnsiTags("The Bank [closed] [red]vault")).toBe("The Bank [closed] vault");
+  });
+});

--- a/src/stripMudAnsiTags.ts
+++ b/src/stripMudAnsiTags.ts
@@ -1,0 +1,23 @@
+import stripAnsi from "strip-ansi";
+
+// GMCP payloads never carry real control characters (those only appear in the
+// regular telnet output stream). Instead this MUD's "ANSI Player Class"
+// writes its own bracketed tag vocabulary - e.g. "[red]", "[bold]",
+// "[normal]" - directly into GMCP text fields (room/item/player names, etc).
+// Contexts that render GMCP text as plain text (document.title, sidebar
+// headings) need both forms stripped; stripAnsi handles real escapes too, as
+// defense-in-depth against a server that does send them.
+const MUD_ANSI_TAGS = [
+  "red", "green", "yellow", "blue", "purple", "cyan", "gray", "white",
+  "magenta", "grey",
+  "bold", "unbold", "bright", "unbright",
+  "blink", "unblink",
+  "underline", "inverse",
+  "beep",
+  "normal",
+];
+const MUD_ANSI_TAG_REGEX = new RegExp(`\\[(?:${MUD_ANSI_TAGS.join("|")})\\]`, "gi");
+
+export function stripMudAnsiTags(text: string): string {
+  return stripAnsi(text).replace(MUD_ANSI_TAG_REGEX, "");
+}

--- a/src/stripMudAnsiTags.ts
+++ b/src/stripMudAnsiTags.ts
@@ -7,6 +7,10 @@ import stripAnsi from "strip-ansi";
 // Contexts that render GMCP text as plain text (document.title, sidebar
 // headings) need both forms stripped; stripAnsi handles real escapes too, as
 // defense-in-depth against a server that does send them.
+//
+// The result is trimmed: markup often brackets the whole value ("[red]Outer
+// Rim[normal]") but sometimes sits outside the padding, and callers treat an
+// empty result as "no value" so they can fall back.
 const MUD_ANSI_TAGS = [
   "red", "green", "yellow", "blue", "purple", "cyan", "gray", "white",
   "magenta", "grey",
@@ -19,5 +23,5 @@ const MUD_ANSI_TAGS = [
 const MUD_ANSI_TAG_REGEX = new RegExp(`\\[(?:${MUD_ANSI_TAGS.join("|")})\\]`, "gi");
 
 export function stripMudAnsiTags(text: string): string {
-  return stripAnsi(text).replace(MUD_ANSI_TAG_REGEX, "");
+  return stripAnsi(text).replace(MUD_ANSI_TAG_REGEX, "").trim();
 }


### PR DESCRIPTION
## Summary
- The MUD embeds its own bracketed color/attribute markup (e.g. `[red]`, `[bold]`, `[normal]`) directly in GMCP `Room.Info` text fields, since GMCP payloads never carry real ANSI control characters.
- `document.title` and the sidebar's room heading (`RoomInfoDisplay`) rendered this markup verbatim - e.g. a title of `Mongoose Client - mthydra: [red]O[bold][red]ute[red]r R[bold][red]i[red]m[normal]` instead of `Mongoose Client - mthydra: Outer Rim`.
- Added a shared `stripMudAnsiTags` helper (also runs `strip-ansi` as defense-in-depth against real escapes) and applied it to the window subtitle and the sidebar's room name/area.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/App src/components/RoomInfoDisplay`
- [x] Manually verified the regex against the reported example decodes to `Outer Rim`