### PR TITLE
Fix split-frame line handling

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -331,24 +331,48 @@ describe('MudClient lifecycle cleanup', () => {
     expect(useUserlistStore.getState().hasReceivedList).toBe(false);
   });
 
+  it('buffers text split across frames until the line is complete', () => {
+    const client = new MudClient('example.test', 443);
+    client.connect();
+    const socket = mockWebSocketInstances[0];
+
+    sendSocketText(socket, 'Hello ');
+    expect(useOutputStore.getState().entries).toEqual([]);
+
+    sendSocketText(socket, 'world\r\n');
+    expect(useOutputStore.getState().entries).toEqual([
+      {
+        id: 1,
+        type: 'message',
+        message: 'Hello world',
+      },
+    ]);
+  });
+
   it('buffers partial MCP frames until the line is complete', () => {
     const client = new MudClient('example.test', 443);
     client.connect();
     const socket = mockWebSocketInstances[0];
     const receiveLine = vi.mocked(client.mcpSession.receiveLine);
 
-    sendSocketText(socket, '#$#MCP version: 2.1');
+    sendSocketText(socket, '#');
     expect(receiveLine).not.toHaveBeenCalled();
+    expect(useOutputStore.getState().entries).toEqual([]);
 
-    sendSocketText(socket, ' to: 2.1\r\n');
+    sendSocketText(socket, '$#MCP version: 2.1 to: 2.1\r\n');
     expect(receiveLine).toHaveBeenCalledWith('#$#MCP version: 2.1 to: 2.1');
+    expect(useOutputStore.getState().entries).toEqual([]);
   });
 
-  it('records non-MCP prompt text without waiting for a newline', () => {
+  it('records non-MCP prompt text at a Telnet GA boundary', () => {
     const client = new MudClient('example.test', 443);
 
     client.connect();
-    sendSocketText(mockWebSocketInstances[0], 'look');
+    const socket = mockWebSocketInstances[0];
+    sendSocketText(socket, 'look');
+    expect(useOutputStore.getState().entries).toEqual([]);
+
+    sendSocketBytes(socket, [255, 249]);
 
     expect(useOutputStore.getState().entries).toContainEqual({
       id: 1,
@@ -404,6 +428,9 @@ describe('MudClient lifecycle cleanup', () => {
     // "é" (U+00E9) is 0xC3 0xA9 in UTF-8; deliver each byte in its own frame.
     sendSocketBytes(socket, [0xc3]);
     sendSocketBytes(socket, [0xa9]);
+    expect(useOutputStore.getState().entries).toEqual([]);
+
+    sendSocketText(socket, '\n');
 
     expect(useOutputStore.getState().entries).toContainEqual(
       expect.objectContaining({ type: 'message', message: 'é' }),
@@ -427,6 +454,7 @@ describe('MudClient lifecycle cleanup', () => {
     // A fresh connection delivers the orphaned continuation byte alone.
     client.connect();
     sendSocketBytes(mockWebSocketInstances[1], [0xa9]);
+    sendSocketText(mockWebSocketInstances[1], '\n');
 
     // Without a reset the retained 0xC3 + 0xA9 would decode to "é"; after reset the
     // orphan continuation byte is an invalid sequence -> U+FFFD, never "é".

--- a/src/client.ts
+++ b/src/client.ts
@@ -138,6 +138,16 @@ class MudClient {
       this.handleData(data);
     });
 
+    this.telnet.on("command", (command) => {
+      if (
+        (command === TelnetCommand.GA || command === TelnetCommand.EOR) &&
+        this.telnetBuffer
+      ) {
+        this.handleTextLine(this.telnetBuffer.replace(/\r$/, ""));
+        this.telnetBuffer = "";
+      }
+    });
+
     this.telnet.on("negotiation", (command, option) => {
       // Negotiation that we support GMCP
       if (command === TelnetCommand.WILL && option === TelnetOption.GMCP) {
@@ -199,6 +209,16 @@ class MudClient {
 
     this.telnet.on("data", (data: ArrayBuffer) => {
       this.handleData(data);
+    });
+
+    this.telnet.on("command", (command) => {
+      if (
+        (command === TelnetCommand.GA || command === TelnetCommand.EOR) &&
+        this.telnetBuffer
+      ) {
+        this.handleTextLine(this.telnetBuffer.replace(/\r$/, ""));
+        this.telnetBuffer = "";
+      }
     });
 
     // The WASM server does not send telnet negotiation (no IAC sequences),
@@ -327,11 +347,6 @@ An MCP message consists of three parts: the name of the message, the authenticat
 
     for (const line of lines) {
       this.handleTextLine(line.replace(/\r$/, ""));
-    }
-
-    if (this.telnetBuffer && !this.telnetBuffer.startsWith("#$#")) {
-      this.emitMessage(this.telnetBuffer);
-      this.telnetBuffer = "";
     }
   }
 

--- a/src/telnet.test.ts
+++ b/src/telnet.test.ts
@@ -88,6 +88,17 @@ describe('Telnet', () => {
     );
   });
 
+  it.each([TelnetCommand.GA, TelnetCommand.EOR])(
+    'should pass prompt boundary command %i',
+    async (command) => {
+      await testEvent(
+        'command',
+        Buffer.from([TelnetCommand.IAC, command]),
+        [command],
+      );
+    },
+  );
+
   it('should pass subnegotiations', async () => {
     await testEvent(
       'subnegotiation',

--- a/src/telnet.ts
+++ b/src/telnet.ts
@@ -58,6 +58,7 @@ export enum TelnetOption {
 }
 
 export enum TelnetCommand {
+  EOR = 239, // End of record.
   SE = 240, //  End of subnegotiation parameters.
   NOP = 241, //   No operation.
   DM = 242, //  Data mark. The data stream portion of a Synch.
@@ -136,7 +137,7 @@ export class TelnetParser extends EventEmitter {
     this.buffer = Buffer.concat([this.buffer, Buffer.from(data)]);
 
     while (this.buffer.length > 0) {
-      let done;
+      let done: boolean | undefined;
       switch (this.state) {
         case TelnetState.DATA:
           this.handleData();
@@ -185,7 +186,9 @@ export class TelnetParser extends EventEmitter {
 
     switch (command) {
       case TelnetCommand.NOP:
-        this.emit("command", TelnetCommand.NOP);
+      case TelnetCommand.GA:
+      case TelnetCommand.EOR:
+        this.emit("command", command);
         this.state = TelnetState.DATA;
         break;
       case TelnetCommand.SB:


### PR DESCRIPTION
## Summary

- retain incomplete Telnet text across WebSocket frames until a real line or prompt boundary
- surface Telnet GA and EOR commands so unterminated prompts still render
- preserve split MCP lines even when the `#$#` prefix is itself split across frames

## Root cause

`MudClient.handleData` treated every WebSocket frame tail as complete prompt text unless the full tail already started with `#$#`. WebSocket frame boundaries are not line boundaries, so ordinary output was fragmented and partial MCP prefixes were exposed as visible text.

## Impact

Split output lines are rendered and spoken once as complete lines, split MCP messages remain out-of-band, and newline-free prompts continue to flush at explicit Telnet GA/EOR boundaries.

## TDD

The regression tests failed first for ordinary split lines, a one-character MCP prefix, and missing GA/EOR command events. After the fix:

- `npm test -- src/client.test.ts src/telnet.test.ts` — 23 passed
- `npm run typecheck` — passed
- `npm test` — 1,027 passed
- repository precommit hook — passed

Closes #58