### PR TITLE
Activate service worker updates immediately

### DIFF
--- a/src/sw.test.ts
+++ b/src/sw.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const workboxMocks = vi.hoisted(() => ({
+  cleanupOutdatedCaches: vi.fn(),
+  clientsClaim: vi.fn(),
+  precacheAndRoute: vi.fn(),
+  registerRoute: vi.fn(),
+}));
+
+vi.mock("workbox-core", () => ({
+  clientsClaim: workboxMocks.clientsClaim,
+}));
+
+vi.mock("workbox-precaching", () => ({
+  cleanupOutdatedCaches: workboxMocks.cleanupOutdatedCaches,
+  precacheAndRoute: workboxMocks.precacheAndRoute,
+}));
+
+vi.mock("workbox-routing", () => ({
+  registerRoute: workboxMocks.registerRoute,
+}));
+
+vi.mock("workbox-strategies", () => ({
+  CacheFirst: vi.fn(),
+}));
+
+vi.mock("workbox-expiration", () => ({
+  ExpirationPlugin: vi.fn(),
+}));
+
+describe("service worker activation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("activates an installed update without waiting for every tab to close", async () => {
+    const skipWaiting = vi.fn();
+    vi.stubGlobal("self", {
+      __WB_MANIFEST: [],
+      addEventListener: vi.fn(),
+      skipWaiting,
+    });
+
+    await import("./sw");
+
+    expect(skipWaiting).toHaveBeenCalledOnce();
+  });
+});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -15,6 +15,7 @@ type PushPayload = {
   url?: string;
 };
 
+self.skipWaiting();
 clientsClaim();
 cleanupOutdatedCaches();
 precacheAndRoute(self.__WB_MANIFEST);


### PR DESCRIPTION
## Summary

- activate newly installed service-worker updates immediately
- add a regression test covering worker startup activation

## Root cause

The inject-manifest service worker claimed clients after activation but never called `skipWaiting()`, so an installed update remained waiting until every open tab closed.

## Impact

Deployed updates can activate while existing tabs remain open instead of leaving users on the previous bundle indefinitely.

## Verification

- `npm test -- src/sw.test.ts` (red before the fix, green after)
- `npm test` (105 files, 1043 tests)
- `npm run typecheck`
- `npm run build`
- `npm run precommit`

Closes #65