### PR TITLE
Centralize persisted state

### DIFF
--- a/src/FileTransferStore.ts
+++ b/src/FileTransferStore.ts
@@ -1,4 +1,9 @@
-import { openDB, IDBPDatabase } from 'idb';
+import {
+  openIndexedDatabase,
+  requestToPromise,
+  transactionDone,
+  type IndexedDatabaseSchema,
+} from "./persistence";
 
 export interface FileChunk {
   hash: string;
@@ -19,108 +24,153 @@ export interface FileMetadata {
   mimeType?: string;
 }
 
+const fileTransferDatabaseSchema: IndexedDatabaseSchema = {
+  name: "file-transfer-store",
+  version: 1,
+  upgrade: (database) => {
+    if (!database.objectStoreNames.contains("chunks")) {
+      const chunkStore = database.createObjectStore("chunks", {
+        keyPath: ["hash", "index"],
+      });
+      chunkStore.createIndex("hash", "hash", { unique: false });
+    }
+
+    if (!database.objectStoreNames.contains("metadata")) {
+      const metadataStore = database.createObjectStore("metadata", {
+        keyPath: "hash",
+      });
+      metadataStore.createIndex("direction", "direction", { unique: false });
+    }
+  },
+};
+
 export class FileTransferStore {
-  private db: IDBPDatabase | null = null;
-  private dbName = 'file-transfer-store';
-  private dbVersion = 1;
+  private db: IDBDatabase | null = null;
 
   async initialize(): Promise<void> {
-    this.db = await openDB(this.dbName, this.dbVersion, {
-      upgrade(db) {
-        // Create object stores if they don't exist
-        if (!db.objectStoreNames.contains('chunks')) {
-          const chunkStore = db.createObjectStore('chunks', { keyPath: ['hash', 'index'] });
-          chunkStore.createIndex('hash', 'hash', { unique: false });
-        }
-        
-        if (!db.objectStoreNames.contains('metadata')) {
-          const metadataStore = db.createObjectStore('metadata', { keyPath: 'hash' });
-          metadataStore.createIndex('direction', 'direction', { unique: false });
-        }
-      }
-    });
+    this.db = await openIndexedDatabase(fileTransferDatabaseSchema);
   }
 
   async saveChunk(chunk: FileChunk): Promise<void> {
     if (!this.db) await this.initialize();
 
     const tx = this.db!.transaction(['chunks', 'metadata'], 'readwrite');
-    await tx.objectStore('chunks').put(chunk);
+    const done = transactionDone(tx);
+    await requestToPromise(tx.objectStore('chunks').put(chunk));
 
-    const metadata = await tx.objectStore('metadata').get(chunk.hash);
+    const metadata = await requestToPromise<FileMetadata | undefined>(
+      tx.objectStore('metadata').get(chunk.hash),
+    );
     if (metadata) {
       if (!metadata.receivedChunks.includes(chunk.index)) {
-        await tx.objectStore('metadata').put({
-          ...metadata,
-          receivedChunks: [...metadata.receivedChunks, chunk.index],
-          lastActivityTimestamp: Date.now(),
-        });
+        await requestToPromise(
+          tx.objectStore('metadata').put({
+            ...metadata,
+            receivedChunks: [...metadata.receivedChunks, chunk.index],
+            lastActivityTimestamp: Date.now(),
+          }),
+        );
       }
     }
-    await tx.done;
+    await done;
   }
 
   async getChunk(hash: string, index: number): Promise<FileChunk | undefined> {
     if (!this.db) await this.initialize();
-    return this.db!.get('chunks', [hash, index]);
+    const tx = this.db!.transaction('chunks', 'readonly');
+    const done = transactionDone(tx);
+    const chunk = await requestToPromise<FileChunk | undefined>(
+      tx.objectStore('chunks').get([hash, index]),
+    );
+    await done;
+    return chunk;
   }
 
   async getAllChunks(hash: string): Promise<FileChunk[]> {
     if (!this.db) await this.initialize();
-    return this.db!.getAllFromIndex('chunks', 'hash', hash);
+    const tx = this.db!.transaction('chunks', 'readonly');
+    const done = transactionDone(tx);
+    const chunks = await requestToPromise<FileChunk[]>(
+      tx.objectStore('chunks').index('hash').getAll(hash),
+    );
+    await done;
+    return chunks;
   }
 
   async saveFileMetadata(metadata: FileMetadata): Promise<void> {
     if (!this.db) await this.initialize();
-    await this.db!.put('metadata', metadata);
+    const tx = this.db!.transaction('metadata', 'readwrite');
+    const done = transactionDone(tx);
+    tx.objectStore('metadata').put(metadata);
+    await done;
   }
 
   async updateFileMetadata(metadata: FileMetadata): Promise<void> {
-    if (!this.db) await this.initialize();
-    await this.db!.put('metadata', metadata);
+    await this.saveFileMetadata(metadata);
   }
 
   async getFileMetadata(hash: string): Promise<FileMetadata | undefined> {
     if (!this.db) await this.initialize();
-    return this.db!.get('metadata', hash);
+    const tx = this.db!.transaction('metadata', 'readonly');
+    const done = transactionDone(tx);
+    const metadata = await requestToPromise<FileMetadata | undefined>(
+      tx.objectStore('metadata').get(hash),
+    );
+    await done;
+    return metadata;
   }
 
   async getAllFileMetadata(): Promise<FileMetadata[]> {
     if (!this.db) await this.initialize();
-    return this.db!.getAll('metadata');
+    const tx = this.db!.transaction('metadata', 'readonly');
+    const done = transactionDone(tx);
+    const metadata = await requestToPromise<FileMetadata[]>(
+      tx.objectStore('metadata').getAll(),
+    );
+    await done;
+    return metadata;
   }
 
   async getIncompleteTransfers(direction: 'incoming' | 'outgoing'): Promise<FileMetadata[]> {
     if (!this.db) await this.initialize();
-    const allMetadata = await this.db!.getAllFromIndex('metadata', 'direction', direction);
-    return allMetadata.filter(metadata => 
+    const tx = this.db!.transaction('metadata', 'readonly');
+    const done = transactionDone(tx);
+    const allMetadata = await requestToPromise<FileMetadata[]>(
+      tx.objectStore('metadata').index('direction').getAll(direction),
+    );
+    await done;
+    return allMetadata.filter(metadata =>
       metadata.receivedChunks.length < metadata.totalChunks
     );
   }
 
   async deleteFile(hash: string): Promise<void> {
     if (!this.db) await this.initialize();
-    
+
     // Delete all chunks
     const tx = this.db!.transaction(['chunks', 'metadata'], 'readwrite');
-    const chunks = await tx.objectStore('chunks').index('hash').getAll(hash);
-    
+    const done = transactionDone(tx);
+    const chunks = await requestToPromise<FileChunk[]>(
+      tx.objectStore('chunks').index('hash').getAll(hash),
+    );
+
     for (const chunk of chunks) {
-      await tx.objectStore('chunks').delete([hash, chunk.index]);
+      tx.objectStore('chunks').delete([hash, chunk.index]);
     }
-    
+
     // Delete metadata
-    await tx.objectStore('metadata').delete(hash);
-    await tx.done;
+    tx.objectStore('metadata').delete(hash);
+    await done;
   }
 
   async clearAll(): Promise<void> {
     if (!this.db) await this.initialize();
-    
+
     const tx = this.db!.transaction(['chunks', 'metadata'], 'readwrite');
-    await tx.objectStore('chunks').clear();
-    await tx.objectStore('metadata').clear();
-    await tx.done;
+    const done = transactionDone(tx);
+    tx.objectStore('chunks').clear();
+    tx.objectStore('metadata').clear();
+    await done;
   }
 
   async close(): Promise<void> {

--- a/src/SessionRecorder.ts
+++ b/src/SessionRecorder.ts
@@ -1,3 +1,10 @@
+import {
+  openIndexedDatabase,
+  requestToPromise,
+  transactionDone,
+  type IndexedDatabaseSchema,
+} from "./persistence";
+
 export interface SessionEvent {
   timestamp: number;
   type: 'websocket-send' | 'websocket-receive' | 'user-input' | 'connection' | 'gmcp' | 'mcp' | 'file-transfer' | 'error';
@@ -24,6 +31,20 @@ export interface SessionLog {
   metadata: SessionMetadata;
   events: SessionEvent[];
 }
+
+const sessionDatabaseSchema: IndexedDatabaseSchema = {
+  name: "SessionLogs",
+  version: 1,
+  upgrade: (database) => {
+    if (!database.objectStoreNames.contains("sessions")) {
+      const store = database.createObjectStore("sessions", {
+        keyPath: "metadata.sessionId",
+      });
+      store.createIndex("startTime", "metadata.startTime");
+      store.createIndex("url", "metadata.url");
+    }
+  },
+};
 
 export class SessionRecorder {
   private events: SessionEvent[] = [];
@@ -184,69 +205,45 @@ export class SessionRecorder {
 
   async saveSessionToIndexedDB(): Promise<void> {
     const sessionLog = this.getSessionLog();
-    
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.open('SessionLogs', 1);
-      
-      request.onerror = () => reject(request.error);
-      
-      request.onsuccess = () => {
-        const db = request.result;
-        const transaction = db.transaction(['sessions'], 'readwrite');
-        const store = transaction.objectStore('sessions');
-        
-        const addRequest = store.put(sessionLog);
-        addRequest.onsuccess = () => resolve();
-        addRequest.onerror = () => reject(addRequest.error);
-      };
-      
-      request.onupgradeneeded = () => {
-        const db = request.result;
-        if (!db.objectStoreNames.contains('sessions')) {
-          const store = db.createObjectStore('sessions', { keyPath: 'metadata.sessionId' });
-          store.createIndex('startTime', 'metadata.startTime');
-          store.createIndex('url', 'metadata.url');
-        }
-      };
-    });
+
+    const database = await openIndexedDatabase(sessionDatabaseSchema);
+    try {
+      const transaction = database.transaction("sessions", "readwrite");
+      const done = transactionDone(transaction);
+      transaction.objectStore("sessions").put(sessionLog);
+      await done;
+    } finally {
+      database.close();
+    }
   }
 
   static async loadSessionFromIndexedDB(sessionId: string): Promise<SessionLog | null> {
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.open('SessionLogs', 1);
-      
-      request.onerror = () => reject(request.error);
-      
-      request.onsuccess = () => {
-        const db = request.result;
-        const transaction = db.transaction(['sessions'], 'readonly');
-        const store = transaction.objectStore('sessions');
-        
-        const getRequest = store.get(sessionId);
-        getRequest.onsuccess = () => resolve(getRequest.result || null);
-        getRequest.onerror = () => reject(getRequest.error);
-      };
-    });
+    const database = await openIndexedDatabase(sessionDatabaseSchema);
+    try {
+      const transaction = database.transaction("sessions", "readonly");
+      const done = transactionDone(transaction);
+      const session = await requestToPromise<SessionLog | undefined>(
+        transaction.objectStore("sessions").get(sessionId),
+      );
+      await done;
+      return session ?? null;
+    } finally {
+      database.close();
+    }
   }
 
   static async listSessions(): Promise<SessionMetadata[]> {
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.open('SessionLogs', 1);
-      
-      request.onerror = () => reject(request.error);
-      
-      request.onsuccess = () => {
-        const db = request.result;
-        const transaction = db.transaction(['sessions'], 'readonly');
-        const store = transaction.objectStore('sessions');
-        
-        const getAllRequest = store.getAll();
-        getAllRequest.onsuccess = () => {
-          const sessions = getAllRequest.result.map((log: SessionLog) => log.metadata);
-          resolve(sessions);
-        };
-        getAllRequest.onerror = () => reject(getAllRequest.error);
-      };
-    });
+    const database = await openIndexedDatabase(sessionDatabaseSchema);
+    try {
+      const transaction = database.transaction("sessions", "readonly");
+      const done = transactionDone(transaction);
+      const sessions = await requestToPromise<SessionLog[]>(
+        transaction.objectStore("sessions").getAll(),
+      );
+      await done;
+      return sessions.map((log) => log.metadata);
+    } finally {
+      database.close();
+    }
   }
 }

