### PR TITLE
Stop sounds on media shutdown

### DIFF
--- a/src/audio/MediaService.ts
+++ b/src/audio/MediaService.ts
@@ -463,6 +463,7 @@ export class MediaService {
   }
 
   shutdown(): void {
+    this.stopAllSounds();
     if (this.shutdownComplete) {
       return;
     }

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -456,6 +456,31 @@ describe('GMCPClientMedia', () => {
     expect(handler.sounds.effect).toBe(newSound);
   });
 
+  it('stops and releases all sounds when the media service shuts down', async () => {
+    const firstSound = createMockSound('one.ogg');
+    const secondSound = createMockSound('two.ogg');
+    mockCreateSound.mockResolvedValueOnce(firstSound).mockResolvedValueOnce(secondSound);
+
+    await handler.handlePlay({
+      key: 'first',
+      name: 'one.ogg',
+      type: 'sound',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+    await handler.handlePlay({
+      key: 'second',
+      name: 'two.ogg',
+      type: 'sound',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+
+    client.media.shutdown();
+
+    expect(firstSound.cleanup).toHaveBeenCalledOnce();
+    expect(secondSound.cleanup).toHaveBeenCalledOnce();
+    expect(handler.sounds).toEqual({});
+  });
+
   it('cleans up a sound when its MCMP finish endpoint is reached', async () => {
     vi.useFakeTimers();
     const sound = createMockSound('bell.ogg');


### PR DESCRIPTION
## What changed

- stop and release all active sounds when `MediaService.shutdown()` runs
- add a regression test covering multiple active sounds and registry cleanup

## Why

`MediaService.shutdown()` cleared listeners, preferences, media-session state, and effects without releasing active sounds. Disconnect teardown could therefore leave audio playing and retain sound instances.

## Impact

Disconnecting or otherwise shutting down the media service now stops active audio and releases the associated sound objects.

## Validation

- TDD regression reproduced before the fix
- `npm test -- src/gmcp/Client/Media.test.ts`
- `npm test` (104 files, 1,034 tests)
- `npm run typecheck`
- staged Biome lint and diff checks

Closes #67