### PR TITLE
Fix exact media name matching

### DIFF
--- a/src/audio/MediaService.ts
+++ b/src/audio/MediaService.ts
@@ -131,6 +131,7 @@ export interface ExtendedSound extends Sound {
   ambisonicRenderer?: AmbisonicRenderer;
   positionalFoa?: PositionalFoaRenderer;
   inputChannels?: number;
+  mediaName?: string;
   mediaPosition?: Position;
   priority?: number;
   tag?: string;
@@ -267,6 +268,7 @@ export class MediaService {
     if (!this.sounds[key]) {
       const sound = (await this.cacophony.createSound(url)) as ExtendedSound;
       sound.key = key;
+      sound.mediaName = data.name;
       this.sounds[key] = sound;
     }
   }
@@ -315,6 +317,7 @@ export class MediaService {
     }
 
     sound.key = soundKey;
+    sound.mediaName = data.name;
     this.assignSoundMetadata(sound, data);
     this.sounds[soundKey] = sound;
     this.applySoundState(sound, data);
@@ -427,9 +430,7 @@ export class MediaService {
   }
 
   soundsByName(name: string): ExtendedSound[] {
-    return Object.values(this.sounds).filter((sound) => {
-      return typeof sound.url === 'string' && sound.url.endsWith(name);
-    });
+    return Object.values(this.sounds).filter((sound) => sound.mediaName === name);
   }
 
   soundsByKey(key: string): ExtendedSound[] {

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -561,6 +561,59 @@ describe('GMCPClientMedia', () => {
     expect(handler.sounds).toEqual({});
   });
 
+  it('stops only the sound whose name exactly matches', async () => {
+    const exactSound = createMockSound('https://media.example/beep.mp3');
+    const suffixSound = createMockSound('https://media.example/loudbeep.mp3');
+    mockCreateSound.mockResolvedValueOnce(exactSound).mockResolvedValueOnce(suffixSound);
+
+    await handler.handlePlay({
+      key: 'beep',
+      name: 'beep.mp3',
+      type: 'sound',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+    await handler.handlePlay({
+      key: 'loud-beep',
+      name: 'loudbeep.mp3',
+      type: 'sound',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+
+    handler.handleStop({ name: 'beep.mp3' } as GMCPMessageClientMediaStop);
+
+    expect(exactSound.cleanup).toHaveBeenCalledOnce();
+    expect(suffixSound.cleanup).not.toHaveBeenCalled();
+    expect(handler.sounds.beep).toBeUndefined();
+    expect(handler.sounds['loud-beep']).toBe(suffixSound);
+  });
+
+  it('updates only the sound whose name exactly matches', async () => {
+    const exactSound = createMockSound('https://media.example/beep.mp3');
+    const suffixSound = createMockSound('https://media.example/loudbeep.mp3');
+    mockCreateSound.mockResolvedValueOnce(exactSound).mockResolvedValueOnce(suffixSound);
+
+    await handler.handlePlay({
+      key: 'beep',
+      name: 'beep.mp3',
+      type: 'sound',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+    await handler.handlePlay({
+      key: 'loud-beep',
+      name: 'loudbeep.mp3',
+      type: 'sound',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+
+    handler.handleUpdate({
+      name: 'beep.mp3',
+      volume: 25,
+    } as GMCPMessageClientMediaUpdate);
+
+    expect(exactSound.volume).toBe(0.25);
+    expect(suffixSound.volume).toBe(0.5);
+  });
+
   it('updates an existing sound in place without replaying it', async () => {
     const sound = createMockSound('https://media.example/radio.ogg');
     mockCreateSound.mockResolvedValue(sound);


### PR DESCRIPTION
## What changed

- record the exact protocol media name on loaded and played sounds
- match `Client.Media.Stop {name}` and `Client.Media.Update {name}` against that exact name
- add regressions proving `beep.mp3` does not stop or update `loudbeep.mp3`

## Root cause

The shared name lookup used `String.endsWith`, so a requested name could match an unrelated longer filename with the same suffix.

## Validation

- TDD red: both new stop and update regressions failed against the suffix matcher
- TDD green: `npm test -- src/gmcp/Client/Media.test.ts` (31 tests)
- `npm run typecheck`
- `npm test` (104 files, 1,036 tests)
- `npm run lint:staged`

Closes #68