### PR TITLE
Fix media preload cache

### DIFF
--- a/docs/GMCP/packages/client-media.md
+++ b/docs/GMCP/packages/client-media.md
@@ -25,11 +25,14 @@ Sets the default media URL prefix used by `Load` and `Play`.
 ```json
 {
   "name": "weather/rain.ogg",
-  "url": "https://example.invalid/media/"
+  "url": "https://example.invalid/media/",
+  "type": "music"
 }
 ```
 
-Preloads a sound at `(url || defaultUrl) + name`.
+Preloads media at `(url || defaultUrl) + name`. Set `type` to `"music"` to use
+the same proxied URL as music playback. The client retains at most 32 preloaded
+entries and evicts the oldest preload when the limit is reached.
 
 ### `Client.Media.Play`
 

--- a/src/audio/MediaService.ts
+++ b/src/audio/MediaService.ts
@@ -19,6 +19,7 @@ const CORS_PROXY = 'https://mongoose.world:9080/?url=';
 type CacophonySoundKind = NonNullable<Parameters<Cacophony['createSound']>[1]>;
 const CACOPHONY_BUFFER = 'buffer' satisfies CacophonySoundKind;
 const CACOPHONY_HTML = 'html' satisfies CacophonySoundKind;
+const MAX_PRELOADED_SOUNDS = 32;
 
 /** Constant makeup gain restoring the clean positional FOA decode to a useful level. Tune by ear.
  *  The SN3D encode + SH-HRIR binaural decode lands well below unity, so a positioned source is
@@ -31,6 +32,7 @@ const POSITIONAL_FOA_STEREO_WIDTH_RAD = 0.6;
 export interface ClientMediaLoadPayload {
   readonly url?: string;
   readonly name: string;
+  readonly type?: MediaType;
 }
 
 export type MediaType = 'sound' | 'music' | 'video';
@@ -154,6 +156,7 @@ export class MediaService {
   private readonly cleanedSounds = new WeakSet<ExtendedSound>();
   private readonly effects: MediaEffects;
   private readonly mediaSession = new MediaSessionController();
+  private readonly preloadedSoundKeys = new Set<string>();
   private currentMusic?: ExtendedSound;
   private globalMuted = false;
   private isWindowFocused = true;
@@ -263,13 +266,27 @@ export class MediaService {
   }
 
   async load(data: ClientMediaLoadPayload): Promise<void> {
-    const url = this.resolvedUrl(data);
+    const url = this.mediaUrl(data);
     const key = url;
     if (!this.sounds[key]) {
       const sound = (await this.cacophony.createSound(url)) as ExtendedSound;
+
+      while (this.preloadedSoundKeys.size >= MAX_PRELOADED_SOUNDS) {
+        const oldestKey = this.preloadedSoundKeys.values().next().value;
+        if (oldestKey === undefined) {
+          break;
+        }
+        this.preloadedSoundKeys.delete(oldestKey);
+        const oldestSound = this.sounds[oldestKey];
+        if (oldestSound) {
+          this.releaseSound(oldestSound, oldestKey);
+        }
+      }
+
       sound.key = key;
       sound.mediaName = data.name;
       this.sounds[key] = sound;
+      this.preloadedSoundKeys.add(key);
     }
   }
 
@@ -286,6 +303,7 @@ export class MediaService {
     data.key = data.key || mediaUrl;
     const soundKey = data.key;
     let sound = this.sounds[soundKey] as ExtendedSound;
+    this.preloadedSoundKeys.delete(soundKey);
     const panType = data.is3d ? 'HRTF' : 'stereo';
     const isNewSound = !sound || sound.url !== mediaUrl;
     if (isNewSound) {
@@ -625,11 +643,13 @@ export class MediaService {
 
     if (key !== undefined && this.sounds[key] === sound) {
       delete this.sounds[key];
+      this.preloadedSoundKeys.delete(key);
     }
 
     for (const soundKey of Object.keys(this.sounds)) {
       if (this.sounds[soundKey] === sound) {
         delete this.sounds[soundKey];
+        this.preloadedSoundKeys.delete(soundKey);
       }
     }
 

--- a/src/gmcp/Client/Media.test.ts
+++ b/src/gmcp/Client/Media.test.ts
@@ -23,6 +23,7 @@ import { MediaService } from '../../audio/MediaService';
 import { useSpatialStore } from '../../stores/spatialStore';
 import {
   GMCPClientMedia,
+  type GMCPMessageClientMediaLoad,
   type GMCPMessageClientMediaListenerOrientation,
   type GMCPMessageClientMediaListenerPosition,
   type GMCPMessageClientMediaPlay,
@@ -224,6 +225,51 @@ describe('GMCPClientMedia', () => {
     expect(mockCreateSound).toHaveBeenCalledTimes(1);
     expect(sound.play).toHaveBeenCalledOnce();
     expect(handler.sounds['https://media.example/chime.ogg']).toBe(sound);
+  });
+
+  it('reuses a preloaded music sound under the proxied playback key', async () => {
+    const mediaUrl = 'https://media.example/theme.ogg';
+    const proxiedUrl = `https://mongoose.world:9080/?url=${encodeURIComponent(mediaUrl)}`;
+    const sound = createMockSound(proxiedUrl);
+    mockCreateSound.mockResolvedValue(sound);
+
+    await handler.handleLoad({
+      name: 'theme.ogg',
+      url: 'https://media.example/',
+      type: 'music',
+    } as GMCPMessageClientMediaLoad);
+
+    expect(handler.sounds[proxiedUrl]).toBe(sound);
+
+    await handler.handlePlay({
+      name: 'theme.ogg',
+      url: 'https://media.example/',
+      type: 'music',
+      volume: 50,
+    } as GMCPMessageClientMediaPlay);
+
+    expect(mockCreateSound).toHaveBeenCalledTimes(1);
+    expect(sound.play).toHaveBeenCalledOnce();
+    expect(handler.sounds[proxiedUrl]).toBe(sound);
+  });
+
+  it('evicts the oldest preload when the preload cache reaches its limit', async () => {
+    const sounds = Array.from({ length: 33 }, (_, index) =>
+      createMockSound(`https://media.example/sound-${index}.ogg`),
+    );
+    mockCreateSound.mockImplementation(async () => sounds[mockCreateSound.mock.calls.length - 1]);
+
+    for (let index = 0; index < sounds.length; index += 1) {
+      await handler.handleLoad({
+        name: `sound-${index}.ogg`,
+        url: 'https://media.example/',
+      });
+    }
+
+    expect(Object.keys(handler.sounds)).toHaveLength(32);
+    expect(handler.sounds['https://media.example/sound-0.ogg']).toBeUndefined();
+    expect(sounds[0].cleanup).toHaveBeenCalledOnce();
+    expect(handler.sounds['https://media.example/sound-32.ogg']).toBe(sounds[32]);
   });
 
   it('passes string sound types to Cacophony', async () => {

--- a/src/gmcp/Client/Media.ts
+++ b/src/gmcp/Client/Media.ts
@@ -27,6 +27,7 @@ import { GMCPMessage, GMCPPackage } from '../package';
 export class GMCPMessageClientMediaLoad extends GMCPMessage implements ClientMediaLoadPayload {
   public readonly url?: string;
   public readonly name!: string;
+  public readonly type?: MediaType = 'sound';
 }
 
 export type { ExtendedSound, MediaType };


### PR DESCRIPTION
## Summary

- key preloaded music with the same proxied URL used by playback
- reuse the preloaded sound instead of fetching a duplicate
- cap preload-owned cache entries at 32 and clean up the oldest entry through the existing release path
- document the `Client.Media.Load` music type and cache bound

## Root cause

`load()` cached the plain resolved URL while `play()` used the proxied music URL, so music playback could never find its preload. Preload-created entries also had no ownership tracking or eviction policy.

## Validation

- `npm test -- src/gmcp/Client/Media.test.ts` (33 tests)
- `npm test` (104 files, 1,038 tests)
- `npm run typecheck`
- `npm run lint:staged`

Closes #69