--- a/src/components/input.test.tsx
+++ b/src/components/input.test.tsx
@@ -234,7 +234,8 @@ describe('CommandInput Component', () => {
     
     // Should have saved only the last 1000 commands
     const savedValue = JSON.parse(localStorageMock.setItem.mock.calls[0][1]);
-    expect(savedValue.length).toBeLessThanOrEqual(1000);
+    expect(savedValue.version).toBe(1);
+    expect(savedValue.data.length).toBeLessThanOrEqual(1000);
   });
 
 });

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -7,6 +7,11 @@ import { useRoomStore } from "../stores/roomStore";
 import { registerCommandInput } from "../inputFocus";
 import type MudClient from "../client"; // Import MudClient
 import type { RoomPlayer } from "../gmcp/Room"; // Import RoomPlayer type
+import {
+  loadStoredValue,
+  saveStoredValue,
+  type LocalStorageSchema,
+} from "../persistence";
 
 type SendFunction = (text: string) => void;
 
@@ -17,7 +22,19 @@ type Props = {
 };
 
 const STORAGE_KEY = 'command_history';
+const STORAGE_VERSION = 1;
 const MAX_HISTORY = 1000;
+
+const commandHistorySchema: LocalStorageSchema<string[]> = {
+  key: STORAGE_KEY,
+  version: STORAGE_VERSION,
+  migrate: (data, storedVersion) => {
+    if (storedVersion > STORAGE_VERSION || !Array.isArray(data)) {
+      return undefined;
+    }
+    return data.filter((command): command is string => typeof command === "string");
+  },
+};
 
 // Helper function to quote name if needed
 const quoteNameIfNeeded = (name: string): string => {
@@ -59,23 +76,10 @@ const CommandInput = ({ onSend, inputRef }: Props) => {
 
   // Load saved history on component mount
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (!saved) return;
-    try {
-      const savedHistory = JSON.parse(saved);
-      if (!Array.isArray(savedHistory)) {
-        throw new Error('command history is not an array');
-      }
-      // Replay the commands into CommandHistory (skip non-string entries defensively)
-      savedHistory.forEach((cmd: unknown) => {
-        if (typeof cmd === 'string') {
-          commandHistoryRef.current.addCommand(cmd);
-        }
-      });
-    } catch (e) {
-      console.warn('Failed to load command history:', e);
-      localStorage.removeItem(STORAGE_KEY);
-    }
+    const savedHistory = loadStoredValue(commandHistorySchema, []);
+    savedHistory.forEach((command) => {
+      commandHistoryRef.current.addCommand(command);
+    });
   }, []);
 
   // Register input ref with InputStore for focus functionality
