### PR TITLE
Preserve media metadata on repeated play

### DIFF
--- a/src/audio/MediaService.ts
+++ b/src/audio/MediaService.ts
@@ -587,10 +587,10 @@ export class MediaService {
     sound: ExtendedSound,
     data: Pick<ClientMediaPlayPayload, 'key' | 'tag' | 'type' | 'upmix' | 'channels'>,
   ): void {
-    sound.key = data.key;
-    sound.tag = data.tag;
-    sound.mediaType = data.type;
-    sound.upmix = data.upmix;
+    sound.key = data.key ?? sound.key;
+    sound.tag = data.tag ?? sound.tag;
+    sound.mediaType = data.type ?? sound.mediaType;
+    sound.upmix = data.upmix ?? sound.upmix;
     const channels = this.normalizeInputChannels(data.channels);
     if (channels !== undefined) {
       sound.inputChannels = channels;

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -405,6 +405,34 @@ describe('GMCPClientMedia', () => {
     expect(handler.sounds).toEqual({});
   });
 
+  it('preserves existing metadata when a repeated play omits optional fields', async () => {
+    const sound = createMockSound('rain.ogg');
+    mockCreateSound.mockResolvedValue(sound);
+
+    await handler.handlePlay({
+      key: 'rain-loop',
+      name: 'rain.ogg',
+      tag: 'weather',
+      type: 'sound',
+      upmix: 'ambisonic',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+
+    await handler.handlePlay({
+      key: 'rain-loop',
+      name: 'rain.ogg',
+      volume: 25,
+    } as GMCPMessageClientMediaPlay);
+
+    expect(sound.key).toBe('rain-loop');
+    expect(sound.tag).toBe('weather');
+    expect(sound.mediaType).toBe('sound');
+    expect(sound.upmix).toBe('ambisonic');
+
+    handler.handleStop({ tag: 'weather' } as GMCPMessageClientMediaStop);
+    expect(sound.cleanup).toHaveBeenCalledOnce();
+  });
+
   it('cleans up the replaced sound and stores only the replacement', async () => {
     const oldSound = createMockSound('one.ogg');
     const newSound = createMockSound('two.ogg');


### PR DESCRIPTION
## Summary

- preserve existing key, tag, media type, and upmix metadata when a repeated `Client.Media.Play` omits those optional fields
- add an end-to-end regression test covering repeated playback and stop-by-tag behavior

## Root cause

`assignSoundMetadata` assigned optional play payload fields unconditionally. Reusing an existing sound with an omitted field therefore replaced its stored metadata with `undefined`, preventing later targeted stop or update operations from matching it.

## User impact

Repeated play messages can omit unchanged metadata without losing the identifiers used by targeted media controls.

## TDD and validation

- Red: the new focused regression failed because the second play erased `sound.tag`
- Green: the focused regression passes after applying nullish merge semantics
- `npm test` — 104 files, 1,033 tests passed
- `npm run typecheck`
- `npm run lint:staged`

Closes #71