### PR TITLE
Fix virtual MIDI port leak

### DIFF
--- a/src/VirtualMidiService.test.ts
+++ b/src/VirtualMidiService.test.ts
@@ -1,0 +1,55 @@
+import JZZ from 'jzz';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { virtualMidiService } from './VirtualMidiService';
+
+const { openMidiOut, refresh, register, tiny } = vi.hoisted(() => ({
+  openMidiOut: vi.fn(),
+  refresh: vi.fn(),
+  register: vi.fn(),
+  tiny: vi.fn(),
+}));
+
+vi.mock('jzz', () => {
+  const jzz = vi.fn(() => ({
+    openMidiOut,
+    refresh,
+  }));
+
+  return {
+    default: Object.assign(jzz, {
+      synth: {
+        Tiny: {
+          register,
+        },
+      },
+    }),
+  };
+});
+
+vi.mock('jzz-synth-tiny', () => ({
+  Tiny: tiny,
+}));
+
+describe('VirtualMidiService', () => {
+  beforeEach(() => {
+    virtualMidiService.close();
+    vi.clearAllMocks();
+  });
+
+  it('closes the existing virtual port before replacing it', async () => {
+    const firstPort = {
+      close: vi.fn(),
+    };
+    const secondPort = {
+      close: vi.fn(),
+    };
+    openMidiOut.mockResolvedValueOnce(firstPort).mockResolvedValueOnce(secondPort);
+
+    await virtualMidiService.getVirtualPort();
+    await virtualMidiService.getVirtualPort();
+
+    expect(firstPort.close).toHaveBeenCalledOnce();
+    expect(secondPort.close).not.toHaveBeenCalled();
+    expect(JZZ().openMidiOut).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/VirtualMidiService.ts
+++ b/src/VirtualMidiService.ts
@@ -66,6 +66,7 @@ export class VirtualMidiService {
     }
 
     try {
+      this.close();
       // Get the virtual port through JZZ
       this.virtualPort = await JZZ().openMidiOut(this.portName);
       return this.virtualPort;


### PR DESCRIPTION
## Summary

- close the existing virtual MIDI port before opening its replacement
- add a regression test covering repeated `getVirtualPort()` calls

## Root cause

`getVirtualPort()` replaced the stored JZZ MIDI-out handle without closing the previous handle, so every reconnect could leak another port for the lifetime of the page.

## User impact

Repeated virtual MIDI port acquisition no longer leaks the previously opened port.

## Validation

- `npm test -- src/VirtualMidiService.test.ts`
- `npm test` (104 files, 1,028 tests)
- `npm run typecheck`
- pre-commit staged-file lint

Closes #64