@@ -90,7 +94,7 @@ const CommandInput = ({ onSend, inputRef }: Props) => {
       const history = commandHistoryRef.current.getHistory();
       // Save only up to MAX_HISTORY commands
       const trimmedHistory = history.slice(-MAX_HISTORY);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmedHistory));
+      saveStoredValue(commandHistorySchema, trimmedHistory);
     } catch (e) {
       console.warn('Failed to save command history:', e);
     }

--- a/src/components/output.test.tsx
+++ b/src/components/output.test.tsx
@@ -125,7 +125,7 @@ describe("Output persistence", () => {
   };
 
   const parsePayload = (raw: unknown) =>
-    JSON.parse(raw as string) as { version: number; lines: unknown[] };
+    JSON.parse(raw as string) as { version: number; data: unknown[] };
 
   beforeEach(() => {
     localStorage.clear();
@@ -148,8 +148,8 @@ describe("Output persistence", () => {
 
     // First (failed) attempt writes all 10 lines; the retry writes the recent half.
     expect(setItemSpy).toHaveBeenCalledTimes(2);
-    expect(parsePayload(setItemSpy.mock.calls[0][1]).lines).toHaveLength(10);
-    expect(parsePayload(setItemSpy.mock.calls[1][1]).lines).toHaveLength(5);
+    expect(parsePayload(setItemSpy.mock.calls[0][1]).data).toHaveLength(10);
+    expect(parsePayload(setItemSpy.mock.calls[1][1]).data).toHaveLength(5);
 
     // Component still functions: a subsequent save succeeds without throwing.
     expect(() => output.saveOutput()).not.toThrow();
@@ -182,7 +182,7 @@ describe("Output persistence", () => {
     vi.advanceTimersByTime(500);
 
     expect(setItemSpy).toHaveBeenCalledTimes(1);
-    expect(parsePayload(setItemSpy.mock.calls[0][1]).lines).toHaveLength(3);
+    expect(parsePayload(setItemSpy.mock.calls[0][1]).data).toHaveLength(3);
   });
 
   it("flushes the pending save synchronously on unmount", () => {
@@ -197,7 +197,7 @@ describe("Output persistence", () => {
 
     // Written synchronously, before any timer advances.
     expect(setItemSpy).toHaveBeenCalledTimes(1);
-    expect(parsePayload(setItemSpy.mock.calls[0][1]).lines).toHaveLength(2);
+    expect(parsePayload(setItemSpy.mock.calls[0][1]).data).toHaveLength(2);
   });
 
   it("cancels a pending save on clearLog so stale data is not re-persisted", () => {

--- a/src/components/output.tsx
+++ b/src/components/output.tsx
@@ -14,6 +14,12 @@ import { useOutputStore, type OutputEntry } from '../stores/outputStore';
 import BlockquoteWithCopy from './BlockquoteWithCopy';
 import { autoLogService } from '../logging/AutoLogService';
 import type { AutoLogLineType, AutoLogSourceType } from '../logging/AutoLogTypes';
+import {
+  loadStoredValue,
+  removeStoredValue,
+  saveStoredValue,
+  type LocalStorageSchema,
+} from "../persistence";
 
 export enum OutputType {
   Command = 'command',
@@ -39,24 +45,33 @@ interface SavedOutputLine {
   metadata?: Record<string, any>; // Optional additional data
 }
 
-interface StoredOutputLog {
-  version: number;
-  lines: SavedOutputLine[];
-}
-
 const OUTPUT_LOG_VERSION = 2;
+const outputLogSchema: LocalStorageSchema<SavedOutputLine[]> = {
+  key: "outputLog",
+  version: OUTPUT_LOG_VERSION,
+  migrate: (data, storedVersion) => {
+    if (storedVersion > OUTPUT_LOG_VERSION) {
+      return undefined;
+    }
 
-// localStorage quota errors surface as a DOMException whose name/code differs
-// across browsers (QuotaExceededError / NS_ERROR_DOM_QUOTA_REACHED).
-function isQuotaExceededError(error: unknown): boolean {
-  return (
-    error instanceof DOMException &&
-    (error.name === "QuotaExceededError" ||
-      error.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
-      error.code === 22 ||
-      error.code === 1014)
-  );
-}
+    if (Array.isArray(data)) {
+      return data as SavedOutputLine[];
+    }
+
+    // The pre-shared-persistence shape carried its domain version beside lines.
+    if (
+      storedVersion === 0 &&
+      typeof data === "object" &&
+      data !== null &&
+      (data as { version?: unknown }).version === OUTPUT_LOG_VERSION &&
+      Array.isArray((data as { lines?: unknown }).lines)
+    ) {
+      return (data as { lines: SavedOutputLine[] }).lines;
+    }
+
+    return undefined;
+  },
+};
 
 interface Props {
   client: MudClient;
@@ -128,31 +143,13 @@ class Output extends React.Component<Props, State> {
       };
     }).filter(savedLine => savedLine.sourceContent !== ""); // Filter out lines that ended up empty
 
-    const writeLines = (lines: SavedOutputLine[]) => {
-      const storedLog: StoredOutputLog = {
-        version: OUTPUT_LOG_VERSION,
-        lines,
-      };
-      localStorage.setItem(Output.LOCAL_STORAGE_KEY, JSON.stringify(storedLog));
-    };
-
     // Saving is best-effort — a failed write (e.g. QuotaExceededError) must never
     // propagate out of componentDidUpdate and crash the output view.
-    try {
-      writeLines(linesToSave);
-    } catch (error) {
-      if (isQuotaExceededError(error)) {
-        // One recovery attempt: drop the oldest half of the persisted set and retry.
-        const trimmed = linesToSave.slice(Math.floor(linesToSave.length / 2));
-        try {
-          writeLines(trimmed);
-          return;
-        } catch (retryError) {
-          console.warn("Failed to persist output log after trimming:", retryError);
-          return;
-        }
-      }
-      console.warn("Failed to persist output log:", error);
+    const result = saveStoredValue(outputLogSchema, linesToSave);
+    if (result === "quota-exceeded") {
+      // One recovery attempt: drop the oldest half of the persisted set and retry.
+      const trimmed = linesToSave.slice(Math.floor(linesToSave.length / 2));
+      saveStoredValue(outputLogSchema, trimmed);
     }
   };
 
@@ -262,53 +259,25 @@ class Output extends React.Component<Props, State> {
   };
 
   loadOutput = (): OutputLine[] => {
-    const savedOutputString = localStorage.getItem(Output.LOCAL_STORAGE_KEY);
-    if (savedOutputString) {
-      try {
-        const parsedData = JSON.parse(savedOutputString);
+    const savedLines = loadStoredValue(outputLogSchema, []);
+    // Re-process source data through handlers to recreate proper React components.
+    return savedLines.map((savedLine: SavedOutputLine): OutputLine => {
+      const currentKey = this.messageKey++;
+      const recreatedElements = this.recreateContentFromSource(savedLine);
 
-        // Check for new versioned format
-        if (parsedData && typeof parsedData === 'object' && 'version' in parsedData && 'lines' in parsedData) {
-          const storedLog = parsedData as StoredOutputLog;
-          if (storedLog.version === OUTPUT_LOG_VERSION) {
-            // Re-process source data through handlers to recreate proper React components
-            return storedLog.lines.map((savedLine: SavedOutputLine): OutputLine => {
-              const currentKey = this.messageKey++;
-              const recreatedElements = this.recreateContentFromSource(savedLine);
+      const wrappedContent = recreatedElements.length === 1 ?
+        recreatedElements[0] :
+        <>{recreatedElements}</>;
 
-              // Create the wrapper div with the recreated content
-              const wrappedContent = recreatedElements.length === 1 ?
-                recreatedElements[0] :
-                <>{recreatedElements}</>;
-
-              return {
-                id: currentKey,
-                type: savedLine.type,
-                content: <div key={currentKey} className={`output-line output-line-${savedLine.type}`}>{wrappedContent}</div>,
-                sourceType: savedLine.sourceType,
-                sourceContent: savedLine.sourceContent,
-                metadata: savedLine.metadata
-              };
-            });
-          } else {
-            // Clear old incompatible data
-            console.warn(`Unsupported log version: ${storedLog.version}. Clearing old data.`);
-            localStorage.removeItem(Output.LOCAL_STORAGE_KEY);
-            return [];
-          }
-        } else {
-          // Clear old format data
-          console.log("Clearing old format output log.");
-          localStorage.removeItem(Output.LOCAL_STORAGE_KEY);
-          return [];
-        }
-      } catch (error) {
-        console.error("Failed to parse saved output log:", error);
-        localStorage.removeItem(Output.LOCAL_STORAGE_KEY); // Clear corrupted data
-        return []; // Return empty array on error
-      }
-    }
-    return [];
+      return {
+        id: currentKey,
+        type: savedLine.type,
+        content: <div key={currentKey} className={`output-line output-line-${savedLine.type}`}>{wrappedContent}</div>,
+        sourceType: savedLine.sourceType,
+        sourceContent: savedLine.sourceContent,
+        metadata: savedLine.metadata
+      };
+    });
   };
 
   addCommand = (command: string) => {
@@ -729,7 +698,7 @@ scrollToBottom = () => { const output = this.outputRef.current; if (output) {
     const frozenDiv = this.frozenRef.current;
     if (frozenDiv) frozenDiv.innerHTML = '';
     this.setState({ liveOutput: [] });
-    localStorage.removeItem(Output.LOCAL_STORAGE_KEY); // Also clear from local storage
+    removeStoredValue(Output.LOCAL_STORAGE_KEY);
   }
 
   copyLog() {

--- a/src/dbStorage.ts
+++ b/src/dbStorage.ts
@@ -1,45 +1,60 @@
+import {
+    openIndexedDatabase,
+    requestToPromise,
+    transactionDone,
+    type IndexedDatabaseSchema,
+} from "./persistence";
+
 const DB_NAME = 'toaststunt-saves';
 const STORE_NAME = 'checkpoints';
 
-function openDB(): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-        const req = indexedDB.open(DB_NAME, 1);
-        req.onupgradeneeded = () => {
-            req.result.createObjectStore(STORE_NAME);
-        };
-        req.onsuccess = () => resolve(req.result);
-        req.onerror = () => reject(req.error);
-    });
-}
+const checkpointDatabaseSchema: IndexedDatabaseSchema = {
+    name: DB_NAME,
+    version: 1,
+    upgrade: (database) => {
+        if (!database.objectStoreNames.contains(STORE_NAME)) {
+            database.createObjectStore(STORE_NAME);
+        }
+    },
+};
 
 export async function saveCheckpoint(dbKey: string, data: Uint8Array): Promise<void> {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
+    const db = await openIndexedDatabase(checkpointDatabaseSchema);
+    try {
         const tx = db.transaction(STORE_NAME, 'readwrite');
+        const done = transactionDone(tx);
         tx.objectStore(STORE_NAME).put(data, dbKey);
-        tx.oncomplete = () => { db.close(); resolve(); };
-        tx.onerror = () => { db.close(); reject(tx.error); };
-    });
+        await done;
+    } finally {
+        db.close();
+    }
 }
 
 export async function loadCheckpoint(dbKey: string): Promise<Uint8Array | null> {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
+    const db = await openIndexedDatabase(checkpointDatabaseSchema);
+    try {
         const tx = db.transaction(STORE_NAME, 'readonly');
-        const req = tx.objectStore(STORE_NAME).get(dbKey);
-        req.onsuccess = () => { db.close(); resolve(req.result || null); };
-        req.onerror = () => { db.close(); reject(req.error); };
-    });
+        const done = transactionDone(tx);
+        const result = await requestToPromise<Uint8Array | undefined>(
+            tx.objectStore(STORE_NAME).get(dbKey),
+        );
+        await done;
+        return result ?? null;
+    } finally {
+        db.close();
+    }
 }
 
 export async function deleteCheckpoint(dbKey: string): Promise<void> {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
+    const db = await openIndexedDatabase(checkpointDatabaseSchema);
+    try {
         const tx = db.transaction(STORE_NAME, 'readwrite');
+        const done = transactionDone(tx);
         tx.objectStore(STORE_NAME).delete(dbKey);
-        tx.oncomplete = () => { db.close(); resolve(); };
-        tx.onerror = () => { db.close(); reject(tx.error); };
-    });
+        await done;
+    } finally {
+        db.close();
+    }
 }
 
 export async function hashDbBytes(data: ArrayBuffer): Promise<string> {

--- a/src/gmcp/Auth.ts
+++ b/src/gmcp/Auth.ts
@@ -1,9 +1,20 @@
 import { inbound, outbound } from "../protocol/messages";
+import {
+    loadStoredValue,
+    saveStoredValue,
+    type LocalStorageSchema,
+} from "../persistence";
 import { gmcpJsonMessage } from "./messages";
 import { GMCPPackage } from "./package";
 
 const authToken = gmcpJsonMessage<"Token", string>("Token");
 const authLogin = gmcpJsonMessage<"Login", never, string>("Login");
+const authTokenSchema: LocalStorageSchema<string> = {
+    key: "LoginRefreshToken",
+    version: 1,
+    migrate: (data, storedVersion) =>
+        storedVersion <= 1 && typeof data === "string" ? data : undefined,
+};
 
 const GMCPAutoLoginBase = GMCPPackage.with({
     packageName: "Auth.Autologin",
@@ -20,11 +31,11 @@ export class GMCPAutoLogin extends GMCPAutoLoginBase {
     }
 
     handleToken(data: string): void {
-        localStorage.setItem("LoginRefreshToken", data);
+        saveStoredValue(authTokenSchema, data);
     }
 
     sendStoredLogin(): void {
-        const token = localStorage.getItem("LoginRefreshToken");
+        const token = loadStoredValue(authTokenSchema, "");
         if (token) {
             this.sendLogin(token);
         }

--- a/src/hooks/useChannelHistory.test.tsx
+++ b/src/hooks/useChannelHistory.test.tsx
@@ -161,8 +161,9 @@ describe("useChannelHistory", () => {
       expect(saved).not.toBeNull();
 
       const parsed = JSON.parse(saved || "{}");
-      expect(parsed.buffers.all.messages).toHaveLength(MAX_PERSISTED_ALL_MESSAGES);
-      expect(parsed.buffers.gossip.messages).toHaveLength(MAX_PERSISTED_CHANNEL_MESSAGES);
+      expect(parsed.version).toBe(1);
+      expect(parsed.data.buffers.all.messages).toHaveLength(MAX_PERSISTED_ALL_MESSAGES);
+      expect(parsed.data.buffers.gossip.messages).toHaveLength(MAX_PERSISTED_CHANNEL_MESSAGES);
     });
   });
 

--- a/src/hooks/useChannelHistory.tsx
+++ b/src/hooks/useChannelHistory.tsx
@@ -3,6 +3,11 @@ import { announce } from "@react-aria/live-announcer";
 import { useChannelHistoryStore, type ChannelTextEntry } from "../stores/channelHistoryStore";
 import { usePreferences, type NavigationKeyScheme } from "../stores/preferencesStore";
 import { extractLinks, openLink, type ExtractedLink } from "../messageLinks";
+import {
+  loadStoredValue,
+  saveStoredValue,
+  type LocalStorageSchema,
+} from "../persistence";
 
 const navigationKeyMaps: Record<NavigationKeyScheme, { up: string; down: string; left: string; right: string }> = {
   jkli: { up: "i", down: "k", left: "j", right: "l" },
@@ -44,7 +49,30 @@ interface Buffer {
 }
 
 const CHANNEL_HISTORY_STORAGE_KEY = "channelHistory";
+const CHANNEL_HISTORY_STORAGE_VERSION = 1;
 const ALL_BUFFER_NAME = "all";
+
+type StoredChannelHistory = {
+  buffers?: Record<string, Partial<Buffer>>;
+  bufferOrder?: unknown[];
+  currentBufferIndex?: number;
+  timestampsEnabled?: boolean;
+};
+
+const channelHistorySchema: LocalStorageSchema<StoredChannelHistory> = {
+  key: CHANNEL_HISTORY_STORAGE_KEY,
+  version: CHANNEL_HISTORY_STORAGE_VERSION,
+  migrate: (data, storedVersion) => {
+    if (
+      storedVersion > CHANNEL_HISTORY_STORAGE_VERSION ||
+      typeof data !== "object" ||
+      data === null
+    ) {
+      return undefined;
+    }
+    return data as StoredChannelHistory;
+  },
+};
 
 export const MAX_ALL_BUFFER_MESSAGES = 1000;
 export const MAX_CHANNEL_BUFFER_MESSAGES = 500;
@@ -142,48 +170,40 @@ export const useChannelHistory = () => {
   const lastKeyPress = useRef<{ key: string; time: number; count: number } | null>(null);
   const lastProcessedChannelEntryId = useRef(0);
 
-  // Load state from localStorage on mount
+  // Load state through the shared versioned persistence owner on mount.
   useEffect(() => {
-    try {
-      const saved = localStorage.getItem(CHANNEL_HISTORY_STORAGE_KEY);
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        const storedOrder = Array.isArray(parsed.bufferOrder) ? parsed.bufferOrder : [];
-        const loadedOrder = [
-          ALL_BUFFER_NAME,
-          ...storedOrder.filter((name: unknown): name is string => typeof name === "string" && name !== ALL_BUFFER_NAME),
-        ];
-        const storedBuffers = parsed.buffers && typeof parsed.buffers === "object" ? parsed.buffers : {};
-        const loadedBuffers = new Map<string, Buffer>(
-          loadedOrder.map((name: string): [string, Buffer] => [
-            name,
-            normalizeLoadedBuffer(name, storedBuffers[name])
-          ])
-        );
-        setBuffers(loadedBuffers);
-        setBufferOrder(loadedOrder);
-        setCurrentBufferIndex(
-          Math.min(Math.max(parsed.currentBufferIndex || 0, 0), loadedOrder.length - 1)
-        );
-        setTimestampsEnabled(parsed.timestampsEnabled ?? true);
-      }
-    } catch (error) {
-      console.error("Failed to load channel history:", error);
-    }
+    const parsed = loadStoredValue<StoredChannelHistory>(
+      channelHistorySchema,
+      {},
+    );
+    const storedOrder = Array.isArray(parsed.bufferOrder) ? parsed.bufferOrder : [];
+    const loadedOrder = [
+      ALL_BUFFER_NAME,
+      ...storedOrder.filter((name: unknown): name is string => typeof name === "string" && name !== ALL_BUFFER_NAME),
+    ];
+    const storedBuffers = parsed.buffers && typeof parsed.buffers === "object" ? parsed.buffers : {};
+    const loadedBuffers = new Map<string, Buffer>(
+      loadedOrder.map((name: string): [string, Buffer] => [
+        name,
+        normalizeLoadedBuffer(name, storedBuffers[name])
+      ])
+    );
+    setBuffers(loadedBuffers);
+    setBufferOrder(loadedOrder);
+    setCurrentBufferIndex(
+      Math.min(Math.max(parsed.currentBufferIndex || 0, 0), loadedOrder.length - 1)
+    );
+    setTimestampsEnabled(parsed.timestampsEnabled ?? true);
   }, []);
 
-  // Save state to localStorage whenever it changes
+  // Save state through the same schema whenever it changes.
   useEffect(() => {
-    try {
-      localStorage.setItem(CHANNEL_HISTORY_STORAGE_KEY, JSON.stringify({
+    saveStoredValue(channelHistorySchema, {
         buffers: serializeBuffersForStorage(buffers),
         bufferOrder,
         currentBufferIndex,
         timestampsEnabled,
-      }));
-    } catch (error) {
-      console.error("Failed to save channel history:", error);
-    }
+    });
   }, [buffers, bufferOrder, currentBufferIndex, timestampsEnabled]);
 
   // Handle channel messages. The "all" buffer is the aggregate of every

--- a/src/logging/AutoLogStore.ts
+++ b/src/logging/AutoLogStore.ts
@@ -7,24 +7,31 @@ import {
   AutoLogSession,
   AutoLogSessionDraft,
 } from "./AutoLogTypes";
+import {
+  openIndexedDatabase,
+  requestToPromise,
+  transactionDone,
+  type IndexedDatabaseSchema,
+} from "../persistence";
 
 const SESSION_INDEX_STARTED_AT = "startedAt";
 const ENTRY_INDEX_SESSION_ID = "sessionId";
 
-function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-  });
-}
+const autoLogDatabaseSchema: IndexedDatabaseSchema = {
+  name: AUTOLOG_DB_NAME,
+  version: AUTOLOG_DB_VERSION,
+  upgrade: (database) => {
+    if (!database.objectStoreNames.contains(AUTOLOG_SESSIONS_STORE)) {
+      const sessions = database.createObjectStore(AUTOLOG_SESSIONS_STORE, { keyPath: "id" });
+      sessions.createIndex(SESSION_INDEX_STARTED_AT, "startedAt", { unique: false });
+    }
 
-function transactionDone(transaction: IDBTransaction): Promise<void> {
-  return new Promise((resolve, reject) => {
-    transaction.oncomplete = () => resolve();
-    transaction.onerror = () => reject(transaction.error);
-    transaction.onabort = () => reject(transaction.error);
-  });
-}
+    if (!database.objectStoreNames.contains(AUTOLOG_ENTRIES_STORE)) {
+      const entries = database.createObjectStore(AUTOLOG_ENTRIES_STORE, { keyPath: ["sessionId", "sequence"] });
+      entries.createIndex(ENTRY_INDEX_SESSION_ID, "sessionId", { unique: false });
+    }
+  },
+};
 
 function createSessionId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -47,26 +54,7 @@ export class AutoLogStore {
       return this.db;
     }
 
-    this.db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open(AUTOLOG_DB_NAME, AUTOLOG_DB_VERSION);
-
-      request.onupgradeneeded = () => {
-        const db = request.result;
-
-        if (!db.objectStoreNames.contains(AUTOLOG_SESSIONS_STORE)) {
-          const sessions = db.createObjectStore(AUTOLOG_SESSIONS_STORE, { keyPath: "id" });
-          sessions.createIndex(SESSION_INDEX_STARTED_AT, "startedAt", { unique: false });
-        }
-
-        if (!db.objectStoreNames.contains(AUTOLOG_ENTRIES_STORE)) {
-          const entries = db.createObjectStore(AUTOLOG_ENTRIES_STORE, { keyPath: ["sessionId", "sequence"] });
-          entries.createIndex(ENTRY_INDEX_SESSION_ID, "sessionId", { unique: false });
-        }
-      };
-
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
-    });
+    this.db = await openIndexedDatabase(autoLogDatabaseSchema);
 
     this.db.onversionchange = () => {
       this.close();

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadStoredValue,
+  openIndexedDatabase,
+  removeStoredValue,
+  saveStoredValue,
+  type LocalStorageSchema,
+} from "./persistence";
+
+type ExampleState = {
+  name: string;
+};
+
+const schema: LocalStorageSchema<ExampleState> = {
+  key: "example-state",
+  version: 2,
+  migrate: (data, storedVersion) => {
+    if (
+      storedVersion > 2 ||
+      typeof data !== "object" ||
+      data === null ||
+      typeof (data as { name?: unknown }).name !== "string"
+    ) {
+      return undefined;
+    }
+
+    return { name: (data as { name: string }).name };
+  },
+};
+
+describe("local persistence", () => {
+  beforeEach(() => {
+    vi.mocked(localStorage.getItem).mockReset();
+    vi.mocked(localStorage.setItem).mockReset();
+    vi.mocked(localStorage.removeItem).mockReset();
+  });
+
+  it("loads a current versioned value through the schema migration entry point", () => {
+    vi.mocked(localStorage.getItem).mockReturnValueOnce(
+      JSON.stringify({ version: 2, data: { name: "current" } }),
+    );
+
+    expect(loadStoredValue(schema, { name: "fallback" })).toEqual({
+      name: "current",
+    });
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("migrates an unversioned legacy value and writes the current envelope", () => {
+    vi.mocked(localStorage.getItem).mockReturnValueOnce(
+      JSON.stringify({ name: "legacy" }),
+    );
+
+    expect(loadStoredValue(schema, { name: "fallback" })).toEqual({
+      name: "legacy",
+    });
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "example-state",
+      JSON.stringify({ version: 2, data: { name: "legacy" } }),
+    );
+  });
+
+  it("migrates a legacy raw string that was not JSON encoded", () => {
+    const rawStringSchema: LocalStorageSchema<string> = {
+      key: "legacy-token",
+      version: 1,
+      migrate: (data, storedVersion) =>
+        storedVersion === 0 && typeof data === "string" ? data : undefined,
+    };
+    vi.mocked(localStorage.getItem).mockReturnValueOnce("legacy-token-value");
+
+    expect(loadStoredValue(rawStringSchema, "")).toBe("legacy-token-value");
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "legacy-token",
+      JSON.stringify({ version: 1, data: "legacy-token-value" }),
+    );
+  });
+
+  it("returns the fallback when storage access is blocked", () => {
+    vi.mocked(localStorage.getItem).mockImplementationOnce(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+
+    expect(loadStoredValue(schema, { name: "fallback" })).toEqual({
+      name: "fallback",
+    });
+  });
+
+  it("reports quota and unavailable writes through one result policy", () => {
+    vi.mocked(localStorage.setItem)
+      .mockImplementationOnce(() => {
+        throw new DOMException("full", "QuotaExceededError");
+      })
+      .mockImplementationOnce(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+
+    expect(saveStoredValue(schema, { name: "quota" })).toBe("quota-exceeded");
+    expect(saveStoredValue(schema, { name: "blocked" })).toBe("unavailable");
+  });
+
+  it("guards removals when storage is unavailable", () => {
+    vi.mocked(localStorage.removeItem).mockImplementationOnce(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+
+    expect(removeStoredValue("example-state")).toBe(false);
+  });
+});
+
+describe("IndexedDB persistence", () => {
+  const databaseName = `persistence-test-${crypto.randomUUID()}`;
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(databaseName);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  });
+
+  it("runs database creation and migrations through one versioned entry point", async () => {
+    const upgrade = vi.fn((database: IDBDatabase) => {
+      database.createObjectStore("records");
+    });
+
+    const database = await openIndexedDatabase({
+      name: databaseName,
+      version: 2,
+      upgrade,
+    });
+
+    expect(upgrade).toHaveBeenCalledOnce();
+    expect(upgrade).toHaveBeenCalledWith(
+      database,
+      0,
+      2,
+      expect.any(IDBTransaction),
+    );
+    expect(database.objectStoreNames.contains("records")).toBe(true);
+    database.close();
+  });
+});

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,0 +1,187 @@
+export type LocalStorageSchema<T> = {
+  key: string;
+  version: number;
+  migrate: (data: unknown, storedVersion: number) => T | undefined;
+};
+
+export type StorageWriteResult =
+  | "saved"
+  | "quota-exceeded"
+  | "unavailable";
+
+type StoredEnvelope = {
+  version: number;
+  data: unknown;
+};
+
+export type IndexedDatabaseSchema = {
+  name: string;
+  version: number;
+  upgrade: (
+    database: IDBDatabase,
+    oldVersion: number,
+    newVersion: number | null,
+    transaction: IDBTransaction,
+  ) => void;
+};
+
+function isStoredEnvelope(value: unknown): value is StoredEnvelope {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Partial<StoredEnvelope>).version === "number" &&
+    Object.hasOwn(value, "data")
+  );
+}
+
+function isQuotaExceededError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const candidate = error as { name?: unknown; code?: unknown };
+  return (
+    candidate.name === "QuotaExceededError" ||
+    candidate.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+    candidate.code === 22 ||
+    candidate.code === 1014
+  );
+}
+
+function warn(operation: string, key: string, error: unknown): void {
+  console.warn(`Persistence ${operation} failed for "${key}":`, error);
+}
+
+export function saveStoredValue<T>(
+  schema: LocalStorageSchema<T>,
+  data: T,
+): StorageWriteResult {
+  try {
+    localStorage.setItem(
+      schema.key,
+      JSON.stringify({ version: schema.version, data }),
+    );
+    return "saved";
+  } catch (error) {
+    warn("write", schema.key, error);
+    return isQuotaExceededError(error) ? "quota-exceeded" : "unavailable";
+  }
+}
+
+export function removeStoredValue(key: string): boolean {
+  try {
+    localStorage.removeItem(key);
+    return true;
+  } catch (error) {
+    warn("remove", key, error);
+    return false;
+  }
+}
+
+export function loadStoredValue<T>(
+  schema: LocalStorageSchema<T>,
+  fallback: T,
+): T {
+  let serialized: string | null;
+  try {
+    serialized = localStorage.getItem(schema.key);
+  } catch (error) {
+    warn("read", schema.key, error);
+    return fallback;
+  }
+
+  if (serialized === null) {
+    return fallback;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch (parseError) {
+    try {
+      const migrated = schema.migrate(serialized, 0);
+      if (migrated !== undefined) {
+        saveStoredValue(schema, migrated);
+        return migrated;
+      }
+    } catch (migrationError) {
+      warn("migrate", schema.key, migrationError);
+      removeStoredValue(schema.key);
+      return fallback;
+    }
+
+    warn("parse", schema.key, parseError);
+    removeStoredValue(schema.key);
+    return fallback;
+  }
+
+  try {
+    const envelope = isStoredEnvelope(parsed)
+      ? parsed
+      : { version: 0, data: parsed };
+    let migrated = schema.migrate(envelope.data, envelope.version);
+
+    // Some legacy surfaces wrote raw strings. If a raw value happens to also
+    // be valid JSON, give the schema one chance to recognize the original text.
+    if (migrated === undefined && !isStoredEnvelope(parsed)) {
+      migrated = schema.migrate(serialized, 0);
+    }
+
+    if (migrated === undefined) {
+      removeStoredValue(schema.key);
+      return fallback;
+    }
+
+    if (envelope.version !== schema.version) {
+      saveStoredValue(schema, migrated);
+    }
+
+    return migrated;
+  } catch (error) {
+    warn("migrate", schema.key, error);
+    removeStoredValue(schema.key);
+    return fallback;
+  }
+}
+
+export function openIndexedDatabase(
+  schema: IndexedDatabaseSchema,
+): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(schema.name, schema.version);
+
+    request.onupgradeneeded = (event) => {
+      if (!request.transaction) {
+        reject(new Error(`IndexedDB upgrade transaction missing for "${schema.name}"`));
+        return;
+      }
+
+      schema.upgrade(
+        request.result,
+        event.oldVersion,
+        event.newVersion,
+        request.transaction,
+      );
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => {
+      reject(new Error(`IndexedDB upgrade blocked for "${schema.name}"`));
+    };
+  });
+}
+
+export function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  });
+}

