### PR TITLE
Close replaced WebRTC connections

### DIFF
--- a/src/WebRTCService.test.ts
+++ b/src/WebRTCService.test.ts
@@ -90,7 +90,9 @@ describe('WebRTCService', () => {
   });
 
   afterEach(() => {
-    timeoutIds.forEach((id) => originalClearTimeout(id));
+    timeoutIds.forEach((id) => {
+      originalClearTimeout(id);
+    });
     timeoutIds = [];
   });
 
@@ -160,6 +162,21 @@ describe('WebRTCService', () => {
 
       expect(mockCreateDataChannelFn).toHaveBeenCalledWith('fileTransfer', expect.any(Object));
       expect((webRTCService as any).dataChannel).not.toBeNull();
+    });
+
+    it('should close existing connections before creating replacements', async () => {
+      await webRTCService.createPeerConnection();
+      const existingPeerConnection = (webRTCService as any).peerConnection;
+      const existingDataChannel = (webRTCService as any).dataChannel;
+      const peerConnectionCloseSpy = vi.spyOn(existingPeerConnection, 'close');
+      const dataChannelCloseSpy = vi.spyOn(existingDataChannel, 'close');
+
+      await webRTCService.createPeerConnection();
+
+      expect(dataChannelCloseSpy).toHaveBeenCalledOnce();
+      expect(peerConnectionCloseSpy).toHaveBeenCalledOnce();
+      expect((webRTCService as any).dataChannel).not.toBe(existingDataChannel);
+      expect((webRTCService as any).peerConnection).not.toBe(existingPeerConnection);
     });
 
     it('should handle errors when creating peer connection', async () => {

--- a/src/WebRTCService.ts
+++ b/src/WebRTCService.ts
@@ -13,6 +13,10 @@ export class WebRTCService extends EventEmitter {
   }
 
   async createPeerConnection(): Promise<void> {
+    if (this.peerConnection || this.dataChannel) {
+      this.close();
+    }
+
     try {
       const configuration: RTCConfiguration = {
         iceServers: [


### PR DESCRIPTION
## Summary

- close an existing WebRTC data channel and peer connection before creating replacements
- reuse `WebRTCService.close()` as the existing lifecycle owner
- add a regression test covering repeated `createPeerConnection()` calls

## Root cause

`createPeerConnection()` assigned a new `RTCPeerConnection` while retaining the previous data channel, so recovery callers that did not call `close()` first leaked both resources.

## Validation

- `npm test -- src/WebRTCService.test.ts` (67 tests)
- `npm test` (1,039 tests)
- `npm run typecheck`
- `npm run build`
- `npm run lint:staged`

Closes #73