### PR TITLE
Preserve MCP multiline whitespace

### DIFF
--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -72,6 +72,24 @@ describe('MCP codec', () => {
     });
   });
 
+  it('preserves multiline continuation indentation and trailing whitespace', () => {
+    const line = '#$#* 9b76 content:     if (x > 1)  ';
+
+    expect(parseMcpLine(line)).toEqual({
+      type: 'multiline-continuation',
+      continuation: {
+        tag: '9b76',
+        key: 'content',
+        value: '    if (x > 1)  ',
+        keyvals: { content: '    if (x > 1)  ' },
+      },
+    });
+    expect(parseMcpMultiline(line)).toEqual({
+      name: '9b76',
+      keyvals: { content: '    if (x > 1)  ' },
+    });
+  });
+
   it('encodes outbound values without dropping falsy data', () => {
     expect(
       encodeMcpMessage('package-message', 'auth01', {

--- a/src/mcp/codec.ts
+++ b/src/mcp/codec.ts
@@ -15,14 +15,14 @@ const MCP_MULTILINE_CLOSE_PREFIX = '#$#:';
 type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
 
 export function parseMcpLine(rawLine: string): ParsedMcpLine {
-  const line = rawLine.trimEnd();
-
-  if (line.startsWith(MCP_MULTILINE_PREFIX)) {
-    const continuation = parseMcpMultilineContinuation(line);
+  if (rawLine.startsWith(MCP_MULTILINE_PREFIX)) {
+    const continuation = parseMcpMultilineContinuation(rawLine);
     return continuation.ok
       ? { type: 'multiline-continuation', continuation: continuation.value }
       : { type: 'invalid', raw: rawLine, error: continuation.error };
   }
+
+  const line = rawLine.trimEnd();
 
   if (line.startsWith(MCP_MULTILINE_CLOSE_PREFIX)) {
     const closure = parseMcpMultilineClose(line);
@@ -47,10 +47,8 @@ export function parseMcpMessage(message: string): McpMessage | null {
 }
 
 export function parseMcpMultiline(message: string): McpMessage | null {
-  const line = message.trimEnd();
-
-  if (line.startsWith(MCP_MULTILINE_CLOSE_PREFIX)) {
-    const parsed = parseMcpMultilineClose(line);
+  if (message.startsWith(MCP_MULTILINE_CLOSE_PREFIX)) {
+    const parsed = parseMcpMultilineClose(message.trimEnd());
     if (!parsed.ok) {
       console.log(parsed.error);
       return null;
@@ -58,7 +56,7 @@ export function parseMcpMultiline(message: string): McpMessage | null {
     return { name: parsed.value.tag, keyvals: {} };
   }
 
-  const parsed = parseMcpMultilineContinuation(line);
+  const parsed = parseMcpMultilineContinuation(message);
   if (!parsed.ok) {
     console.log(parsed.error);
     return null;
@@ -125,7 +123,7 @@ function parseMcpMessageResult(message: string): ParseResult<McpMessage> {
 }
 
 function parseMcpMultilineContinuation(message: string): ParseResult<McpMultilineContinuation> {
-  const match = message.match(/^#\$#\*\s+(\S+)\s+([^:\s]+)\s*:\s*(.*)$/);
+  const match = message.match(/^#\$#\*\s+(\S+)\s+([^:\s]+)\s*: ?(.*)$/);
   if (!match) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

- preserve leading indentation in MCP multiline continuation values
- preserve trailing whitespace in MCP multiline continuation values
- cover both public multiline parsing entry points with a regression test

## Root cause

The continuation parser trimmed the raw line and then consumed all whitespace after the `:` delimiter, so editor round trips silently rewrote indented MOO source.

## Impact

MOO code opened and saved through `dns-org-mud-moo-simpleedit` now retains its original indentation and trailing whitespace.

## Validation

- `npm test -- src/mcp.test.ts`
- `npm test` (104 files, 1032 tests)
- `npm run typecheck`
- `npm run lint:staged`
- `git diff --check -- src/mcp.test.ts src/mcp/codec.ts`

Closes #66