### PR TITLE
Recover WebRTC file transfers through GMCP signalling

### DIFF
--- a/src/FileTransferManager.test.ts
+++ b/src/FileTransferManager.test.ts
@@ -164,6 +164,71 @@ describe('FileTransferManager lifecycle', () => {
     expect(webRTCService.cleanup).toHaveBeenCalledTimes(1);
   });
 
+  it('re-signals an active outgoing transfer after WebRTC reconnects', async () => {
+    const { gmcpFileTransfer, manager, webRTCService } = createManager();
+    const file = new File(['hello'], 'hello.txt');
+    const transfers = manager as unknown as {
+      outgoingTransfers: Map<
+        string,
+        {
+          file: File;
+          filename: string;
+          hash: string;
+          recipient: string;
+        }
+      >;
+    };
+    transfers.outgoingTransfers.set('file-hash', {
+      file,
+      filename: file.name,
+      hash: 'file-hash',
+      recipient: 'Bob',
+    });
+    webRTCService.recipient = 'Bob';
+
+    webRTCService.emit('webRTCReconnecting');
+    await flush();
+
+    expect(webRTCService.createOffer).toHaveBeenCalledTimes(1);
+    expect(gmcpFileTransfer.sendOffer).toHaveBeenCalledWith({
+      recipient: 'Bob',
+      filename: 'hello.txt',
+      filesize: file.size,
+      offerSdp: JSON.stringify({ type: 'offer', sdp: 'mock' }),
+      hash: 'file-hash',
+    });
+  });
+
+  it('requests a fresh offer for an accepted incoming transfer after WebRTC reconnects', async () => {
+    const { gmcpFileTransfer, manager, webRTCService } = createManager();
+    const transfers = manager as unknown as {
+      acceptedOffers: Map<
+        string,
+        {
+          filename: string;
+          hash: string;
+          sender: string;
+          filesize: number;
+        }
+      >;
+    };
+    transfers.acceptedOffers.set('file-hash', {
+      filename: 'hello.txt',
+      hash: 'file-hash',
+      sender: 'Bob',
+      filesize: 5,
+    });
+    webRTCService.recipient = 'Bob';
+
+    webRTCService.emit('webRTCReconnecting');
+    await flush();
+
+    expect(gmcpFileTransfer.sendRequestResend).toHaveBeenCalledWith({
+      sender: 'Bob',
+      hash: 'file-hash',
+    });
+  });
+
   it('emits fileTransferAccepted when an outgoing transfer is accepted', async () => {
     const { manager, webRTCService } = createManager();
     webRTCService.isDataChannelOpen.mockReturnValue(true);

--- a/src/FileTransferManager.ts
+++ b/src/FileTransferManager.ts
@@ -97,6 +97,38 @@ export default class FileTransferManager extends EventEmitter {
       });
     }
   };