--- a/src/stores/preferencesStore.test.ts
+++ b/src/stores/preferencesStore.test.ts
@@ -47,7 +47,7 @@ describe("preferencesStore", () => {
     expect(usePreferences.getState().editor.accessibilityMode).toBe(before);
   });
 
-  it("persists changes to localStorage in the raw PrefState shape", () => {
+  it("persists changes in the shared versioned envelope", () => {
     // localStorage is a no-op mock in the test setup, so assert on the write.
     const setItem = vi.mocked(localStorage.setItem);
     setItem.mockClear();
@@ -61,11 +61,12 @@ describe("preferencesStore", () => {
     expect(setItem).toHaveBeenCalledWith("preferences", expect.any(String));
     const lastCall = setItem.mock.calls.at(-1);
     const stored = JSON.parse(lastCall?.[1] as string);
-    expect(stored.general.localEcho).toBe(true);
-    expect(stored.general.syncTimezoneToServer).toBe(false);
-    expect(stored.general.syncLocationToServer).toBe(true);
+    expect(stored.version).toBe(1);
+    expect(stored.data.general.localEcho).toBe(true);
+    expect(stored.data.general.syncTimezoneToServer).toBe(false);
+    expect(stored.data.general.syncLocationToServer).toBe(true);
     // action functions are not serialized by JSON.stringify
-    expect(stored.setGeneral).toBeUndefined();
+    expect(stored.data.setGeneral).toBeUndefined();
   });
 
   it("notifies subscribers on change", () => {
@@ -125,7 +126,7 @@ describe("preferencesStore", () => {
     expect(setItem).toHaveBeenCalledOnce();
 
     const stored = JSON.parse(setItem.mock.calls[0][1]);
-    expect(stored.speech.rate).toBe(1.3);
+    expect(stored.data.speech.rate).toBe(1.3);
   });
 
   it("flushes pending preference persistence before the page is discarded", () => {
@@ -142,9 +143,19 @@ describe("preferencesStore", () => {
     expect(setItem).toHaveBeenCalledOnce();
 
     const stored = JSON.parse(setItem.mock.calls[0][1]);
-    expect(stored.sound).toEqual({
+    expect(stored.data.sound).toEqual({
       muteInBackground: true,
       volume: 0.5,
     });
+  });
+
+  it("does not throw when preference storage is blocked", () => {
+    vi.mocked(localStorage.setItem).mockImplementationOnce(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+
+    usePreferences.getState().setMidi({ enabled: true });
+
+    expect(() => vi.runAllTimers()).not.toThrow();
   });
 });

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
+import {
+  loadStoredValue,
+  saveStoredValue,
+  type LocalStorageSchema,
+} from "../persistence";
 
 export enum AutoreadMode {
   Off = "off",
@@ -85,6 +90,7 @@ type PrefActions = {
 };
 
 const STORAGE_KEY = "preferences";
+const STORAGE_VERSION = 1;
 const PERSIST_DEBOUNCE_MS = 250;
 
 function getInitialPreferences(): PrefState {
@@ -134,28 +140,36 @@ function mergePreferences(initial: PrefState, stored: PrefState): PrefState {
   };
 }
 
+const preferencesSchema: LocalStorageSchema<PrefState> = {
+  key: STORAGE_KEY,
+  version: STORAGE_VERSION,
+  migrate: (data, storedVersion) => {
+    if (
+      storedVersion > STORAGE_VERSION ||
+      typeof data !== "object" ||
+      data === null
+    ) {
+      return undefined;
+    }
+
+    const parsed = data as PrefState & { general?: { volume?: number } };
+
+    // Version 0 stored the raw preference object. Move the old general volume
+    // into sound before normalizing every version against current defaults.
+    if (storedVersion === 0 && parsed.general?.volume !== undefined && parsed.sound) {
+      if (!parsed.sound.volume) {
+        parsed.sound.volume = parsed.general.volume;
+      }
+      delete parsed.general.volume;
+    }
+
+    return mergePreferences(getInitialPreferences(), parsed);
+  },
+};
+
 function loadPreferences(): PrefState {
   const initial = getInitialPreferences();
-  const storedData = localStorage.getItem(STORAGE_KEY);
-  if (!storedData) return initial;
-
-  let parsed: (PrefState & { general?: { volume?: number } }) | null = null;
-  try {
-    parsed = JSON.parse(storedData);
-  } catch {
-    return initial;
-  }
-  if (!parsed) return initial;
-
-  // Migration: move volume from general to sound if it exists.
-  if (parsed.general?.volume !== undefined && parsed.sound) {
-    if (!parsed.sound.volume) {
-      parsed.sound.volume = parsed.general.volume;
-    }
-    delete parsed.general.volume;
-  }
-
-  return mergePreferences(initial, parsed);
+  return loadStoredValue(preferencesSchema, initial);
 }
 
 /**
@@ -193,10 +207,11 @@ function flushPendingPreferences(): void {
     persistTimer = undefined;
   }
 
-  // JSON.stringify drops the action functions, leaving exactly the PrefState
-  // shape the previous store wrote.
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(pendingPersistState));
-  pendingPersistState = undefined;
+  // JSON.stringify drops the action functions, leaving the PrefState data
+  // inside the shared versioned persistence envelope.
+  if (saveStoredValue(preferencesSchema, pendingPersistState) === "saved") {
+    pendingPersistState = undefined;
+  }
 }
 
 usePreferences.subscribe((state) => {


### PR DESCRIPTION
## Summary

- add one shared persistence owner for versioned local storage, migration, quota/error handling, and IndexedDB opening/upgrades
- migrate preferences, channel history, command history, output history, auth tokens, checkpoints, session logs, file transfers, and autolog storage to that owner
- preserve legacy raw and versioned data through schema migration, including the existing raw auth token and output-log shapes

## Root cause

Persisted state was owned independently by each feature. The stores used incompatible payload shapes, version handling, error behavior, and IndexedDB upgrade paths, so blocked storage or future schema changes had to be solved repeatedly in each caller.

## Impact

All current durable client state now goes through the same versioned contract. Blocked or full local storage is handled without crashing consumers, legacy values migrate into the shared envelope, and IndexedDB creation/upgrades use one entry point.

## TDD and validation

- observed the new persistence suite fail before `src/persistence.ts` existed
- observed the legacy raw-token regression fail before raw-string migration was added
- `npm test` — 107 files, 1,063 tests passed
- `npm run typecheck`
- `npm run lint:staged`
- `git diff --cached --check`

Closes #76