### PR TITLE
Fix outgoing file transfer timeouts

### DIFF
--- a/src/FileTransferManager.test.ts
+++ b/src/FileTransferManager.test.ts
@@ -110,14 +110,17 @@ function createManager() {
   const webRTCService = Object.assign(new EventEmitter(), {
     cleanup: vi.fn(),
     createPeerConnection: vi.fn(async () => {}),
+    createOffer: vi.fn(async () => ({ type: 'offer', sdp: 'mock' })),
     handleOffer: vi.fn(async () => {}),
     createAnswer: vi.fn(async () => ({ type: 'answer', sdp: 'mock' })),
     handleAnswer: vi.fn(async () => {}),
     isDataChannelOpen: vi.fn().mockReturnValue(false),
     sendData: vi.fn(async () => {}),
+    waitForConnection: vi.fn(async () => {}),
   });
   const gmcpFileTransfer = Object.assign(new EventEmitter(), {
     sendAccept: vi.fn(async () => {}),
+    sendOffer: vi.fn(async () => {}),
     sendReject: vi.fn(),
     sendCancel: vi.fn(),
     sendRequestResend: vi.fn(),
@@ -198,6 +201,80 @@ describe('FileTransferManager lifecycle', () => {
       hash: 'file-hash',
       filename: 'hello.txt',
     });
+  });
+
+  it('does not start the outgoing timeout clock while waiting for acceptance', async () => {
+    const { manager, webRTCService } = createManager();
+    webRTCService.isDataChannelOpen.mockReturnValue(true);
+    const onError = vi.fn();
+    manager.on('fileTransferError', onError);
+
+    await manager.sendFile(new File(['hello'], 'hello.txt'), 'Bob');
+
+    const transfers = manager as unknown as {
+      checkTransferTimeouts(): void;
+      outgoingTransfers: Map<string, { lastActivityTimestamp?: number }>;
+    };
+    const transfer = Array.from(transfers.outgoingTransfers.values())[0];
+    expect(transfer.lastActivityTimestamp).toBeUndefined();
+
+    vi.spyOn(Date, 'now').mockReturnValue(Number.MAX_SAFE_INTEGER);
+    transfers.checkTransferTimeouts();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('starts the outgoing timeout clock after the data channel opens', async () => {
+    const { manager, webRTCService } = createManager();
+    webRTCService.isDataChannelOpen.mockReturnValue(true);
+    const transfer = {
+      file: new File([], 'empty.txt'),
+      filename: 'empty.txt',
+      hash: 'file-hash',
+      lastActivityTimestamp: undefined as number | undefined,
+      recipient: 'Bob',
+    };
+    const transfers = manager as unknown as {
+      outgoingTransfers: Map<string, typeof transfer>;
+    };
+    transfers.outgoingTransfers.set(transfer.hash, transfer);
+
+    vi.spyOn(Date, 'now').mockReturnValue(1234);
+    await manager.handleAcceptedTransfer({
+      sender: 'Bob',
+      hash: transfer.hash,
+      filename: transfer.filename,
+      answerSdp: '{}',
+    } as FileTransferAccept);
+
+    expect(transfer.lastActivityTimestamp).toBe(1234);
+  });
+
+  it('refreshes outgoing activity after a chunk is sent', async () => {
+    const { manager } = createManager();
+    const transfer = {
+      file: new File(['hello'], 'hello.txt'),
+      filename: 'hello.txt',
+      hash: 'file-hash',
+      lastActivityTimestamp: 1,
+      recipient: 'Bob',
+    };
+    const transfers = manager as unknown as {
+      outgoingTransfers: Map<string, typeof transfer>;
+      sendChunk(
+        filename: string,
+        hash: string,
+        chunk: ArrayBuffer,
+        offset: number,
+        totalSize: number,
+      ): Promise<void>;
+    };
+    transfers.outgoingTransfers.set(transfer.hash, transfer);
+
+    vi.spyOn(Date, 'now').mockReturnValue(5678);
+    await transfers.sendChunk(transfer.filename, transfer.hash, new ArrayBuffer(5), 0, 5);
+
+    expect(transfer.lastActivityTimestamp).toBe(5678);
   });
 });
 

--- a/src/FileTransferManager.ts
+++ b/src/FileTransferManager.ts
@@ -42,7 +42,7 @@ interface FileTransferTask {
   file: File;
   filename: string;
   hash: string;
-  lastActivityTimestamp: number;
+  lastActivityTimestamp?: number;
   recipient: string;
 }
 
@@ -156,7 +156,6 @@ export default class FileTransferManager extends EventEmitter {
       file,
       filename: file.name,
       hash: fileHash,
-      lastActivityTimestamp: Date.now(),
       recipient,
     });
 
@@ -289,6 +288,10 @@ export default class FileTransferManager extends EventEmitter {
       dataBuffer.set(new Uint8Array(chunk), 4 + headerBuffer.byteLength);
 
       await this.webRTCService.sendData(dataBuffer.buffer);
+      const transfer = this.outgoingTransfers.get(hash);
+      if (transfer) {
+        transfer.lastActivityTimestamp = Date.now();
+      }
     } catch {
       throw new FileTransferError(
         FileTransferErrorCodes.DATA_CHANNEL_ERROR,
@@ -334,6 +337,7 @@ export default class FileTransferManager extends EventEmitter {
       await this.waitForDataChannel(hash);
       console.log(`[FileTransferManager] Data channel ready for outgoing transfer of: ${filename}`);
 
+      outgoingTransfer.lastActivityTimestamp = Date.now();
       await this.startFileTransfer(outgoingTransfer.file, outgoingTransfer.hash);
       console.log(`[FileTransferManager] File transfer completed successfully: ${filename}`);
       this.emit('fileSendComplete', { hash, filename });
@@ -631,6 +635,7 @@ export default class FileTransferManager extends EventEmitter {
 
       if (direction === 'send' && savedOutgoingTransfer) {
         // Re-register the transfer and restart
+        savedOutgoingTransfer.lastActivityTimestamp = undefined;
         this.outgoingTransfers.set(hash, savedOutgoingTransfer);
         await this.startFileTransfer(savedOutgoingTransfer.file, savedOutgoingTransfer.hash);
       } else if (direction === 'receive' && savedIncomingTransfer) {
@@ -670,7 +675,10 @@ export default class FileTransferManager extends EventEmitter {
 
     // Check outgoing transfers
     this.outgoingTransfers.forEach((transfer, hash) => {
-      if (now - transfer.lastActivityTimestamp > this.transferTimeout) {
+      if (
+        transfer.lastActivityTimestamp !== undefined &&
+        now - transfer.lastActivityTimestamp > this.transferTimeout
+      ) {
         this.handleTransferError(
           hash,
           transfer.filename,


### PR DESCRIPTION
## Summary

- leave the outgoing timeout clock stopped while the recipient decides whether to accept
- start timeout tracking only after the data channel opens
- refresh outgoing activity after every successfully sent chunk
- discard stale activity timestamps before retrying a send

## Root cause

Outgoing transfers were timestamped when the offer was created, then never refreshed while data was sent. The timeout interval therefore counted recipient decision time and total transfer duration as inactivity.

## Validation

- TDD regression: three new tests failed against the old behavior, then passed with the fix
- `npm test -- src/FileTransferManager.test.ts` (12 passed)
- `npm run typecheck`
- `npm test` (1,031 passed)
- pre-commit Biome lint on the two changed files

Closes #61