+  private readonly handleWebRTCReconnecting = async (): Promise<void> => {
+    const recipient = this.webRTCService.recipient;
+    const outgoingTransfer = Array.from(this.outgoingTransfers.values()).find(
+      (transfer) => transfer.recipient === recipient,
+    );
+
+    try {
+      if (outgoingTransfer) {
+        const offer = await this.webRTCService.createOffer();
+        await this.gmcpFileTransfer.sendOffer({
+          recipient: outgoingTransfer.recipient,
+          filename: outgoingTransfer.filename,
+          filesize: outgoingTransfer.file.size,
+          offerSdp: JSON.stringify(offer),
+          hash: outgoingTransfer.hash,
+        });
+        return;
+      }
+
+      const acceptedOffer = Array.from(this.acceptedOffers.values()).find(
+        (offer) => offer.sender === recipient,
+      );
+      if (acceptedOffer) {
+        await this.gmcpFileTransfer.sendRequestResend({
+          sender: acceptedOffer.sender,
+          hash: acceptedOffer.hash,
+        });
+      }
+    } catch (error) {
+      console.error('[FileTransferManager] Failed to re-signal recovered connection:', error);
+    }
+  };
 
   constructor(webRTCService: WebRTCService, gmcpFileTransfer: GMCPClientFileTransfer) {
     super();
@@ -124,6 +156,7 @@ export default class FileTransferManager extends EventEmitter {
   private setupListeners(): void {
     this.webRTCService.on('dataChannelMessage', this.handleDataChannelMessage);
     this.webRTCService.on('iceCandidate', this.handleLocalIceCandidate);
+    this.webRTCService.on('webRTCReconnecting', this.handleWebRTCReconnecting);
     this.gmcpFileTransfer.on('offer', this.handleFileTransferOffer);
     this.gmcpFileTransfer.on('accept', this.handleFileTransferAccepted);
     this.gmcpFileTransfer.on('reject', this.handleFileTransferRejected);
@@ -695,6 +728,7 @@ export default class FileTransferManager extends EventEmitter {
   cleanup(): void {
     this.webRTCService.off('dataChannelMessage', this.handleDataChannelMessage);
     this.webRTCService.off('iceCandidate', this.handleLocalIceCandidate);
+    this.webRTCService.off('webRTCReconnecting', this.handleWebRTCReconnecting);
     this.gmcpFileTransfer.off('offer', this.handleFileTransferOffer);
     this.gmcpFileTransfer.off('accept', this.handleFileTransferAccepted);
     this.gmcpFileTransfer.off('reject', this.handleFileTransferRejected);

--- a/src/WebRTCService.test.ts
+++ b/src/WebRTCService.test.ts
@@ -838,6 +838,18 @@ describe('WebRTCService', () => {
   });
 
   describe('attemptRecovery', () => {
+    it('coalesces concurrent recovery attempts', async () => {
+      await webRTCService.createPeerConnection();
+      const createPeerConnectionSpy = vi.spyOn(webRTCService, 'createPeerConnection');
+
+      await Promise.all([
+        (webRTCService as any).attemptRecovery(),
+        (webRTCService as any).attemptRecovery(),
+      ]);
+
+      expect(createPeerConnectionSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should close existing connection and create new one', async () => {
       await webRTCService.createPeerConnection();
 

--- a/src/WebRTCService.ts
+++ b/src/WebRTCService.ts
@@ -5,6 +5,7 @@ export class WebRTCService extends EventEmitter {
   private dataChannel: RTCDataChannel | null = null;
   private connectionTimeout: number = 300000; // 5 minutes timeout
   private connectionTimeoutId?: number;
+  private recoveryAttempt: Promise<void> | null = null;
   public recipient: string = '';
   public pendingCandidates: RTCIceCandidateInit[] = [];
 
@@ -160,22 +161,28 @@ export class WebRTCService extends EventEmitter {
     };
   }
 
-  private async attemptRecovery(): Promise<void> {
-    try {
+  private attemptRecovery(): Promise<void> {
+    if (!this.recoveryAttempt) {
       console.log('[WebRTCService] Attempting connection recovery');
-      // Close existing connection
-      this.close();
-
-      // Wait a moment before reconnecting
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      // Try to establish a new connection
-      await this.createPeerConnection();
-
-      console.log('[WebRTCService] Recovery attempt completed');
-    } catch (error) {
-      console.error('[WebRTCService] Recovery attempt failed:', error);
+      this.recoveryAttempt = Promise.resolve()
+        .then(async () => {
+          this.close();
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          await this.createPeerConnection();
+          this.emit('webRTCReconnecting');
+        })
+        .then(() => {
+          console.log('[WebRTCService] Recovery attempt completed');
+        })
+        .catch((error) => {
+          console.error('[WebRTCService] Recovery attempt failed:', error);
+        })
+        .finally(() => {
+          this.recoveryAttempt = null;
+        });
     }
+
+    return this.recoveryAttempt;
   }
 
   private async attemptChannelRecovery(): Promise<void> {


### PR DESCRIPTION
## Summary

- coalesce concurrent WebRTC recovery attempts into one replacement connection
- re-signal outgoing transfers with a fresh GMCP offer after reconnect
- request a fresh offer for accepted incoming transfers
- unregister the recovery listener during manager cleanup

## Root cause

Recovery rebuilt the peer connection inside `WebRTCService` but never handed control back to `FileTransferManager`, the owner of the offer/answer signalling path. Multiple recovery calls also had no shared in-flight guard.

## Verification

- `npm test -- src/WebRTCService.test.ts src/FileTransferManager.test.ts` (82 passed)
- `npm test` (1,042 passed)
- `npm run typecheck`
- staged Biome lint hook

Closes #72